### PR TITLE
fix(styles): fix sidebar icon shift, link logo and change tooltip

### DIFF
--- a/frontend/src/assets/retry.svg
+++ b/frontend/src/assets/retry.svg
@@ -1,6 +1,6 @@
 <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M2 8C2 6.4087 2.63214 4.88258 3.75736 3.75736C4.88258 2.63214 6.4087 2 8 2C9.67737 2.00631 11.2874 2.66082 12.4933 3.82667L14 5.33333" stroke="#9EA6B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M14 2V5.33333H10.6666" stroke="#9EA6B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M14 8C14 9.5913 13.3679 11.1174 12.2426 12.2426C11.1174 13.3679 9.5913 14 8 14C6.32263 13.9937 4.71265 13.3392 3.50667 12.1733L2 10.6667" stroke="#9EA6B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M5.33333 10.6667H2V14" stroke="#9EA6B8" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M2 8C2 6.4087 2.63214 4.88258 3.75736 3.75736C4.88258 2.63214 6.4087 2 8 2C9.67737 2.00631 11.2874 2.66082 12.4933 3.82667L14 5.33333" stroke="#B2C3D4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14 2V5.33333H10.6666" stroke="#B2C3D4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M14 8C14 9.5913 13.3679 11.1174 12.2426 12.2426C11.1174 13.3679 9.5913 14 8 14C6.32263 13.9937 4.71265 13.3392 3.50667 12.1733L2 10.6667" stroke="#B2C3D4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.33333 10.6667H2V14" stroke="#B2C3D4" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/frontend/src/components/HistoryModal.tsx
+++ b/frontend/src/components/HistoryModal.tsx
@@ -243,7 +243,7 @@ const HistoryModal = ({
   }
 
   return (
-    <div className="fixed left-[52px] top-0 max-w-sm w-[300px] h-full border-[0.5px] border-[#D7E0E9] flex flex-col select-none bg-white">
+    <div className="fixed left-[52px] top-0 max-w-sm w-[300px] h-full border-r-[0.5px] border-[#D7E0E9] flex flex-col select-none bg-white">
       <div className="flex justify-between items-center ml-[18px] mt-[14px]">
         <p className="text-[#1C1D1F] font-medium text-[16px]">Chat History</p>
         <button

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -22,10 +22,11 @@ export const Sidebar = ({
 }) => {
   const location = useLocation()
   const [showHistory, setShowHistory] = useState<boolean>(false)
+
   return (
     <TooltipProvider>
       <div
-        className={`bg-white h-full w-[52px] border-r-[0.5px] border-[#D7E0E9] flex flex-col items-center space-y-[10px] fixed ${className} z-20 select-none`}
+        className={`bg-white h-full w-[52px] border-r-[0.5px] border-[#D7E0E9] flex flex-col fixed ${className} z-20 select-none`}
       >
         {showHistory && (
           <HistoryModal
@@ -33,54 +34,67 @@ export const Sidebar = ({
             onClose={() => setShowHistory(false)}
           />
         )}
-        {photoLink && (
-          <img
-            className="w-[32px] h-[32px] mt-[16px] rounded-full mb-[15px]"
-            src={`/api/v1/proxy/${encodeURIComponent(photoLink)}`}
-            alt="Profile"
-          />
-        )}
-        <Link
-          to="/"
-          className="flex w-[32px] h-[32px] border-[1px] border-[#C4D0DC] items-center justify-center rounded-[6px]"
-        >
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Plus size={18} stroke="#384049" />
-            </TooltipTrigger>
-            <Tip side="right" info="Ask & Search" />
-          </Tooltip>
-        </Link>
-        <div
-          onClick={() => setShowHistory((history) => !history)}
-          className={`flex w-[32px] h-[32px] ${showHistory ? "bg-[#D8DFE680]" : ""} rounded-[8px] items-center justify-center cursor-pointer  hover:bg-[#D8DFE680]`}
-        >
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <History size={18} stroke="#384049" />
-            </TooltipTrigger>
-            <Tip side="right" info="History" />
-          </Tooltip>
+        <div className="flex flex-col items-center pt-4">
+          {photoLink && (
+            <img
+              className="w-8 h-8 rounded-full mb-4"
+              src={`/api/v1/proxy/${encodeURIComponent(photoLink)}`}
+              alt="Profile"
+            />
+          )}
         </div>
-        <Link
-          to={`${role === UserRole.SuperAdmin || role === UserRole.Admin ? "/admin/integrations" : "/integrations"}`}
-          className="flex w-[32px] h-[32px] items-center justify-center hover:bg-[#D8DFE680] rounded-[6px]"
+
+        <div className="flex flex-col items-center mt-[10px]">
+          <Link
+            to="/"
+            className="flex w-8 h-8 border border-[#C4D0DC] items-center justify-center rounded-md"
+          >
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Plus size={18} stroke="#384049" />
+              </TooltipTrigger>
+              <Tip side="right" info="New" />
+            </Tooltip>
+          </Link>
+
+          <div
+            onClick={() => setShowHistory((history) => !history)}
+            className={`flex w-8 h-8 ${showHistory ? "bg-[#D8DFE680]" : ""} rounded-lg items-center justify-center cursor-pointer hover:bg-[#D8DFE680] mt-[10px]`}
+          >
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <History size={18} stroke="#384049" />
+              </TooltipTrigger>
+              <Tip side="right" info="History" />
+            </Tooltip>
+          </div>
+
+          <Link
+            to={`${role === UserRole.SuperAdmin || role === UserRole.Admin ? "/admin/integrations" : "/integrations"}`}
+            className="flex w-8 h-8 items-center justify-center hover:bg-[#D8DFE680] rounded-md mt-[10px]"
+          >
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Plug
+                  stroke="#384049"
+                  size={18}
+                  {...(location.pathname === "/admin/integrations" ||
+                  location.pathname === "/integrations"
+                    ? { className: "text-blue-500 hover:text-blue-600" }
+                    : { className: "hover:text-blue-600" })}
+                />
+              </TooltipTrigger>
+              <Tip side="right" info="Integrations" />
+            </Tooltip>
+          </Link>
+        </div>
+
+        <a
+          href="https://xynehq.com"
+          className="mt-auto mb-4 flex justify-center"
         >
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Plug
-                stroke="#384049"
-                size={18}
-                {...(location.pathname === "/admin/integrations" ||
-                location.pathname === "/integrations"
-                  ? { className: "text-blue-500 hover:text-blue-600" }
-                  : { className: "hover:text-blue-600" })}
-              />
-            </TooltipTrigger>
-            <Tip side="right" info="Integrations" />
-          </Tooltip>
-        </Link>
-        <img style={{ marginTop: "auto", marginBottom: "16px" }} src={Logo} />
+          <img src={Logo} alt="Logo" />
+        </a>
       </div>
     </TooltipProvider>
   )

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -986,19 +986,18 @@ const MessageCitationList = ({
             </a>
           </li>
         ))}
-        {!!citations.length &&
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <img
-              onClick={onToggleSources}
-              className="cursor-pointer"
-              src={Expand}
-            />
-          </TooltipTrigger>
-          <Tip side="right" info="Show All Sources" margin="ml-[16px]" />
-        </Tooltip>
-
-        }
+        {!!citations.length && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <img
+                onClick={onToggleSources}
+                className="cursor-pointer"
+                src={Expand}
+              />
+            </TooltipTrigger>
+            <Tip side="right" info="Show All Sources" margin="ml-[16px]" />
+          </Tooltip>
+        )}
       </ul>
     </TooltipProvider>
   )
@@ -1169,7 +1168,7 @@ const ChatMessage = ({
               <div className="flex ml-[52px] mt-[24px] items-center">
                 <Copy
                   size={16}
-                  stroke={`${isCopied ? "#4F535C" : "#9EA6B8"}`}
+                  stroke={`${isCopied ? "#4F535C" : "#B2C3D4"}`}
                   className={`cursor-pointer`}
                   onMouseDown={(e) => setIsCopied(true)}
                   onMouseUp={(e) => setIsCopied(false)}


### PR DESCRIPTION
# why

If we clicked the history icon it would shift all the icons in the sidebar.
Link logo in sidebar to xyne website (will be configurable per company)
Change tooltip for home page

# what changed
 - Sidebar.tsx
 - svg icon color for retry

# test plan
visually
