### PR TITLE
fix(chat): increase max summary size for better recall

### DIFF
--- a/server/api/chat.ts
+++ b/server/api/chat.ts
@@ -74,7 +74,7 @@ import {
   type VespaUser,
 } from "@/search/types"
 import { APIError } from "openai"
-const { JwtPayloadKey, chatHistoryPageSize } = config
+const { JwtPayloadKey, chatHistoryPageSize, maxDefaultSummary } = config
 const Logger = getLogger(Subsystem.Chat)
 
 // this is not always the case but unless our router detects that we need
@@ -786,7 +786,7 @@ export async function* UnderstandMessageAndAnswer(
       userCtx,
       0.5,
       20,
-      3,
+      5,
     )
   } else {
     Logger.info(
@@ -801,7 +801,7 @@ export async function* UnderstandMessageAndAnswer(
       0.5,
       20,
       3,
-      5,
+      maxDefaultSummary
     )
   }
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -57,4 +57,5 @@ export default {
   vespaMaxRetryAttempts: 3,
   vespaRetryDelay: 1000, // 1 sec
   chatHistoryPageSize: 21,
+  maxDefaultSummary: 8
 }


### PR DESCRIPTION
# why

Max Summary Size controls relevant chunks per document. Even if we match a document with a good score but fail to fetch the chunk where the answer is it will lead to AI failing to answer.
Now if we do not put any cap we do unnecessarily send too many chunks that can significantly ramp up the cost unnecessarily. We could expose this via env variable as well in future or via Admin settings.

# what changed

Added a new config value `maxDefaultSummary` and it is used in `generateIterativeTimeFilterAndQueryRewrite`

# test plan

Test locally with my eval Q/A where a basic question was failing and eventually passed simply by increasing this value.