### PR TITLE
fix(contact-permission): add exact match indexing to ensure the where clause works correctly for contacts

### DIFF
--- a/server/vespa/schemas/user.sd
+++ b/server/vespa/schemas/user.sd
@@ -134,7 +134,9 @@ schema user {
         # we just put the email
         # for who has this contact
         field owner type string {
-            indexing: attribute | summary
+            indexing: index | attribute | summary
+            attribute: fast-search
+            match: exact
         }
     }
     # Fuzzy matching for the 'name' field

--- a/server/vespa/schemas/user.sd
+++ b/server/vespa/schemas/user.sd
@@ -135,7 +135,6 @@ schema user {
         # for who has this contact
         field owner type string {
             indexing: index | attribute | summary
-            attribute: fast-search
             match: exact
         }
     }


### PR DESCRIPTION

### Description
Stumbled upon the bug user schema (other contacts) in permissions while trying to improve search.
If we don't have 
```
            indexing: index | attribute | summary
            match: exact
```
then the where clause with the `owner` check for the contacts data doesn't work.
### Testing
manually, where previously incorrect data came now is respecting permissions

### Additional Notes
need to ensure anything in where clause is always indexed correctly, it's a silent error and hard to find.