### PR TITLE
Add login with google, authentication and authorization

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,11 @@
+NOTION_API_KEY=
+DATABASE_URL=
+ENCRYPTION_KEY=
+SERVICE_ACCOUNT_ENCRYPTION_KEY=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=
+# because of vite server we want to redirect to
+# the dev server so that it is easier to continue the development
+POST_OAUTH_REDIRECT=
+JWT_SECRET=

--- a/api/auth.ts
+++ b/api/auth.ts
@@ -1,0 +1,20 @@
+// import { Google, type GoogleRefreshedTokens, type GoogleTokens } from "arctic";
+
+// import { generateCodeVerifier, generateState } from "arctic";
+
+// const clientId = process.env.GOOGLE_CLIENT_ID!
+// const clientSecret = process.env.GOOGLE_CLIENT_SECRET!
+// const redirectURI = process.env.GOOGLE_REDIRECT_URI!
+
+// const google = new Google(clientId, clientSecret, redirectURI);
+
+
+// const state = generateState();
+// const codeVerifier = generateCodeVerifier();
+
+// const url: URL = await google.createAuthorizationURL(state, codeVerifier, {
+//     scopes: ['profile', 'email']
+// });
+// const tokens: GoogleTokens = await google.validateAuthorizationCode(code, codeVerifier);
+// const refreshTokens: GoogleRefreshedTokens = await google.refreshAccessToken(refreshToken);
+

--- a/config.ts
+++ b/config.ts
@@ -1,3 +1,4 @@
 export default {
-    page: 8
+    page: 8,
+    JwtPayloadKey: 'jwtPayload'
 }

--- a/db/connector.ts
+++ b/db/connector.ts
@@ -10,6 +10,7 @@ export const insertConnector = async (
     trx: PgTransaction<any>,
     workspaceId: number,
     userId: number,
+    workspaceExternalId: string,
     name: string,
     type: ConnectorType,        // Use TypeScript enum for type safety
     authType: AuthType,          // Use TypeScript enum for authType
@@ -23,6 +24,7 @@ export const insertConnector = async (
         const inserted = await trx.insert(connectors).values({
             workspaceId,
             userId,
+            workspaceExternalId,
             externalId: externalId,    // Unique external ID for the connection
             name: name,                // Name of the connection
             type: type,                // Type of connection from the enum
@@ -43,7 +45,7 @@ export const insertConnector = async (
 };
 
 // for the admin we can get all the connectors
-export const getConnectors = async (workspaceId: number) => {
+export const getConnectors = async (workspaceId: string) => {
     const res = await db.select({
         id: connectors.externalId,
         app: connectors.app,
@@ -51,7 +53,7 @@ export const getConnectors = async (workspaceId: number) => {
         type: connectors.type,
         status: connectors.status,
         createdAt: connectors.createdAt
-    }).from(connectors).where(eq(connectors.workspaceId, workspaceId))
+    }).from(connectors).where(eq(connectors.workspaceExternalId, workspaceId))
     return res
 }
 

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -21,6 +21,8 @@ export const workspaces = pgTable("workspaces", {
     id: serial("id").notNull().primaryKey(),
     name: text("name").notNull(),
     domain: text("domain").notNull().unique(),
+    // email
+    createdBy: text('created_by').notNull().unique(),
     externalId: text("external_id")
         .unique()
         .notNull(),
@@ -34,7 +36,7 @@ export const workspaces = pgTable("workspaces", {
         .notNull()
         .default(sql`'1970-01-01T00:00:00Z'`),
 });
-const encryptionKey = process.env.ENCRYPTION_KEY;
+const encryptionKey = process.env.ENCRYPTION_KEY!;
 if (!encryptionKey) {
     throw new Error('ENCRYPTION_KEY environment variable is not set.');
 }
@@ -63,6 +65,10 @@ export const users = pgTable(
         externalId: text("external_id")
             .unique()
             .notNull(),
+        // this will come handy for jwt token
+        workspaceExternalId: text("workspace_external_id")
+            .unique()
+            .notNull(),
         createdAt: timestamp("created_at", { withTimezone: true })
             .notNull()
             .default(sql`NOW()`),
@@ -73,6 +79,7 @@ export const users = pgTable(
             .notNull()
             .default(sql`'1970-01-01T00:00:00Z'`),
         lastLogin: timestamp("last_login", { withTimezone: true }),
+        // TODO: turn user role to actual enum type
         role: text("role", { enum: ["user", "admin", "superadmin"] })
             .notNull()
             .default("user"),
@@ -99,6 +106,9 @@ export const connectors = pgTable("connectors", {
         .notNull()
         .references(() => users.id),
     externalId: text("external_id")
+        .unique()
+        .notNull(),
+    workspaceExternalId: text("workspace_external_id")
         .unique()
         .notNull(),
     name: text("name").notNull(),

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -1,7 +1,7 @@
 import { createId } from "@paralleldrive/cuid2";
 import { db } from "./client";
 import { users, workspaces } from "./schema";
-import { getUserWithWorkspaceByEmail } from "./user";
+import { getUserAndWorkspaceByEmail } from "./user";
 
 const seed = async () => {
     console.log('here')

--- a/db/user.ts
+++ b/db/user.ts
@@ -1,8 +1,10 @@
 import { and, eq } from "drizzle-orm";
 import { db } from "./client";
 import { users, workspaces } from "./schema";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+import { createId } from "@paralleldrive/cuid2";
 
-export const getUserWithWorkspaceByEmail = async (workspaceId: number, email: string) => {
+export const getUserAndWorkspaceByEmail = async (trx: PgTransaction<any>, workspaceId: number, email: string) => {
     return await db
         .select({
             user: users,
@@ -14,4 +16,60 @@ export const getUserWithWorkspaceByEmail = async (workspaceId: number, email: st
             eq(users.email, email),  // Filter by user email
             eq(users.workspaceId, workspaceId),  // Filter by workspaceId
         )).limit(1)
+}
+
+export const getUserAndWorkspaceByOnlyEmail = async (trx: PgTransaction<any>, email: string) => {
+    return await db
+        .select({
+            user: users,
+            workspace: workspaces,
+        })
+        .from(users)
+        .innerJoin(workspaces, eq(users.workspaceId, workspaces.id))  // Join workspaces on users.workspaceId
+        .where(and(
+            eq(users.email, email),  // Filter by user email
+        )).limit(1)
+}
+
+// a util to fetch one whenever we do limit(1)
+const onlyOne = (res, errorMsg: string) => {
+    if (res.length) {
+        return res[0]
+    } else {
+        throw new Error(errorMsg)
+    }
+}
+
+// since email is unique across the users we don't need workspaceId
+export const getUserByEmail = async (trx: PgTransaction<any>, email: string) => {
+    return await db
+        .select().from(users)
+        .where(and(
+            eq(users.email, email),
+        )).limit(1)
+}
+
+export const createUser = async (trx: PgTransaction<any>,
+    workspaceId: number,
+    email: string,
+    name: string,
+    photoLink: string,
+    accessToken: string,
+    refreshToken: string,
+    role: string,
+    workspaceExternalId: string,
+) => {
+    const externalId = createId();
+    return await trx.insert(users).values({
+        externalId,
+        workspaceId,
+        email,
+        name,
+        photoLink,
+        workspaceExternalId,
+        googleAccessToken: accessToken,
+        googleRefreshToken: refreshToken,
+        lastLogin: new Date(),
+        role,
+    }).returning()
 }

--- a/db/workspace.ts
+++ b/db/workspace.ts
@@ -1,0 +1,39 @@
+import { createId } from "@paralleldrive/cuid2";
+import { workspaces } from "./schema";
+import { db } from "./client";
+import { eq } from "drizzle-orm";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+
+export const mustGetWorkspaceByDomain = async (domain: string) => {
+    const res = await db.select().from(workspaces).where(eq(workspaces.domain, domain)).limit(1)
+    if (res.length) {
+        return res[0]
+    } else {
+        throw new Error('Could not find workspaces by domain')
+    }
+}
+export const getWorkspaceByDomain = async (domain: string) => {
+    return db.select().from(workspaces).where(eq(workspaces.domain, domain)).limit(1)
+}
+
+export const getWorkspaceByEmail = async (trx: PgTransaction<any>, email: string) => {
+    const res = await db.select().from(workspaces).where(eq(workspaces.createdBy, email)).limit(1)
+    if (res.length) {
+        return res[0]
+    } else {
+        throw new Error('Could not find workspaces by domain')
+    }
+}
+
+export const createWorkspace = async (trx: PgTransaction<any>, createdBy: string, domain: string) => {
+    const externalId = createId();
+    // extract a default name out of the domain
+    let name = domain.split('@')[0]
+    name = name[0].toUpperCase() + name.slice(1)
+    return trx.insert(workspaces).values({
+        externalId,
+        createdBy,
+        domain,
+        name,
+    }).returning()
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,7 +11,7 @@ import { Toaster } from '@/components/ui/toaster'
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({})
 
 
 // Create a new router instance

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -12,6 +12,7 @@
 
 import { Route as rootRoute } from './routes/__root'
 import { Route as SearchImport } from './routes/search'
+import { Route as AuthImport } from './routes/auth'
 import { Route as IndexImport } from './routes/index'
 import { Route as AdminIntegrationsImport } from './routes/admin/integrations'
 
@@ -19,6 +20,11 @@ import { Route as AdminIntegrationsImport } from './routes/admin/integrations'
 
 const SearchRoute = SearchImport.update({
   path: '/search',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const AuthRoute = AuthImport.update({
+  path: '/auth',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -43,6 +49,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexImport
       parentRoute: typeof rootRoute
     }
+    '/auth': {
+      id: '/auth'
+      path: '/auth'
+      fullPath: '/auth'
+      preLoaderRoute: typeof AuthImport
+      parentRoute: typeof rootRoute
+    }
     '/search': {
       id: '/search'
       path: '/search'
@@ -64,6 +77,7 @@ declare module '@tanstack/react-router' {
 
 export const routeTree = rootRoute.addChildren({
   IndexRoute,
+  AuthRoute,
   SearchRoute,
   AdminIntegrationsRoute,
 })
@@ -77,12 +91,16 @@ export const routeTree = rootRoute.addChildren({
       "filePath": "__root.tsx",
       "children": [
         "/",
+        "/auth",
         "/search",
         "/admin/integrations"
       ]
     },
     "/": {
       "filePath": "index.tsx"
+    },
+    "/auth": {
+      "filePath": "auth.tsx"
     },
     "/search": {
       "filePath": "search.tsx"

--- a/frontend/src/routes/auth.tsx
+++ b/frontend/src/routes/auth.tsx
@@ -1,0 +1,48 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+export const description =
+  "A login form with email and password. There's an option to login with Google and a link to sign up if you don't have an account."
+
+export const containerClassName =
+  "w-full h-screen flex items-center justify-center px-4"
+
+export default function LoginForm() {
+  return (
+    <div className='flex w-full h-full justify-center'>
+        <div className='max-w-sm flex items-center'>
+            <Card className="h-auto">
+            <CardHeader>
+                <CardTitle className="text-2xl">Login</CardTitle>
+                <CardDescription>
+                Login with your workspace google account
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                <div className="grid gap-4">
+                <Button variant="outline" className="w-full" onClick={(e) => {
+                    window.location.href = 'http://localhost:3000/v1/auth/callback'
+                }}>
+                    Login with Google
+                </Button>
+                </div>
+            </CardContent>
+            </Card>
+        </div>
+    </div>
+  )
+}
+
+export const Route = createFileRoute('/auth')({
+  component: LoginForm
+})

--- a/migrations/0005_sad_shriek.sql
+++ b/migrations/0005_sad_shriek.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "workspaces" ADD COLUMN "created_by" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "workspaces" ADD CONSTRAINT "workspaces_created_by_unique" UNIQUE("created_by");

--- a/migrations/0006_nervous_brother_voodoo.sql
+++ b/migrations/0006_nervous_brother_voodoo.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN "workspace_external_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "users" ADD CONSTRAINT "users_workspace_external_id_unique" UNIQUE("workspace_external_id");

--- a/migrations/0007_early_sprite.sql
+++ b/migrations/0007_early_sprite.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "connectors" ADD COLUMN "workspace_external_id" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "connectors" ADD CONSTRAINT "connectors_workspace_external_id_unique" UNIQUE("workspace_external_id");

--- a/migrations/meta/0005_snapshot.json
+++ b/migrations/meta/0005_snapshot.json
@@ -1,0 +1,411 @@
+{
+  "id": "3b888f0d-f787-4337-afc8-6b633af8c836",
+  "prevId": "f7df19ce-8f7e-46aa-9062-77d45d050830",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "connector_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_type": {
+          "name": "app_type",
+          "type": "app_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connecting'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connectors_workspace_id_workspaces_id_fk": {
+          "name": "connectors_workspace_id_workspaces_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "connectors_user_id_users_id_fk": {
+          "name": "connectors_user_id_users_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connectors_external_id_unique": {
+          "name": "connectors_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_id"
+          ]
+        },
+        "connectors_workspace_id_user_id_app_type_auth_type_unique": {
+          "name": "connectors_workspace_id_user_id_app_type_auth_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "user_id",
+            "app_type",
+            "auth_type"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photoLink": {
+          "name": "photoLink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_access_token": {
+          "name": "google_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_refresh_token": {
+          "name": "google_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00Z'"
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "email_unique_index": {
+          "name": "email_unique_index",
+          "columns": [
+            {
+              "expression": "LOWER(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_workspace_id_workspaces_id_fk": {
+          "name": "users_workspace_id_workspaces_id_fk",
+          "tableFrom": "users",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_external_id_unique": {
+          "name": "users_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_id"
+          ]
+        }
+      }
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00Z'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspaces_domain_unique": {
+          "name": "workspaces_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        },
+        "workspaces_created_by_unique": {
+          "name": "workspaces_created_by_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "created_by"
+          ]
+        },
+        "workspaces_external_id_unique": {
+          "name": "workspaces_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.app_type": {
+      "name": "app_type",
+      "schema": "public",
+      "values": [
+        "google-drive"
+      ]
+    },
+    "public.auth_type": {
+      "name": "auth_type",
+      "schema": "public",
+      "values": [
+        "oauth",
+        "service_account",
+        "custom"
+      ]
+    },
+    "public.connector_type": {
+      "name": "connector_type",
+      "schema": "public",
+      "values": [
+        "saas",
+        "database",
+        "api",
+        "file"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "connected",
+        "connecting",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0006_snapshot.json
+++ b/migrations/meta/0006_snapshot.json
@@ -1,0 +1,424 @@
+{
+  "id": "211655ba-7593-4d81-9c17-7ddc8a3b5dc1",
+  "prevId": "3b888f0d-f787-4337-afc8-6b633af8c836",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "connector_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_type": {
+          "name": "app_type",
+          "type": "app_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connecting'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connectors_workspace_id_workspaces_id_fk": {
+          "name": "connectors_workspace_id_workspaces_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "connectors_user_id_users_id_fk": {
+          "name": "connectors_user_id_users_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connectors_external_id_unique": {
+          "name": "connectors_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_id"
+          ]
+        },
+        "connectors_workspace_id_user_id_app_type_auth_type_unique": {
+          "name": "connectors_workspace_id_user_id_app_type_auth_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "user_id",
+            "app_type",
+            "auth_type"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photoLink": {
+          "name": "photoLink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_access_token": {
+          "name": "google_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_refresh_token": {
+          "name": "google_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_external_id": {
+          "name": "workspace_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00Z'"
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "email_unique_index": {
+          "name": "email_unique_index",
+          "columns": [
+            {
+              "expression": "LOWER(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_workspace_id_workspaces_id_fk": {
+          "name": "users_workspace_id_workspaces_id_fk",
+          "tableFrom": "users",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_external_id_unique": {
+          "name": "users_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_id"
+          ]
+        },
+        "users_workspace_external_id_unique": {
+          "name": "users_workspace_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_external_id"
+          ]
+        }
+      }
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00Z'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspaces_domain_unique": {
+          "name": "workspaces_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        },
+        "workspaces_created_by_unique": {
+          "name": "workspaces_created_by_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "created_by"
+          ]
+        },
+        "workspaces_external_id_unique": {
+          "name": "workspaces_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.app_type": {
+      "name": "app_type",
+      "schema": "public",
+      "values": [
+        "google-drive"
+      ]
+    },
+    "public.auth_type": {
+      "name": "auth_type",
+      "schema": "public",
+      "values": [
+        "oauth",
+        "service_account",
+        "custom"
+      ]
+    },
+    "public.connector_type": {
+      "name": "connector_type",
+      "schema": "public",
+      "values": [
+        "saas",
+        "database",
+        "api",
+        "file"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "connected",
+        "connecting",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/0007_snapshot.json
+++ b/migrations/meta/0007_snapshot.json
@@ -1,0 +1,437 @@
+{
+  "id": "2a7f8fd7-e520-4b84-b371-1cb86b293585",
+  "prevId": "211655ba-7593-4d81-9c17-7ddc8a3b5dc1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.connectors": {
+      "name": "connectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_external_id": {
+          "name": "workspace_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "connector_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "auth_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_type": {
+          "name": "app_type",
+          "type": "app_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connecting'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "connectors_workspace_id_workspaces_id_fk": {
+          "name": "connectors_workspace_id_workspaces_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "connectors_user_id_users_id_fk": {
+          "name": "connectors_user_id_users_id_fk",
+          "tableFrom": "connectors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "connectors_external_id_unique": {
+          "name": "connectors_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_id"
+          ]
+        },
+        "connectors_workspace_external_id_unique": {
+          "name": "connectors_workspace_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_external_id"
+          ]
+        },
+        "connectors_workspace_id_user_id_app_type_auth_type_unique": {
+          "name": "connectors_workspace_id_user_id_app_type_auth_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_id",
+            "user_id",
+            "app_type",
+            "auth_type"
+          ]
+        }
+      }
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "photoLink": {
+          "name": "photoLink",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_access_token": {
+          "name": "google_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_refresh_token": {
+          "name": "google_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_external_id": {
+          "name": "workspace_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00Z'"
+        },
+        "last_login": {
+          "name": "last_login",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "email_unique_index": {
+          "name": "email_unique_index",
+          "columns": [
+            {
+              "expression": "LOWER(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "users_workspace_id_workspaces_id_fk": {
+          "name": "users_workspace_id_workspaces_id_fk",
+          "tableFrom": "users",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_external_id_unique": {
+          "name": "users_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_id"
+          ]
+        },
+        "users_workspace_external_id_unique": {
+          "name": "users_workspace_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "workspace_external_id"
+          ]
+        }
+      }
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1970-01-01T00:00:00Z'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "workspaces_domain_unique": {
+          "name": "workspaces_domain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "domain"
+          ]
+        },
+        "workspaces_created_by_unique": {
+          "name": "workspaces_created_by_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "created_by"
+          ]
+        },
+        "workspaces_external_id_unique": {
+          "name": "workspaces_external_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "public.app_type": {
+      "name": "app_type",
+      "schema": "public",
+      "values": [
+        "google-drive"
+      ]
+    },
+    "public.auth_type": {
+      "name": "auth_type",
+      "schema": "public",
+      "values": [
+        "oauth",
+        "service_account",
+        "custom"
+      ]
+    },
+    "public.connector_type": {
+      "name": "connector_type",
+      "schema": "public",
+      "values": [
+        "saas",
+        "database",
+        "api",
+        "file"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "connected",
+        "connecting",
+        "failed"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -36,6 +36,27 @@
       "when": 1726756431222,
       "tag": "0004_useful_cassandra_nova",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1726906173133,
+      "tag": "0005_sad_shriek",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1726911116712,
+      "tag": "0006_nervous_brother_voodoo",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1726913726163,
+      "tag": "0007_early_sprite",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hono/oauth-providers": "^0.6.1",
     "@hono/zod-validator": "^0.2.2",
     "@notionhq/client": "^2.2.15",
     "@paralleldrive/cuid2": "^2.2.2",

--- a/search/vespa.ts
+++ b/search/vespa.ts
@@ -450,20 +450,6 @@ const getDocumentCount = async () => {
 // Example usage:
 await deleteAllDocuments()
 // console.log('deleted all docs')
-// await insertDocument({
-//     title: 'saheb',
-//     url: '',
-//     app: 'google',
-//     docId: '123',
-//     entity: 'docs',
-//     chunks: [],
-//     owner: 'saheb',
-//     photoLink: '',
-//     ownerEmail: 'saheb',
-//     chunk_embeddings: {},
-//     permissions: ['saheb@xynehq.com'],
-//     mimeType: 'pdf'
-// })
 // await initVespa(email)
 // console.log(JSON.stringify(await searchVespa('welcome my friend, let me provide you with a prompt', 'saheb@xynehq.com')))
 // const output = (await searchVespa(query, email))

--- a/server.ts
+++ b/server.ts
@@ -1,29 +1,48 @@
 import { Hono } from 'hono'
 import { logger } from 'hono/logger'
-// import { Apps, defaultMetrics, MsgType, type Metrics } from './frontend/src/lib/types';
 import fs from 'node:fs'
-// import { initI, search, searchGroupByCount } from './weaviate'
-import { initNotion } from './notion'
-import { autocomplete } from './search/vespa'
 import { AutocompleteApi, autocompleteSchema, SearchApi } from '@/api/search'
-import { z } from 'zod'
 import { zValidator } from '@hono/zod-validator'
-import { addServiceConnectionSchema, searchSchema } from './types'
-import { basicAuth } from 'hono/basic-auth'
-import { AddServiceConnection, GetConnectors } from './api/admin'
-import { boss, init as initQueue, SaaSQueue } from './queue'
+import { addServiceConnectionSchema, searchSchema, UserRole } from '@/types'
+import { AddServiceConnection, GetConnectors } from '@/api/admin'
+import { boss, init as initQueue, SaaSQueue } from '@/queue'
 import { createBunWebSocket } from 'hono/bun'
 import type { ServerWebSocket } from 'bun'
+import { googleAuth } from '@hono/oauth-providers/google'
+import { jwt } from 'hono/jwt'
+import type { JwtVariables } from 'hono/jwt'
+type Variables = JwtVariables
+import { decode, sign, verify } from 'hono/jwt'
+import { db } from '@/db/client'
+import { HTTPException } from 'hono/http-exception'
+import { createWorkspace, getWorkspaceByDomain } from '@/db/workspace'
+import { createUser, getUserByEmail } from '@/db/user'
+import { setCookie } from 'hono/cookie'
+
+
+const clientId = process.env.GOOGLE_CLIENT_ID!
+const clientSecret = process.env.GOOGLE_CLIENT_SECRET!
+const redirectURI = process.env.GOOGLE_REDIRECT_URI!
+
+const postOauthRedirect = process.env.POST_OAUTH_REDIRECT!
+const jwtSecret = process.env.JWT_SECRET!
+
+const CookieName = 'auth-token'
+
 
 const { upgradeWebSocket, websocket } =
     createBunWebSocket<ServerWebSocket>()
 
-const app = new Hono()
+const app = new Hono<{ Variables: Variables }>()
+
+const AuthMiddleware = jwt({
+    secret: jwtSecret,
+    cookie: CookieName
+})
 
 app.use('*', logger())
 
 export const wsConnections = new Map();
-
 
 const wsApp = app.get(
     '/ws',
@@ -50,8 +69,8 @@ const wsApp = app.get(
 
 export type WebSocketApp = typeof wsApp
 
-
 const AppRoutes = app.basePath('/api')
+    .use('*', AuthMiddleware)
     .post('/autocomplete', zValidator('json', autocompleteSchema), AutocompleteApi)
     .get('/search', zValidator('query', searchSchema), SearchApi)
     .basePath('/admin')
@@ -61,14 +80,97 @@ const AppRoutes = app.basePath('/api')
     .post('/service_account', zValidator('form', addServiceConnectionSchema), AddServiceConnection)
     .get('/connectors/all', GetConnectors)
 
-export type AppType = typeof AppRoutes
 
+
+const generateToken = async (email: string, role: string, workspaceId: string) => {
+    console.log('generating token')
+    const payload = {
+        sub: email,
+        role: role,
+        workspaceId,
+        exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 60, // Token expires in 2 months
+    }
+    const jwtToken = await sign(payload, jwtSecret)
+    return jwtToken
+}
+// we won't allow user to reach the login page if they are already logged in
+// or if they have an expired token
+
+// After google oauth is done, google redirects user
+// here and this is where all the onboarding will happen
+// if user account does not exist, then we will automatically
+// create the user and workspace
+// if workspace already exists for that domain then we just login
+// the user and update the last logged in value
+app.get(
+    '/v1/auth/callback',
+    googleAuth({
+        client_id: clientId,
+        client_secret: clientSecret,
+        scope: ['openid', 'email', 'profile'],
+    }),
+    async (c) => {
+        const token = c.get('token')
+        const grantedScopes = c.get('granted-scopes')
+        const user = c.get('user-google')
+
+        const email = user?.email
+        if (!email) {
+            throw new HTTPException(500, { message: 'Could not get the email of the user' })
+        }
+
+        if (!user?.verified_email) {
+            throw new HTTPException(500, { message: 'User email is not verified' })
+        }
+        // hosted domain
+        let domain = user.hd
+        if (!domain && email) {
+            domain = email.split('@')[1]
+        }
+        const name = user?.name || user?.given_name || user?.family_name
+        const photoLink = user?.picture
+
+        const existingUserRes = await getUserByEmail(db, email)
+        // if user exists then workspace exists too
+        if (existingUserRes && existingUserRes.length) {
+            console.log('User found')
+            const existingUser = existingUserRes[0]
+            const jwtToken = await generateToken(existingUser.email, existingUser.role, existingUser.workspaceExternalId)
+            setCookie(c, CookieName, jwtToken)
+            return c.redirect(postOauthRedirect)
+        }
+
+        // check if workspace exists
+        // just create the user
+        const existingWorkspaceRes = await getWorkspaceByDomain(domain)
+        if (existingWorkspaceRes && existingWorkspaceRes.length) {
+            console.log('Workspace found, creating user')
+            const existingWorkspace = existingWorkspaceRes[0]
+            const [user] = await createUser(db, existingWorkspace.id, email, name, photoLink, token?.token, "test", UserRole.SuperAdmin, existingWorkspace.externalId)
+            const jwtToken = await generateToken(user.email, user.role, user.workspaceExternalId)
+            setCookie(c, CookieName, jwtToken)
+            return c.redirect(postOauthRedirect)
+        }
+
+        // we could not find the user and the workspace
+        // creating both
+
+        console.log('Creating workspace and user')
+        const userAcc = await db.transaction(async (trx) => {
+            const [workspace] = await createWorkspace(trx, email, domain)
+            const [user] = await createUser(trx, workspace.id, email, name, photoLink, token?.token, "test", UserRole.SuperAdmin, workspace.externalId)
+            return user
+        })
+
+        const jwtToken = await generateToken(userAcc.email, userAcc.role, userAcc.workspaceExternalId)
+        setCookie(c, CookieName, jwtToken)
+        return c.redirect(postOauthRedirect)
+    }
+)
+export type AppType = typeof AppRoutes
 
 export const init = async () => {
     await initQueue()
-    // await initKG()
-    // await initI()
-    // await initNotion()
 }
 init().catch(e => {
     console.error(e)

--- a/types.ts
+++ b/types.ts
@@ -147,3 +147,11 @@ export enum ConnectorStatus {
     Connecting = 'connecting',
     Failed = 'failed'
 }
+
+// very rudimentary
+// temporary roles
+export enum UserRole {
+    User = "user",
+    Admin = "admin",
+    SuperAdmin = "super_admin"
+}


### PR DESCRIPTION
Added login with Google. Currently we do not get the refresh token.
I'm still thinking if we even need the refresh token? Our own Jwt token would have it's own refresh token and once our own access token and refresh token both expire then user can just login again.

login and signup clubbed together
added authorization for all the routes.
one example of 401 in api call and UI redirects to login page


add `workspaceExternalId` to both users and connectors.