### PR TITLE
fix(events) get data from one year since ingestion and increase vespa limits

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -31,12 +31,17 @@ services:
       - ../server/vespa-logs:/opt/vespa/logs # Ensure correct permissions
     networks:
       - xyne
+    ulimits:
+      nproc: 409600
     restart: always
     logging:
       driver: json-file
       options:
         max-size: "50m"
         max-file: "6"
+    environment:
+      - VESPA_CONFIGSERVER_JVMARGS=-Xms1g -Xmx16g -XX:+UseG1GC -XX:G1HeapRegionSize=32M
+      - VESPA_CONFIGPROXY_JVMARGS=-Xms512m -Xmx8g -XX:+UseG1GC
 
   xyne-db:
     image: postgres

--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -412,6 +412,9 @@ const insertCalendarEvents = async (
   // To get all events from current Date to One Year later
   nextYearDateTime.setFullYear(currentDateTime.getFullYear() + 1)
 
+
+  // we will fetch from one year back
+  currentDateTime.setFullYear(currentDateTime.getFullYear() - 1)
   do {
     const res = await calendar.events.list({
       calendarId: "primary",


### PR DESCRIPTION
since the model size of 1024 we need to increase the size the limits of vespa like nproc, config servers jvm heap sizes.