### PR TITLE
feat(docs): Added fix and typos in documents

### DIFF
--- a/docs/authentication/get-credentials.mdx
+++ b/docs/authentication/get-credentials.mdx
@@ -13,7 +13,7 @@ Create a new project in [Google Cloud Console](https://console.cloud.google.com/
 Switch to the new project you just created.
 
 ## Setting up the OAuth Credentials
-Under APIs and Services section in the menu on the sidebar, click on ```Credentaials```,
+Under APIs and Services section in the menu on the sidebar, click on ```Credentials```,
 
 <img height="200" src="../images/oauth-4.png" />
 - Navigate to the Credentials Section in the sidebar, and click on  ```+CREATE CREDENTIALS ```. 
@@ -32,6 +32,6 @@ Under that select the ```OAuth client ID``` option.
 
 <Note> Use ```http://localhost:3000/v1/auth/callback``` and ```http://localhost:3000/oauth/callback``` when using devmode.</Note>
 
-Click ```CREATE``` and make sure save the Client ID and Client Secret for putting it in the [```.env``` of the application](https://xyne.mintlify.app/quickstart#post-execution-steup-environment-variables)
+Click ```CREATE``` and make sure to save the Client ID and Client Secret for putting it in the [```.env``` of the application](https://xyne.mintlify.app/quickstart#post-execution-steup-environment-variables)
 
 

--- a/docs/authentication/oauth.mdx
+++ b/docs/authentication/oauth.mdx
@@ -47,7 +47,7 @@ Following the same steps above, enable the following APIs :
 
 
 ### Setting up the Oauth Consent Screen
-Once you've enabled the APIs, you'll also need to add the scopes for this APIs. For our app we only require ```readonly``` scopes for all the APIs.
+Once you've enabled the APIs, you'll also need to add the scopes for these APIs. For our app we only require ```readonly``` scopes for all the APIs.
 For this navigate to the Oauth Consent Screen in the Sidebar of your Google Cloud Console : 
 <img height="200" src="../images/oauth-2.png" />
 

--- a/docs/authentication/oauth.mdx
+++ b/docs/authentication/oauth.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'OAuth'
-description: 'Oauth Authorization'
+description: 'OAuth Authorization'
 icon: 'lock'
 ---
 
@@ -46,9 +46,9 @@ Following the same steps above, enable the following APIs :
  - [People](https://console.cloud.google.com/apis/library/people.googleapis.com)
 
 
-### Setting up the Oauth Consent Screen
+### Setting up the OAuth Consent Screen
 Once you've enabled the APIs, you'll also need to add the scopes for these APIs. For our app we only require ```readonly``` scopes for all the APIs.
-For this navigate to the Oauth Consent Screen in the Sidebar of your Google Cloud Console : 
+For this navigate to the OAuth Consent Screen in the Sidebar of your Google Cloud Console : 
 <img height="200" src="../images/oauth-2.png" />
 
 Under ```OAuth Consent``` screen select ```Internal``` : 
@@ -103,9 +103,9 @@ You can also choose to ```manually``` add the scopes in the ```box``` below.
 ```
 
 Leave the next page ,i.e. ```Test users``` blank.
-This concludes the setting-up of your Oauth Consent Screen
+This concludes the setting-up of your OAuth Consent Screen
 
 
-This concludes the set-up process of Google Oauth.
+This concludes the set-up process of Google OAuth.
 
 

--- a/docs/authentication/service-accounts.mdx
+++ b/docs/authentication/service-accounts.mdx
@@ -44,7 +44,7 @@ Following the same steps above, enable the following APIs :
 -  [Admin SDK](https://console.cloud.google.com/marketplace/product/google/admin.googleapis.com)
 
 ## Setting up the Oauth Consent Screen
-Once you've enabled the APIs, you'll also need to add the scopes for this APIs. For our app we only require ```readonly``` scopes for all the APIs.
+Once you've enabled the APIs, you'll also need to add the scopes for these APIs. For our app we only require ```readonly``` scopes for all the APIs.
 For this navigate to the Oauth Consent Screen in the Sidebar of your Google Cloud Console : 
 <img height="200" src="../images/oauth-2.png" />
 
@@ -138,15 +138,15 @@ Once you've filled out the details, click on `CREATE AND CONTINUE`
 - Choose the ```json``` option for downloading the key file, and click on ```Create```.
 <img height="200" src="../images/serv-acc5.png" />
 - Remember the ```Client id``` associated with this json file.
-- Once the key file has been created, choose a reliable location to downloading the key file, this will be used for putting it in the [```.env``` of the application](https://xyne.mintlify.app/deployment/aws/aws-deployment#setup-environment-variables)
+- Once the key file has been created, choose a reliable location for downloading the key file, this will be used for putting it in the [```.env``` of the application](https://xyne.mintlify.app/deployment/aws/aws-deployment#setup-environment-variables)
 
 
 ## Setting up Delegation
 
-- Now that all of this is done, the ```Worspace Admin``` need to do some delegations, navigate to [Domain Wide Delegation](https://admin.google.com/ac/owl/domainwidedelegation). 
+- Now that all of this is done, the ```Worspace Admin``` needs to do some delegations, navigate to [Domain Wide Delegation](https://admin.google.com/ac/owl/domainwidedelegation). 
 - Click on ```Add New``` 
 <img height="200" src="../images/add-new.png" />
-- In there paste the Oauth Client Id that you received when creating the service account key.
+- In there paste the ```Oauth Client Id``` that you received when creating the service account key.
 - Paste the following scopes : 
 ```javascript
 https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/documents.readonly,https://www.googleapis.com/auth/spreadsheets.readonly,https://www.googleapis.com/auth/presentations.readonly,https://www.googleapis.com/auth/contacts.readonly,https://www.googleapis.com/auth/contacts.other.readonly,https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/calendar.events.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly

--- a/docs/authentication/service-accounts.mdx
+++ b/docs/authentication/service-accounts.mdx
@@ -43,9 +43,9 @@ Following the same steps above, enable the following APIs :
  - [People](https://console.cloud.google.com/apis/library/people.googleapis.com)
 -  [Admin SDK](https://console.cloud.google.com/marketplace/product/google/admin.googleapis.com)
 
-## Setting up the Oauth Consent Screen
+## Setting up the OAuth Consent Screen
 Once you've enabled the APIs, you'll also need to add the scopes for these APIs. For our app we only require ```readonly``` scopes for all the APIs.
-For this navigate to the Oauth Consent Screen in the Sidebar of your Google Cloud Console : 
+For this navigate to the OAuth Consent Screen in the Sidebar of your Google Cloud Console : 
 <img height="200" src="../images/oauth-2.png" />
 
 Under ```OAuth Consent``` screen select ```Internal``` : 
@@ -105,7 +105,7 @@ You can also choose to ```manually``` add the scopes in the ```box``` below.
 ```
 
 Leave the next page ,i.e. ```Test users``` blank.
-This concludes the setting-up of your Oauth Consent Screen
+This concludes the setting-up of your OAuth Consent Screen
 
 ### Setting up the Service Account and Credentials
 First, from the menubar on the side, navigate to the ```IAM & Admin``` section. In there look for the ````Service Account```` section. Or directly visit [here](https://console.cloud.google.com/iam-admin/serviceaccounts), and then select your project.
@@ -146,7 +146,7 @@ Once you've filled out the details, click on `CREATE AND CONTINUE`
 - Now that all of this is done, the ```Worspace Admin``` needs to do some delegations, navigate to [Domain Wide Delegation](https://admin.google.com/ac/owl/domainwidedelegation). 
 - Click on ```Add New``` 
 <img height="200" src="../images/add-new.png" />
-- In there paste the ```Oauth Client Id``` that you received when creating the service account key.
+- In there paste the ```OAuth Client Id``` that you received when creating the service account key.
 - Paste the following scopes : 
 ```javascript
 https://www.googleapis.com/auth/drive.readonly,https://www.googleapis.com/auth/documents.readonly,https://www.googleapis.com/auth/spreadsheets.readonly,https://www.googleapis.com/auth/presentations.readonly,https://www.googleapis.com/auth/contacts.readonly,https://www.googleapis.com/auth/contacts.other.readonly,https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/calendar.events.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly

--- a/docs/deployment/cloud/aws/aws-deployment-with-docker.mdx
+++ b/docs/deployment/cloud/aws/aws-deployment-with-docker.mdx
@@ -25,7 +25,7 @@ Deployment of Xyne on AWS EC2 using docker image requires you to only install Do
 - [Docker](https://docs.docker.com/engine/install/) 
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
-Once you have installed the dependency, you can use the following steps to set up the instance.
+Once you have installed the dependencies, you can use the following steps to set up the instance.
 
 <Warning>Ensure you have an instance with enough storage to store the dependencies and run the Xyne Application</Warning>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -85,7 +85,7 @@ And build again from the ``xyne`` folder using :
 docker-compose -f deployment/docker-compose.yml up 
 ```
 
-<Note> Cuurently the client side has .env variables that refer to port 3001, if you've changed the port number ensure to change the values in the .env as well as well. </Note>
+<Note> Cuurently the client side has .env variables that refer to port 3001, if you've changed the port number ensure to change the values in the .env as well. </Note>
 
 ## Ingesting data 
 Follow the guide below to learn more about ingesting data into xyne app: 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -14,7 +14,7 @@ Deployment of Xyne requires you to only install Docker and Docker Compose:
 - [Docker](https://docs.docker.com/engine/install/) 
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
-Once you have installed the dependency, you can use the following steps to set up the app.
+Once you have installed the dependencies, you can use the following steps to set up the app.
 
 
 ## Clone the repository : 


### PR DESCRIPTION
### Description

Fixed  typos in the quickstart guide where there was two `as well` instead of one  , oauth and service account authentication where there was `this` instead of `these` in APIs,  and aws deployment docs with some added corrections .

### Testing

Tested locally

### Additional Notes

No additional notes so far.
