### PR TITLE
Fix(ingestion): ingestion was taking too long

### DIFF
--- a/frontend/src/routes/_authenticated/admin/integrations.tsx
+++ b/frontend/src/routes/_authenticated/admin/integrations.tsx
@@ -3,6 +3,7 @@ import {
   createFileRoute,
   useNavigate,
   UseNavigateResult,
+  useRouterState,
 } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 import { Input } from "@/components/ui/input"
@@ -25,6 +26,7 @@ import { useQuery } from "@tanstack/react-query"
 import { Connectors } from "@/types"
 import { OAuthModal } from "@/oauth"
 import { Sidebar } from "@/components/Sidebar"
+import { PublicUser, PublicWorkspace } from "shared/types"
 
 const logger = console
 
@@ -412,8 +414,12 @@ enum OAuthIntegrationStatus {
   OAuthConnecting = "OAuthConnecting",
   OAuthConnected = "OAuthConnected",
 }
+interface AdminPageProps {
+  user: PublicUser
+  workspace: PublicWorkspace
+}
 
-const AdminLayout = () => {
+const AdminLayout = ({ user, workspace }: AdminPageProps) => {
   const navigator = useNavigate()
   const { isPending, error, data } = useQuery<any[]>({
     queryKey: ["all-connectors"],
@@ -513,7 +519,7 @@ const AdminLayout = () => {
   if (error) return "An error has occurred: " + error.message
   return (
     <div className="flex w-full h-full">
-      <Sidebar />
+      <Sidebar photoLink={user.photoLink ?? ""} />
       <div className="w-full h-full flex items-center justify-center">
         <Tabs
           defaultValue="upload"
@@ -583,5 +589,17 @@ const AdminLayout = () => {
 }
 
 export const Route = createFileRoute("/_authenticated/admin/integrations")({
-  component: AdminLayout,
+  // component: AdminLayout,
+
+  beforeLoad: (params) => {
+    return params
+  },
+  loader: async (params) => {
+    return params
+  },
+  component: () => {
+    const matches = useRouterState({ select: (s) => s.matches })
+    const { user, workspace } = matches[matches.length - 1].context
+    return <AdminLayout user={user} workspace={workspace} />
+  },
 })

--- a/frontend/src/routes/_authenticated/index.tsx
+++ b/frontend/src/routes/_authenticated/index.tsx
@@ -157,6 +157,7 @@ const Index = () => {
                 setAutocompleteQuery={setAutocompleteQuery}
                 setOffset={setOffset}
                 setFilter={setFilter}
+                handleAnswer={() => {}}
                 ref={autocompleteRef}
                 pathname={location.pathname}
                 filter={filter}

--- a/server/ai/provider/bedrock.ts
+++ b/server/ai/provider/bedrock.ts
@@ -352,7 +352,7 @@ class Provider implements LLMProvider {
           modelDetailsMap[params.modelId].cost.onDemand,
         )
       }
-      if(chunk.choices && chunk.choices.length) {
+      if (chunk.choices && chunk.choices.length) {
         yield {
           text: chunk.choices[0].delta.content!,
           metadata: chunk.choices[0].finish_reason,
@@ -362,7 +362,7 @@ class Provider implements LLMProvider {
         yield {
           text: "",
           metadata: "",
-          cost
+          cost,
         }
       }
     }

--- a/server/db/client.ts
+++ b/server/db/client.ts
@@ -7,7 +7,6 @@ import { Subsystem } from "@/types"
 const Logger = getLogger(Subsystem.Db).child({ module: "client" })
 
 const url = `postgres://xyne:xyne@${config.postgresBaseHost}:5432/xyne`
-Logger.info(url)
 
 const queryClient = postgres(url, {
   idle_timeout: 0,

--- a/server/logger/index.ts
+++ b/server/logger/index.ts
@@ -3,10 +3,10 @@ import { Subsystem } from "@/types"
 import type { MiddlewareHandler, Context, Next } from "hono"
 import { getPath } from "hono/utils/url"
 import { v4 as uuidv4 } from "uuid"
-import { existsSync, mkdirSync } from 'fs';
-import { resolve } from 'path';
+import { existsSync, mkdirSync } from "fs"
+import { resolve } from "path"
 
-const logsFolderPath = resolve(process.cwd(), 'server','logs');
+const logsFolderPath = resolve(process.cwd(), "server", "logs")
 
 const humanize = (times: string[]) => {
   const [delimiter, separator] = [",", "."]
@@ -153,13 +153,11 @@ export const LogMiddleware = (loggerType: Subsystem): MiddlewareHandler => {
   }
 }
 
-
-
 const checkLogsFolder = () => {
   if (!existsSync(logsFolderPath)) {
-    mkdirSync(logsFolderPath, {recursive:true});
-    console.log('Logs folder created.');
+    mkdirSync(logsFolderPath, { recursive: true })
+    console.log("Logs folder created.")
   } else {
-    console.log('Logs folder already exists.');
+    console.log("Logs folder already exists.")
   }
 }

--- a/server/server.ts
+++ b/server/server.ts
@@ -227,7 +227,7 @@ app.get(
     client_id: clientId,
     client_secret: clientSecret,
     scope: ["openid", "email", "profile"],
-    redirect_uri: redirectURI,  
+    redirect_uri: redirectURI,
   }),
   async (c: Context) => {
     const token = c.get("token")


### PR DESCRIPTION
pdfs were blocking the rest of the ingestion, so we bifurcate into a generator architecture where pdfs are handled in a separate promise queue and rest of the files are handled separately.

This is so that pdfs never block others as they are currently ingested a lot faster.
Also allowed concurrent pdf downloading so that even there we get a significant boost.