### PR TITLE
fix(ingestion-stats): Update attachment stats via worker message

### DIFF
--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -697,6 +697,7 @@ const stats = z.object({
   type: z.literal(WorkerResponseTypes.Stats),
   userEmail: z.string(),
   count: z.number(),
+  statType: z.nativeEnum(StatType),
 })
 
 const historyId = z.object({
@@ -729,8 +730,8 @@ gmailWorker.onmessage = (message: MessageEvent<ResponseType>) => {
       pendingRequests.delete(userEmail)
     }
   } else if (message.data.type === WorkerResponseTypes.Stats) {
-    const { userEmail, count } = message.data
-    updateUserStats(userEmail, StatType.Gmail, count)
+    const { userEmail, count, statType } = message.data
+    updateUserStats(userEmail, statType, count)
   }
 
   // else if (type === WorkerResponseTypes.Error) {


### PR DESCRIPTION
### Description
In PR #304, we previously updated attachment stats directly when inserting attachments. However, this approach seems doesn't work reliably in multi-threaded ingestion. This update ensures that attachment stats are updated by passing a message from the main thread to avoid concurrency issues
