### PR TITLE
fix(search): Fix people and event ranking

### DIFF
--- a/server/vespa/schemas/event.sd
+++ b/server/vespa/schemas/event.sd
@@ -185,6 +185,8 @@ schema event {
             }
         }
 
+        # Adjusting the ranking by reducing the weight of vector_score and metadata fields in BM25,  
+        # while giving higher importance to BM25 scores for 'name' and 'url'
         first-phase {
             expression: (0.5 * vector_score) + combined_bm25
         }

--- a/server/vespa/schemas/event.sd
+++ b/server/vespa/schemas/event.sd
@@ -181,18 +181,18 @@ schema event {
         function combined_bm25() {
             expression {
                 (scale(bm25(name)) + scale(bm25(url))) +
-                ((scale(bm25(description)) + (scale(bm25(attachmentFilenames)) + scale(bm25(attendeesNames))))) 
+                (0.6 * (scale(bm25(description)) + (scale(bm25(attachmentFilenames)) + scale(bm25(attendeesNames))))) 
             }
         }
 
         first-phase {
-            expression: (vector_score) + combined_bm25
+            expression: (0.5 * vector_score) + combined_bm25
         }
 
         global-phase {
             expression {
               (
-                (normalize_linear(vector_score)) +
+                (0.5 * normalize_linear(vector_score)) +
                 combined_bm25 + 
                 freshness_weight
               )

--- a/server/vespa/schemas/user.sd
+++ b/server/vespa/schemas/user.sd
@@ -188,13 +188,21 @@ schema user {
     }
 
     rank-profile default {
+        constants {
+            decay: 0.8
+        }
+
         match-features {
             bm25(name)
             bm25(email)
         }
+
         global-phase {
+            # Added slight decay to mitigate the disproportionate increase in BM25 scores 
+            # for shorter content with minimal matches, preventing them from 
+            # overpowering more relevant documents.
             expression {
-                normalize_linear(bm25(name))+ normalize_linear(bm25(email))
+               (decay * normalize_linear(bm25(name))) + (decay * normalize_linear(bm25(email)))
             }
         }
     }


### PR DESCRIPTION
### Description
People and meeting/event documents were receiving disproportionately high rankings, even for minimal matches. This update adds weightage to reduce their scores, ensuring they do not dominate the results unfairly

### Additional Notes
This should resolved : #286 