### PR TITLE
fix(vespa): change default model and typo fix

### DIFF
--- a/frontend/src/routes/_authenticated.tsx
+++ b/frontend/src/routes/_authenticated.tsx
@@ -8,6 +8,7 @@ export const Route = createFileRoute("/_authenticated")({
       // If user is not logged in, take user to '/auth'
       throw redirect({ to: "/auth" })
     }
+
     return await res.json()
   },
   component: () => {

--- a/frontend/src/routes/auth.tsx
+++ b/frontend/src/routes/auth.tsx
@@ -18,7 +18,6 @@ export const containerClassName =
 
 export default function LoginForm() {
   const logger = console
-  logger.info("LOGIN WITH GOOGLE CLICKED")
   return (
     <div className="flex w-full h-full justify-center">
       <div className="max-w-sm flex items-center">
@@ -60,8 +59,8 @@ export const Route = createFileRoute("/auth")({
       if (userWorkspace?.user && userWorkspace?.workspace) {
         throw redirect({ to: "/" })
       }
+      return await res.json()
     }
-    return await res.json()
   },
   component: LoginForm,
 })

--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -1105,7 +1105,7 @@ const insertUsersForWorkspace = async (
       gender: user.gender,
       photoLink: user.thumbnailPhotoUrl ?? "",
       aliases: user.aliases ?? [],
-      langauge: preferredLanguage,
+      language: preferredLanguage,
       includeInGlobalAddressList: user.includeInGlobalAddressList ?? false,
       isAdmin: user.isAdmin ?? false,
       isDelegatedAdmin: user.isDelegatedAdmin ?? false,
@@ -1454,9 +1454,7 @@ export const googleDocsVespa = async (
   )
   const docsList: (VespaFileWithDrivePermission | null)[] =
     await Promise.all(docsPromises)
-  return docsList.filter(
-    (doc) => doc !== null,
-  )
+  return docsList.filter((doc) => doc !== null)
 }
 
 export const driveFilesToDoc = async (

--- a/server/search/types.ts
+++ b/server/search/types.ts
@@ -137,7 +137,7 @@ export const VespaUserSchema = z
     gender: z.string().optional(),
     photoLink: z.string().optional(),
     aliases: z.array(z.string()).optional(),
-    langauge: z.string().optional(),
+    language: z.string().optional(),
     includeInGlobalAddressList: z.boolean().optional(),
     isAdmin: z.boolean().optional(),
     isDelegatedAdmin: z.boolean().optional(),

--- a/server/vespa/deploy.sh
+++ b/server/vespa/deploy.sh
@@ -4,8 +4,8 @@ set -e
 mkdir -p models
 
 # URLs to download
-TOKENIZER_URL="https://huggingface.co/Xenova/bge-base-en-v1.5/raw/main/tokenizer.json"
-MODEL_URL="https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/onnx/model_quantized.onnx"
+TOKENIZER_URL="https://huggingface.co/Xenova/bge-small-en-v1.5/raw/main/tokenizer.json"
+MODEL_URL="https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/onnx/model_quantized.onnx"
 
 # File paths
 TOKENIZER_FILE="models/tokenizer.json"

--- a/server/vespa/schemas/file.sd
+++ b/server/vespa/schemas/file.sd
@@ -69,7 +69,7 @@ schema file {
     }
   }
 
-  field chunk_embeddings type tensor<bfloat16>(p{}, v[768])  {
+  field chunk_embeddings type tensor<bfloat16>(p{}, v[384])  {
     indexing: input chunks | embed | attribute | index
     attribute {
         distance-metric: angular
@@ -99,7 +99,7 @@ schema file {
   rank-profile initial {
     # Inputs for the query vector and alpha for hybrid search
     inputs {
-      query(e) tensor<bfloat16>(v[768])  # Query embedding
+      query(e) tensor<bfloat16>(v[384])  # Query embedding
       query(alpha) double  # Alpha parameter for hybrid weight
     }
 

--- a/server/vespa/schemas/mail.sd
+++ b/server/vespa/schemas/mail.sd
@@ -95,7 +95,7 @@ schema mail {
     attribute: fast-search
   }
   }
-  field chunk_embeddings type tensor<bfloat16>(p{}, v[768])  {
+  field chunk_embeddings type tensor<bfloat16>(p{}, v[384])  {
     indexing: guard { input chunks } | embed | attribute | index
     attribute {
       distance-metric: angular
@@ -123,7 +123,7 @@ schema mail {
   # Hybrid search rank profile combining BM25 for subject and chunks, and vector search for chunk embeddings
   rank-profile initial {
     inputs {
-      query(e) tensor<bfloat16>(v[768])  # Query embedding
+      query(e) tensor<bfloat16>(v[384])  # Query embedding
       query(alpha) double  # Alpha parameter for hybrid weight
     }
 

--- a/server/vespa/schemas/user.sd
+++ b/server/vespa/schemas/user.sd
@@ -42,7 +42,7 @@ schema user {
             indexing: attribute | summary
         }
 
-        field langauge type string {
+        field language type string {
             indexing: attribute | summary
         }
 


### PR DESCRIPTION
fix typo `language` and change the model to `bge-small`

Avg score dropped by ~3%
![image](https://github.com/user-attachments/assets/98339b6c-54ef-46db-a7c8-b62ba9e9df0a)

Ingestion speed increases by 60%

Disk usage data @junaid-shirur will add