### PR TITLE
fix(search-params): prevent multi level encoding of params

### DIFF
--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -74,7 +74,7 @@ export const SearchBar = forwardRef<HTMLDivElement, any>(
                     if (e.key === "Enter") {
                       navigate({
                         to: "/search",
-                        search: { query: encodeURIComponent(query) },
+                        search: { query: encodeURIComponent(decodeURIComponent(query)) },
                       })
                       setFilter({}) // Use empty object instead of null
                       // we only want to look for answer if at least

--- a/frontend/src/routes/_authenticated/index.tsx
+++ b/frontend/src/routes/_authenticated/index.tsx
@@ -87,7 +87,7 @@ const Index = () => {
     if (query.trim()) {
       navigate({
         to: "/search",
-        search: { query: encodeURIComponent(query.trim()) },
+        search: { query: encodeURIComponent(decodeURIComponent(query.trim())) },
       })
     }
   }

--- a/frontend/src/routes/_authenticated/search.tsx
+++ b/frontend/src/routes/_authenticated/search.tsx
@@ -79,7 +79,15 @@ export const Search = ({ user, workspace }: IndexProps) => {
   let search: XyneSearch = useSearch({
     from: "/_authenticated/search",
   })
-  const [query, setQuery] = useState(search.query || "") // State to hold the search query
+  const navigate = useNavigate({ from: "/search" })
+  // TODO: debug the react warning
+  // Cannot update a component (`MatchesInner`)
+  if(!search.query) {
+    navigate({
+      to: "/",
+    })
+  }
+  const [query, setQuery] = useState(decodeURIComponent(search.query || "")) // State to hold the search query
   const [offset, setOffset] = useState(0)
   const [results, setResults] = useState<SearchResultDiscriminatedUnion[]>([]) // State to hold the search results
   const [groups, setGroups] = useState<Groups | null>(null)
@@ -90,7 +98,6 @@ export const Search = ({ user, workspace }: IndexProps) => {
   const [answer, setAnswer] = useState<string | null>(null)
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
 
-  const navigate = useNavigate({ from: "/search" })
 
   // close autocomplete if clicked outside
   const autocompleteRef = useRef<HTMLDivElement | null>(null)


### PR DESCRIPTION
the encoded param was encoded again.
also we were allowing empty param to come to `/search` page now it redirects back to `/`