### PR TITLE
fix(AI-Provider): Make AWS region optional in env setup

### DIFF
--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -9,7 +9,6 @@ import { z } from "zod"
 const {
   AwsAccessKey,
   AwsSecretKey,
-  AwsRegion,
   OllamaModel,
   OpenAIKey,
   defaultBestModel,
@@ -88,7 +87,13 @@ let ollamaProvider: LLMProvider | null = null
 const initializeProviders = (): void => {
   if (providersInitialized) return
 
-  if (AwsAccessKey && AwsSecretKey && AwsRegion) {
+  if (AwsAccessKey && AwsSecretKey) {
+    const AwsRegion = process.env["AWS_REGION"] || "us-west-2"
+    if (!process.env["AWS_REGION"]) {
+      Logger.info(
+        "AWS_REGION not provided, falling back to default 'us-west-2'",
+      )
+    }
     const BedrockClient = new BedrockRuntimeClient({
       region: AwsRegion,
       credentials: {

--- a/server/ai/provider/openai.ts
+++ b/server/ai/provider/openai.ts
@@ -55,7 +55,6 @@ export class OpenAIProvider extends BaseProvider {
     params: ModelParams,
   ): AsyncIterableIterator<ConverseResponse> {
     const modelParams = this.getModelParams(params)
-    // Placeholder for Ollama implementation
     const chatCompletion = await (
       this.client as OpenAI
     ).chat.completions.create({

--- a/server/config.ts
+++ b/server/config.ts
@@ -23,19 +23,13 @@ let defaultBestModel: Models = "" as Models
 let bedrockSupport = false
 let AwsAccessKey = ""
 let AwsSecretKey = ""
-let AwsRegion = ""
 let OpenAIKey = ""
 let OllamaModel = ""
 
 // Priority (AWS > OpenAI > Ollama)
-if (
-  process.env["AWS_ACCESS_KEY"] &&
-  process.env["AWS_SECRET_KEY"] &&
-  process.env["AWS_REGION"]
-) {
+if (process.env["AWS_ACCESS_KEY"] && process.env["AWS_SECRET_KEY"]) {
   AwsAccessKey = process.env["AWS_ACCESS_KEY"]
   AwsSecretKey = process.env["AWS_SECRET_KEY"]
-  AwsRegion = process.env["AWS_REGION"]
   bedrockSupport = true
   defaultFastModel = Models.Claude_3_5_Haiku
   defaultBestModel = Models.Claude_3_5_SonnetV2
@@ -65,7 +59,6 @@ export default {
   bedrockSupport,
   AwsAccessKey,
   AwsSecretKey,
-  AwsRegion,
   OpenAIKey,
   OllamaModel,
   redirectUri,


### PR DESCRIPTION
# why
AWS region was previously mandatory in the environment.
# what changed
Made AWS region optional, defaulting to `us-west-2` if not specified.
# test plan
