### PR TITLE
fix(sync-token): even if contacts sync token is expired we don't exit syncing of the whole workspace

### DIFF
--- a/server/integrations/google/sync.ts
+++ b/server/integrations/google/sync.ts
@@ -1279,7 +1279,7 @@ export const handleGoogleServiceAccountChanges = async (
             "Sync token is expired. Clear local cache and retry call without the sync token."
         ) {
           Logger.warn(
-            "This is an error that is not yet implemented, it requires a full sync of the contacts api",
+            "This is an error that is not yet implemented, it requires a full sync of the other contacts api",
           )
         } else {
           throw error


### PR DESCRIPTION
related to #197 

We as of now do not do a full sync of the contacts and simply move ahead to syncing the rest.
This error was causing the whole syncing to break for the whole workspace, until this is implemented we can prevent the early exit.

This case is not supposed to happen as in regular use the syncing happens consistently so rarely we reach a case where a sync token for contacts expired, this happens for long downtime where it might simply be better to do a full sync again.