### PR TITLE
fix(permissions): Add missing permission check for docs

### DIFF
--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -296,7 +296,7 @@ export const HybridDefaultProfile = (
           (
             ({targetHits:${hits}}userInput(@query))
             ${timestampRange ? `and ${userTimestamp}` : ""}
-            ${!hasAppOrEntity ? `and app contains "${Apps.GoogleWorkspace}"` : appOrEntityFilter}
+            ${!hasAppOrEntity ? `and app contains "${Apps.GoogleWorkspace}"` : `${appOrEntityFilter} and permissions contains @email`}
           )
           or
           (


### PR DESCRIPTION
### Description
Fix bug where documents contains both `app` and `entity` were not undergoing the necessary permission checks, causing a permission breakdown for the doc

### Testing
explicitly ingested docs with different permissions, and verified search results

### Additional Notes

Possibly fix for this #299 