### PR TITLE
fix(sync): opposite order of arguments were sent in GetDocument calls in sync

### DIFF
--- a/server/search/vespaClient.ts
+++ b/server/search/vespaClient.ts
@@ -360,14 +360,11 @@ class VespaClient {
       const document = await response.json()
       return document
     } catch (error) {
-      const errMessage = getErrorMessage(error)
       Logger.error(
         error,
-        `Error fetching document docId: ${options.docId} - ${errMessage}`,
+        `Error fetching document docId: ${options.docId} ${JSON.stringify(options)}`,
       )
-      throw new Error(
-        `Error fetching document docId: ${options.docId} - ${errMessage}`,
-      )
+      throw error
     }
   }
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -366,8 +366,7 @@ const server = Bun.serve({
 })
 Logger.info(`listening on port: ${config.port}`)
 
-
-process.on('uncaughtException',(error) => {
-  Logger.error(error, 'uncaughtException')
+process.on("uncaughtException", (error) => {
+  Logger.error(error, "uncaughtException")
   // shutdown server?
 })


### PR DESCRIPTION
for some function calls we were sending opposite arguments for schema and docId