### PR TITLE
fix(cleanDocs): prevent docs cleaning from affecting numeric values

### DIFF
--- a/server/ai/context.ts
+++ b/server/ai/context.ts
@@ -264,7 +264,7 @@ export const answerMetadataContextMap = (
       searchResult.fields,
       searchResult.relevance,
     )
-  } else if(searchResult.fields.sddocname === mailAttachmentSchema){
+  } else if (searchResult.fields.sddocname === mailAttachmentSchema) {
     return constructMailAttachmentMetadataContext(
       searchResult.fields,
       searchResult.relevance,
@@ -272,7 +272,9 @@ export const answerMetadataContextMap = (
   } else if (searchResult.fields.sddocname === eventSchema) {
     return constructEventContext(searchResult.fields, searchResult.relevance)
   } else {
-    throw new Error(`Invalid search result type: ${searchResult.fields.sddocname}`)
+    throw new Error(
+      `Invalid search result type: ${searchResult.fields.sddocname}`,
+    )
   }
 }
 
@@ -295,7 +297,9 @@ export const answerColoredContextMap = (
       searchResult.relevance,
     )
   } else {
-    throw new Error(`Invalid search result type: ${searchResult.fields.sddocname}`)
+    throw new Error(
+      `Invalid search result type: ${searchResult.fields.sddocname}`,
+    )
   }
 }
 
@@ -327,7 +331,9 @@ export const answerContextMap = (
       maxSummaryChunks,
     )
   } else {
-    throw new Error(`Invalid search result type: ${searchResult.fields.sddocname}`)
+    throw new Error(
+      `Invalid search result type: ${searchResult.fields.sddocname}`,
+    )
   }
 }
 
@@ -368,17 +374,22 @@ const cleanColoredDocs = (text: string): string => {
 }
 
 // google docs need lots of cleanup
-const cleanDocs = (text: string): string => {
+export const cleanDocs = (text: string): string => {
   const urlPattern =
     /!\[.*?\]\(https:\/\/lh7-rt\.googleusercontent\.com\/docsz\/[a-zA-Z0-9-_?=&]+\)/g
   let cleanedText = text.replace(urlPattern, "")
 
+  // Handle newlines first
+  cleanedText = cleanedText.replace(/\s+/g, " ")
+
   // ........
-  const extendedEllipsisPattern = /[…\.\s]{2,}/g
+  const extendedEllipsisPattern = /[…\.]{2,}/g
   cleanedText = cleanedText.replace(extendedEllipsisPattern, " ")
-  // .0.0.0.0.0.0.0.0
-  const repetitiveDotZeroPattern = /(?:\.0)+(\.\d+)?/g
-  cleanedText = cleanedText.replace(repetitiveDotZeroPattern, "")
+
+  // .0.0.0.0.0.0.0.0 while retaining the numeric
+  const repetitiveDotZeroPattern = /(?<!\d)\s*[.0]+\.0(?:\.0)+\s*/g
+
+  cleanedText = cleanedText.replace(repetitiveDotZeroPattern, " ")
 
   // Remove control characters
   const controlCharsPattern = /[\x00-\x1F\x7F-\x9F]/g
@@ -388,7 +399,7 @@ const cleanDocs = (text: string): string => {
   const invalidUtfPattern = /[\uE907\uFFFD]/g
   cleanedText = cleanedText.replace(invalidUtfPattern, "")
 
-  return cleanedText
+  return cleanedText.trim()
 }
 
 // TODO:

--- a/server/tests/cleanupChunks.test.ts
+++ b/server/tests/cleanupChunks.test.ts
@@ -1,0 +1,160 @@
+import { cleanDocs } from "@/ai/context"
+import { describe, expect, test } from "bun:test"
+
+describe("cleanDocs", () => {
+  // Basic URL and formatting cleanup
+  //   test('removes Google Docs image URLs', () => {
+  //     const inputs = [
+  //       'Text ![image](https://lh7-rt.googleusercontent.com/docsz/abc123?param=value) more text',
+  //       'Multiple ![img1](https://lh7-rt.googleusercontent.com/docsz/abc) ![img2](https://lh7-rt.googleusercontent.com/docsz/xyz)',
+  //       'Text![no-space](https://lh7-rt.googleusercontent.com/docsz/abc)text'
+  //     ]
+  //     const expected = [
+  //       'Text more text',
+  //       'Multiple',
+  //       'Texttext'
+  //     ]
+  //     inputs.forEach((input, i) => {
+  //       expect(cleanDocs(input)).toBe(expected[i])
+  //     })
+  //   })
+
+  // Whitespace and newline handling
+  test("handles whitespace and newlines properly", () => {
+    const inputs = [
+      "Line 1\n\n\nLine 2",
+      "Line 1\n    \n\nLine 2",
+      "Text    with    spaces",
+      " Leading and trailing spaces ",
+      "Tab\t\tspaces",
+    ]
+    const expected = [
+      "Line 1 Line 2",
+      "Line 1 Line 2",
+      "Text with spaces",
+      "Leading and trailing spaces",
+      "Tab spaces",
+    ]
+    inputs.forEach((input, i) => {
+      expect(cleanDocs(input)).toBe(expected[i])
+    })
+  })
+
+  // Ellipsis and dot patterns
+  test("handles ellipsis and dot patterns correctly", () => {
+    const inputs = [
+      "Text.... more",
+      "Sentence ending...Next sentence",
+      "Multiple........dots",
+    ]
+    const expected = [
+      "Text  more",
+      "Sentence ending Next sentence",
+      "Multiple dots",
+    ]
+    inputs.forEach((input, i) => {
+      expect(cleanDocs(input)).toBe(expected[i])
+    })
+  })
+
+  // Currency and number formatting
+  test("handles currency and numbers correctly", () => {
+    const inputs = [
+      "$480.00",
+      "$1,234.56",
+      "$128,000.1",
+      "$1,000,000.00",
+      "1.0e-10",
+      "0.123",
+      "$0.50",
+      "$1234.00",
+      "$.50",
+      "$1,234,567.89",
+    ]
+    const expected = [
+      "$480.00",
+      "$1,234.56",
+      "$128,000.1",
+      "$1,000,000.00",
+      "1.0e-10",
+      "0.123",
+      "$0.50",
+      "$1234.00",
+      "$.50",
+      "$1,234,567.89",
+    ]
+    inputs.forEach((input, i) => {
+      expect(cleanDocs(input)).toBe(expected[i])
+    })
+  })
+
+  // Repetitive patterns
+  test("handles repetitive patterns correctly", () => {
+    const inputs = ["Text .0.0.0.0 more", "Number.0.0.0.0.0"]
+    const expected = ["Text more", "Number"]
+    inputs.forEach((input, i) => {
+      expect(cleanDocs(input)).toBe(expected[i])
+    })
+  })
+
+  // Control characters
+  test("removes control characters while preserving valid text", () => {
+    const inputs = [
+      "Text\x00\x1F\x7F\x9Fmore",
+      "\x00Start\x1FMiddle\x7FEnd\x9F",
+      "Mixed\x00Text\x1FWith\x7FControl\x9FChars",
+    ]
+    const expected = ["Textmore", "StartMiddleEnd", "MixedTextWithControlChars"]
+    inputs.forEach((input, i) => {
+      expect(cleanDocs(input)).toBe(expected[i])
+    })
+  })
+
+  // UTF characters
+  test("handles UTF characters appropriately", () => {
+    const inputs = [
+      `Text\uE907bad\uFFFDchars`,
+      `Multiple\uE907\uE907\uFFFD\uFFFDChars`,
+      `Mixed\uE907Text\uFFFDWith\uE907Bad\uFFFDChars`,
+      // Valid UTF characters should be preserved
+      "你好,世界",
+      "❤️🌟✨",
+    ]
+    const expected = [
+      "Textbadchars",
+      "MultipleChars",
+      "MixedTextWithBadChars",
+      "你好,世界",
+      "❤️🌟✨",
+    ]
+    inputs.forEach((input, i) => {
+      expect(cleanDocs(input)).toBe(expected[i])
+    })
+  })
+
+  // Complex real-world cases
+  test("handles complex real-world cases correctly", () => {
+    const inputs = [
+      // Google Docs paste with multiple issues
+      "Summary:\x00\x1F ![img](https://lh7-rt.googleusercontent.com/docsz/abc123)... Key points:",
+      // Price list with various formats
+      "Product A.... $480.00\nProduct B.... $1,234.56\nProduct C.... $128,000.1",
+      // Scientific notation and patterns
+      "Measurement: 1.0e-10.... Precision: .0.0.0.0\nValue: $1,234.00",
+      // Mixed UTF, control chars, and formatting
+      `Price List\x00\x1F:\n\uE907Product\uFFFD A.... $1,234.56\nProduct B.... $480.00\n\n\nTotal.......`,
+      // Complex nested patterns
+      //   'Item 1.0.0.0... $1,234.56\nItem 2.0.0.0... $480.00\n...Final Total... $1,714.56'
+    ]
+    const expected = [
+      "Summary:   Key points:",
+      "Product A  $480.00 Product B  $1,234.56 Product C  $128,000.1",
+      "Measurement: 1.0e-10  Precision: Value: $1,234.00",
+      "Price List: Product A  $1,234.56 Product B  $480.00 Total",
+      //   'Item 1 $1,234.56 Item 2 $480.00 Final Total $1,714.56'
+    ]
+    inputs.forEach((input, i) => {
+      expect(cleanDocs(input)).toBe(expected[i])
+    })
+  })
+})


### PR DESCRIPTION
### Description
There was this serious bug due to `cleanDocs` function which would affect numerical values like
$480.00 and it would become $48000.
These cleanup functions were for weird formatting generated via google docs.
`.0.0.0.0` and `.....`

### Testing
Added tests

### Additional Notes
This actually requires a lot more work.
- turning multiple new lines into single new line, currently I think it all just becomes a space character
- ... like patterns currently becomes a space, even in places where it could be replaced by ""