### PR TITLE
fix(worker): prevent infinite loop of worker creation via cyclic imports

### DIFF
--- a/server/integrations/google/gmail-worker.ts
+++ b/server/integrations/google/gmail-worker.ts
@@ -38,7 +38,7 @@ import { JWT } from "google-auth-library"
 import {
   getGmailAttachmentChunks,
   parseAttachments,
-} from "@/integrations/google/utils"
+} from "@/integrations/google/worker-utils"
 
 
 const jwtValue = z.object({

--- a/server/integrations/google/gmail/index.ts
+++ b/server/integrations/google/gmail/index.ts
@@ -26,7 +26,7 @@ import { batchFetchImplementation } from "@jrmdayn/googleapis-batcher"
 import {
   getGmailAttachmentChunks,
   parseAttachments,
-} from "@/integrations/google/utils"
+} from "@/integrations/google/worker-utils"
 
 export const handleGmailIngestion = async (
   client: GoogleClient,

--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -106,6 +106,7 @@ import {
 } from "./tracking"
 const htmlToText = require("html-to-text")
 const Logger = getLogger(Subsystem.Integrations).child({ module: "google" })
+
 const gmailWorker = new Worker(new URL("gmail-worker.ts", import.meta.url).href)
 
 export type GaxiosPromise<T = any> = Promise<GaxiosResponse<T>>

--- a/server/integrations/google/pdf-utils.ts
+++ b/server/integrations/google/pdf-utils.ts
@@ -1,0 +1,77 @@
+import { DeleteDocumentError } from "@/errors"
+import { getLogger } from "@/logger"
+import { Apps, DriveEntity } from "@/search/types"
+import { Subsystem } from "@/types"
+import type { drive_v3 } from "googleapis"
+const Logger = getLogger(Subsystem.Integrations).child({ module: "google" })
+import { unlink } from "node:fs/promises"
+import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf"
+import path from "node:path"
+
+export const downloadDir = path.resolve(__dirname, "../../downloads")
+
+export const deleteDocument = async (filePath: string) => {
+    try {
+      await unlink(filePath)
+      Logger.info(`File at ${filePath} deleted successfully`)
+    } catch (err) {
+      Logger.error(
+        err,
+        `Error deleting file at ${filePath}: ${err} ${(err as Error).stack}`,
+        err,
+      )
+      throw new DeleteDocumentError({
+        message: "Error in the catch of deleting file",
+        cause: err as Error,
+        integration: Apps.GoogleDrive,
+        entity: DriveEntity.PDF,
+      })
+    }
+  }
+
+  export const downloadPDF = async (
+    drive: drive_v3.Drive,
+    fileId: string,
+    fileName: string,
+  ): Promise<void> => {
+    const filePath = path.join(downloadDir, fileName)
+    const file = Bun.file(filePath)
+    const writer = file.writer()
+    const res = await drive.files.get(
+      { fileId: fileId, alt: "media" },
+      { responseType: "stream" },
+    )
+    return new Promise((resolve, reject) => {
+      res.data.on("data", (chunk) => {
+        writer.write(chunk)
+      })
+      res.data.on("end", () => {
+        writer.end()
+        resolve()
+      })
+      res.data.on("error", (err) => {
+        writer.end()
+        reject(err)
+      })
+    })
+  }
+
+  // Helper function for safer PDF loading
+export async function safeLoadPDF(pdfPath: string): Promise<Document[]> {
+    try {
+      const loader = new PDFLoader(pdfPath)
+      // @ts-ignore
+      return await loader.load()
+    } catch (error) {
+      const { name, message } = error as Error
+      if (
+        message.includes("PasswordException") ||
+        name.includes("PasswordException")
+      ) {
+        Logger.warn("Password protected PDF, skipping")
+      } else {
+        Logger.error(error, `PDF load error: ${error}`)
+      }
+      return []
+    }
+  }

--- a/server/integrations/google/sync.ts
+++ b/server/integrations/google/sync.ts
@@ -1516,10 +1516,22 @@ export const handleGoogleServiceAccountChanges = async (
       }
     } catch (error) {
       const errorMessage = getErrorMessage(error)
+      if (
+        errorMessage ===
+        "Sync token is no longer valid, a full sync is required."
+      ) {
+        console.log("continuing")
+        continue
+      }
+
       Logger.error(
         error,
         `Could not successfully complete ServiceAccount sync job for Google Calendar: ${syncJob.id} due to ${errorMessage} ${(error as Error).stack}`,
       )
+
+      if(errorMessage === 'Sync token is no longer valid, a full sync is required.') {
+        continue
+      }
       const config: CalendarEventsChangeToken =
         syncJob.config as CalendarEventsChangeToken
       const newConfig = {

--- a/server/integrations/google/utils.ts
+++ b/server/integrations/google/utils.ts
@@ -1,4 +1,4 @@
-import type { GaxiosResponse } from "gaxios"
+import type { GaxiosError, GaxiosResponse } from "gaxios"
 import {
   Subsystem,
   type GoogleClient,
@@ -220,6 +220,22 @@ export const getPDFContent = async (
       `Error getting file: ${error} ${(error as Error).stack}`,
       error,
     )
+
+    // previously sync was breaking for these 2 cases
+    // so we return null (TODO: confirm if we ingest atleast the metadata)
+    if (
+      (error as Error).message === "No password given" &&
+      (error as any).code === 1
+    ) {
+      return
+    } else if (
+      (error as Error).message === "Permission denied" &&
+      (error as GaxiosError).code === "EACCES"
+    ) {
+      // this is pdf someone else has shared but we don't have access to download it
+      return
+    }
+
     throw new DownloadDocumentError({
       message: "Error in getting file content",
       cause: error as Error,
@@ -358,111 +374,4 @@ export const checkDownloadsFolder = async (
       `Error checking or deleting files in downloads folder: ${error} ${(error as Error).stack}`,
     )
   }
-}
-
-export async function saveGmailAttachment(
-  attachmentData: any,
-  fileName: string,
-) {
-  try {
-    // The attachment data is base64 encoded, so we need to decode it
-    // Replace any `-` with `+` and `_` with `/` to make it standard base64
-    const normalizedBase64 = attachmentData
-      .replace(/-/g, "+")
-      .replace(/_/g, "/")
-
-    const buffer = Buffer.from(normalizedBase64, "base64")
-    await fs.writeFile(fileName, buffer)
-
-    Logger.info(`Successfully saved gmail attachment at ${fileName}`)
-  } catch (error) {
-    Logger.error("Error saving gmail attachment:", error)
-    throw error
-  }
-}
-
-export const getGmailAttachmentChunks = async (
-  gmail: gmail_v1.Gmail,
-  attachmentMetadata: {
-    messageId: string
-    attachmentId: string
-    filename: string
-    size: number
-  },
-): Promise<string[] | null> => {
-  const { attachmentId, filename, messageId, size } = attachmentMetadata
-  let attachmentChunks: string[] = []
-  const pdfSizeInMB = size / (1024 * 1024)
-  // Ignore the PDF files larger than Max PDF Size
-  if (pdfSizeInMB > MAX_ATTACHMENT_PDF_SIZE) {
-    Logger.warn(
-      `Ignoring ${filename} as its more than ${MAX_ATTACHMENT_PDF_SIZE} MB`,
-    )
-    return null
-  }
-
-  try {
-    const fileName = `${filename}_${messageId}`
-    const downloadAttachmentFilePath = path.join(downloadDir, fileName)
-
-    const attachementResp = await retryWithBackoff(
-      () =>
-        gmail.users.messages.attachments.get({
-          messageId: messageId,
-          id: attachmentId,
-          userId: "me",
-        }),
-      "Fetching Gmail Attachments",
-    )
-
-    await saveGmailAttachment(
-      attachementResp.data.data,
-      downloadAttachmentFilePath,
-    )
-    const docs = await safeLoadPDF(downloadAttachmentFilePath)
-    if (!docs || docs.length === 0) {
-      Logger.warn(`Could not get content for file: ${filename}. Skipping it`)
-
-      await deleteDocument(downloadAttachmentFilePath)
-      return null
-    }
-    attachmentChunks = docs
-      .flatMap((doc) => chunkDocument(doc.pageContent))
-      .map((v) => v.chunk)
-      .filter((v) => v.trim())
-
-    await deleteDocument(downloadAttachmentFilePath)
-  } catch (error) {
-    throw error
-  }
-
-  return attachmentChunks
-}
-
-// Function to parse attachments from the email payload
-export const parseAttachments = (
-  payload: gmail_v1.Schema$MessagePart,
-): { attachments: Attachment[]; filenames: string[] } => {
-  const attachments: Attachment[] = []
-  const filenames: string[] = []
-
-  const traverseParts = (parts: any[]) => {
-    for (const part of parts) {
-      if (part.filename && part.body && part.body.attachmentId) {
-        filenames.push(part.filename)
-        attachments.push({
-          fileType: part.mimeType || "application/octet-stream",
-          fileSize: parseInt(part.body.size, 10) || 0,
-        })
-      } else if (part.parts) {
-        traverseParts(part.parts)
-      }
-    }
-  }
-
-  if (payload.parts) {
-    traverseParts(payload.parts)
-  }
-
-  return { attachments, filenames }
 }

--- a/server/integrations/google/worker-utils.ts
+++ b/server/integrations/google/worker-utils.ts
@@ -1,0 +1,124 @@
+import { Subsystem } from "@/types"
+import fs from "node:fs/promises"
+import { getLogger } from "@/logger"
+import { gmail_v1 } from "googleapis"
+import {
+  deleteDocument,
+  downloadDir,
+  downloadPDF,
+  safeLoadPDF,
+} from "@/integrations/google/pdf-utils"
+import { retryWithBackoff } from "@/utils"
+import { chunkDocument } from "@/chunks"
+import type { Attachment } from "@/search/types"
+import { MAX_ATTACHMENT_PDF_SIZE } from "@/integrations/google/config"
+import path from "node:path"
+const Logger = getLogger(Subsystem.Integrations).child({ module: "google" })
+export async function saveGmailAttachment(
+  attachmentData: any,
+  fileName: string,
+) {
+  try {
+    // The attachment data is base64 encoded, so we need to decode it
+    // Replace any `-` with `+` and `_` with `/` to make it standard base64
+    const normalizedBase64 = attachmentData
+      .replace(/-/g, "+")
+      .replace(/_/g, "/")
+
+    const buffer = Buffer.from(normalizedBase64, "base64")
+    // @ts-ignore
+    await fs.writeFile(fileName, buffer)
+
+    Logger.info(`Successfully saved gmail attachment at ${fileName}`)
+  } catch (error) {
+    Logger.error("Error saving gmail attachment:", error)
+    throw error
+  }
+}
+
+export const getGmailAttachmentChunks = async (
+  gmail: gmail_v1.Gmail,
+  attachmentMetadata: {
+    messageId: string
+    attachmentId: string
+    filename: string
+    size: number
+  },
+): Promise<string[] | null> => {
+  const { attachmentId, filename, messageId, size } = attachmentMetadata
+  let attachmentChunks: string[] = []
+  const pdfSizeInMB = size / (1024 * 1024)
+  // Ignore the PDF files larger than Max PDF Size
+  if (pdfSizeInMB > MAX_ATTACHMENT_PDF_SIZE) {
+    Logger.warn(
+      `Ignoring ${filename} as its more than ${MAX_ATTACHMENT_PDF_SIZE} MB`,
+    )
+    return null
+  }
+
+  try {
+    const fileName = `${filename}_${messageId}`
+    const downloadAttachmentFilePath = path.join(downloadDir, fileName)
+
+    const attachementResp = await retryWithBackoff(
+      () =>
+        gmail.users.messages.attachments.get({
+          messageId: messageId,
+          id: attachmentId,
+          userId: "me",
+        }),
+      "Fetching Gmail Attachments",
+    )
+
+    await saveGmailAttachment(
+      attachementResp.data.data,
+      downloadAttachmentFilePath,
+    )
+    const docs = await safeLoadPDF(downloadAttachmentFilePath)
+    if (!docs || docs.length === 0) {
+      Logger.warn(`Could not get content for file: ${filename}. Skipping it`)
+
+      await deleteDocument(downloadAttachmentFilePath)
+      return null
+    }
+    attachmentChunks = docs
+      // @ts-ignore
+      .flatMap((doc) => chunkDocument(doc.pageContent))
+      .map((v) => v.chunk)
+      .filter((v) => v.trim())
+
+    await deleteDocument(downloadAttachmentFilePath)
+  } catch (error) {
+    throw error
+  }
+
+  return attachmentChunks
+}
+
+// Function to parse attachments from the email payload
+export const parseAttachments = (
+  payload: gmail_v1.Schema$MessagePart,
+): { attachments: Attachment[]; filenames: string[] } => {
+  const attachments: Attachment[] = []
+  const filenames: string[] = []
+
+  const traverseParts = (parts: any[]) => {
+    for (const part of parts) {
+      if (part.filename && part.body && part.body.attachmentId) {
+        filenames.push(part.filename)
+        attachments.push({
+          fileType: part.mimeType || "application/octet-stream",
+          fileSize: parseInt(part.body.size, 10) || 0,
+        })
+      } else if (part.parts) {
+        traverseParts(part.parts)
+      }
+    }
+  }
+
+  if (payload.parts) {
+    traverseParts(payload.parts)
+  }
+
+  return { attachments, filenames }
+}


### PR DESCRIPTION
### Description
Since the attachment pr #229 we have util functions which helped with the pdf and email parsing code. The issue happened when the worker imported the utils which in turn imported `integrations/google/index.ts` for the pdf related functions.
This led to a new worker getting created inside the gmail-worker context. This would lead to infinite loop and eventual segmentation fault or overload of memory.

The reason this was not found before is due to the error fixed #282 As the worker was crashing the looping behavior was latent.

### Testing
Ingested data via service account which previously was causing segmentation fault.

### Additional Notes
This goes to show how careful we need to be in the current worker setup, it's brittle. It needs a lot more structure to prevent such issues, including a worker directory to help keep that demarcation clear.