### PR TITLE
fix(chat): multi line output caused empty object in partial json

### DIFF
--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -11,7 +11,7 @@ import OpenAI from "openai"
 import { getLogger } from "@/logger"
 import { MessageRole, Subsystem } from "@/types"
 import { getErrorMessage } from "@/utils"
-import { parse, Allow, OBJ, STR } from "partial-json"
+import { parse } from "partial-json"
 
 import { ModelToProviderMap } from "@/ai/mappers"
 import type {


### PR DESCRIPTION
# why
if we get response with multiple new lines then it would lead to `partial-json` library returns empty object, this causes the `parsed.answer` check to fail leading to further iterations happening in-spite of already having an answer

# what changed
Implementation of `jsonParseLLMOutput` this naturally fixes the `parsed.answer` check.
Other change is now response in such case won't have new line and will lead to bad formatting

# test plan
Currently not tested but actually `jsonParseLLMOutput` requires a test suite of it's own because we have fixed many cases but didn't save why we added each of those fixes.