### PR TITLE
fix(gmail): service account gmail worker crashed due to import of server

### DIFF
--- a/server/integrations/google/gmail-worker.ts
+++ b/server/integrations/google/gmail-worker.ts
@@ -40,6 +40,7 @@ import {
   parseAttachments,
 } from "@/integrations/google/utils"
 
+
 const jwtValue = z.object({
   type: z.literal(MessageTypes.JwtParams),
   userEmail: z.string(),
@@ -86,8 +87,8 @@ self.onmessage = async (event: MessageEvent<MessageType>) => {
   }
 }
 
-self.onerror = (error) => {
-  Logger.error(error, `Error in Gmail worker: ${error}`)
+self.onerror = (error: ErrorEvent) => {
+  Logger.error(error, `Error in Gmail worker: ${JSON.stringify(error)}`)
 }
 
 export const handleGmailIngestion = async (

--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -34,7 +34,7 @@ import {
   UpdateEventCancelledInstances,
 } from "@/search/vespa"
 import { SaaSQueue } from "@/queue"
-import { wsConnections } from "@/server"
+import { wsConnections } from "@/integrations/google/ws"
 import type { WSContext } from "hono/ws"
 import { db } from "@/db/client"
 import { connectors, type SelectConnector } from "@/db/schema"
@@ -707,7 +707,7 @@ const messageTypes = z.discriminatedUnion("type", [stats, historyId])
 
 type ResponseType = z.infer<typeof messageTypes>
 
-gmailWorker.onerror = (error) => {
+gmailWorker.onerror = (error: ErrorEvent) => {
   Logger.error(error, `Error in main thread: worker: ${JSON.stringify(error)}`)
 }
 

--- a/server/integrations/google/utils.ts
+++ b/server/integrations/google/utils.ts
@@ -29,7 +29,7 @@ import {
   downloadPDF,
   getSheetsListFromOneSpreadsheet,
   safeLoadPDF,
-} from "."
+} from "@/integrations/google"
 import { getLogger } from "@/logger"
 import type PgBoss from "pg-boss"
 import fs from "node:fs/promises"

--- a/server/integrations/google/ws.ts
+++ b/server/integrations/google/ws.ts
@@ -1,0 +1,1 @@
+export const wsConnections = new Map()

--- a/server/server.ts
+++ b/server/server.ts
@@ -56,8 +56,8 @@ import {
   MessageApi,
   MessageRetryApi,
 } from "./api/chat"
-import { z } from "zod"
 import { UserRole } from "./shared/types"
+import { wsConnections } from "@/integrations/google/ws"
 type Variables = JwtVariables
 
 const clientId = process.env.GOOGLE_CLIENT_ID!
@@ -112,7 +112,6 @@ const honoMiddlewareLogger = LogMiddleware(Subsystem.Server)
 
 app.use("*", honoMiddlewareLogger)
 
-export const wsConnections = new Map()
 
 export const WsApp = app.get(
   "/ws",


### PR DESCRIPTION
### Description
Due to indirect import of `server.ts` in the worker which caused the `Bun.serve` to run again and crash. This led to worker crashing simply when the app started.

### Testing
Manually tested by doing Service Account ingestion.

### Additional Notes
#229 got introduced here.
Learning is to be careful to not indirectly somehow import from `@/server`.