### PR TITLE
feat(cleanup) : Cleanup  Google Credentials from env.dev

### DIFF
--- a/server/.env.development
+++ b/server/.env.development
@@ -1,5 +1,8 @@
 ENCRYPTION_KEY=+YGPnHv+hsyl8P7CbrFRNJmW4QM6x0FlwO8do0wP2+o=
 SERVICE_ACCOUNT_ENCRYPTION_KEY=w1RJFvEBc7p1ZY006c1t7i98Qj184iWYhqonD6bEWnU=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=http://localhost:3000/v1/auth/callback
 # because of vite server we want to redirect to
 # the dev server so that it is easier to continue the development
 POST_OAUTH_REDIRECT=http://localhost:5173/


### PR DESCRIPTION
### Description
`REFACTOR PR` : Removed the Google Credentials from the .env.dev file. We've decided to move to a new credential. Removed `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`,`GOOGLE_REDIRECT_URI`, and `NOTION_API_KEY.`

### Testing
Tested locally

### Additional Notes
None
