### PR TITLE
fix(vespa): for bge-base we needed higher limits to ensure it works consistently

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -49,6 +49,10 @@ services:
       - ../server/vespa-logs:/opt/vespa/logs
     networks:
       - xyne
+    deploy:
+      resources:
+        limits:
+          memory: 6G
     ulimits:
       nproc: 409600
     restart: always


### PR DESCRIPTION
### Description
due to memory related issues we would get the following vespa errors.
```
Container.com.yahoo.vespa.clustercontroller.core.SystemStateBroadcaster     Cluster 'my_content': Publishing cluster state version 30
xyne-app    | Error: invalid application package (status 400)
xyne-app    | Invalid application:
xyne-app    | Could not import model 'model':
xyne-app    | Could not import ONNX model from '/opt/vespa/var/db/vespa/config_server/serverdb/tenants/default/sessions/9/.preprocessed/models/model.onnx'
vespa       | [2025-02-03 09:40:22.271] INFO    configserver     Container.com.yahoo.vespa.config.server.http.HttpErrorResponse Returning response with response code 400, error-code:INVALID_APPLICATION_PACKAGE, message=Invalid application: Could not import model 'model': Could not import ONNX model from '/opt/vespa/var/db/vespa/config_server/serverdb/tenants/default/sessions/9/.preprocessed/models/model.onnx'
```
now after we added deploy limits the errors don't seem to come.

### Testing
Test locally and @kalpadhwaryu also tested
