### PR TITLE
feat(chat): Add rename chat title

### DIFF
--- a/frontend/src/components/HistoryModal.tsx
+++ b/frontend/src/components/HistoryModal.tsx
@@ -103,20 +103,19 @@ const HistoryModal = ({
       queryClient.setQueryData<SelectPublicChat[]>(
         ["all-connectors"],
         (oldChats) => {
-          if (!oldChats) return []
+          if (!oldChats?.length) return []
 
-          // Find the index of the targeted chat
-          const index = oldChats.findIndex((chat) => chat.externalId === chatId)
-          if (index > -1) {
-            const updatedChat: SelectPublicChat = { ...oldChats[index], title }
-            // Remove that chat at old index and add updatedChat in front
-            const newChats: SelectPublicChat[] = [
-              updatedChat,
-              ...oldChats.filter((_, i) => i !== index),
-            ]
+          // Find the chat to update
+          const chatToUpdate: SelectPublicChat = oldChats.find(
+            (chat) => chat.externalId === chatId,
+          )
+          if (!chatToUpdate) return oldChats
 
-            return newChats
-          }
+          // Create updated chat and filter out old version in one pass
+          return [
+            { ...chatToUpdate, title },
+            ...oldChats.filter((chat) => chat.externalId !== chatId),
+          ]
         },
       )
       setIsEditing(false)

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -101,20 +101,19 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
       queryClient.setQueryData<SelectPublicChat[]>(
         ["all-connectors"],
         (oldChats) => {
-          if (!oldChats) return []
+          if (!oldChats?.length) return []
 
-          // Find the index of the targeted chat
-          const index = oldChats.findIndex((chat) => chat.externalId === chatId)
-          if (index > -1) {
-            const updatedChat: SelectPublicChat = { ...oldChats[index], title }
-            // Remove that chat at old index and add updatedChat in front
-            const newChats: SelectPublicChat[] = [
-              updatedChat,
-              ...oldChats.filter((_, i) => i !== index),
-            ]
+          // Find the chat to update
+          const chatToUpdate: SelectPublicChat = oldChats.find(
+            (chat) => chat.externalId === chatId,
+          )
+          if (!chatToUpdate) return oldChats
 
-            return newChats
-          }
+          // Create updated chat and filter out old version in one pass
+          return [
+            { ...chatToUpdate, title },
+            ...oldChats.filter((chat) => chat.externalId !== chatId),
+          ]
         },
       )
       setChatTitle(editedTitle)


### PR DESCRIPTION
This PR has:

- Chat title can be renamed via triple dot(dropdown) in Chat History.
- Rename chat title from the chat title bar using the Pencil icon.