### PR TITLE
fix(mail): Ensure mail body appears in search result previews

### DIFF
--- a/server/integrations/google/gmail-worker.ts
+++ b/server/integrations/google/gmail-worker.ts
@@ -274,7 +274,7 @@ export const parseMail = async (
 
   // Extract body and chunks
   const body = getBody(payload)
-  const chunks = chunkTextByParagraph(body)
+  const chunks = chunkTextByParagraph(body).filter(v => v)
 
   if (!messageId || !threadId) {
     throw new Error("Invalid message")

--- a/server/integrations/google/gmail/index.ts
+++ b/server/integrations/google/gmail/index.ts
@@ -199,7 +199,7 @@ export const parseMail = async (
 
   // Extract body and chunks
   const body = getBody(payload)
-  const chunks = chunkTextByParagraph(body)
+  const chunks = chunkTextByParagraph(body).filter((v) => v)
 
   if (!messageId || !threadId) {
     throw new Error("Invalid message")


### PR DESCRIPTION
### Description
This fix resolves an issue where the mail body was not appearing in search result previews for certain mails. The problem was caused by empty strings being added to the `chunks` field during indexing. This update ensures that only valid content is indexed.
