### PR TITLE
feat(models): add claude 3.7 and make it default for bedrock

### DIFF
--- a/server/ai/mappers.ts
+++ b/server/ai/mappers.ts
@@ -127,6 +127,19 @@ export const modelDetailsMap: Record<
       },
     },
   },
+[Models.Claude_3_7_Sonnet]: {
+  name: "Claude 3.7 Sonnet",
+  cost: {
+      onDemand: {
+          pricePerThousandInputTokens: 0.003,
+          pricePerThousandOutputTokens: 0.015,
+      },
+      batch: {
+          pricePerThousandInputTokens: 0,
+          pricePerThousandOutputTokens: 0,
+      },
+  },
+},
   [Models.Claude_3_5_SonnetV2]: {
     name: "Claude 3.5 Sonnet v2",
     cost: {
@@ -228,6 +241,7 @@ export const ModelToProviderMap: Record<Models, AIProviders> = {
   [Models.CohereCmdRPlus]: AIProviders.AwsBedrock,
   [Models.CohereCmdR]: AIProviders.AwsBedrock,
   [Models.Claude_3_5_SonnetV2]: AIProviders.AwsBedrock,
+  [Models.Claude_3_7_Sonnet]: AIProviders.AwsBedrock,
   [Models.Claude_3_5_Sonnet]: AIProviders.AwsBedrock,
   [Models.Claude_3_5_Haiku]: AIProviders.AwsBedrock,
   [Models.Amazon_Nova_Micro]: AIProviders.AwsBedrock,

--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -77,7 +77,7 @@ import { TogetherProvider } from "@/ai/provider/together"
 import { Fireworks } from "@/ai/provider/fireworksClient"
 import { FireworksProvider } from "@/ai/provider/fireworks"
 import { GoogleGenerativeAI } from "@google/generative-ai"
-import { GeminiAIProvider } from "./gemini"
+import { GeminiAIProvider } from "@/ai/provider/gemini"
 const Logger = getLogger(Subsystem.AI)
 
 const askQuestionSystemPrompt =

--- a/server/ai/types.ts
+++ b/server/ai/types.ts
@@ -25,6 +25,7 @@ export enum Models {
   CohereCmdRPlus = "cohere.command-r-plus-v1:0",
   CohereCmdR = "cohere.command-r-v1:0",
   Claude_3_5_SonnetV2 = "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+  Claude_3_7_Sonnet = "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
   Claude_3_5_Sonnet = "anthropic.claude-3-5-sonnet-20240620-v1:0",
   Claude_3_5_Haiku = "anthropic.claude-3-5-haiku-20241022-v1:0",
   Amazon_Nova_Micro = "amazon.nova-micro-v1:0",

--- a/server/config.ts
+++ b/server/config.ts
@@ -42,7 +42,7 @@ if (process.env["AWS_ACCESS_KEY"] && process.env["AWS_SECRET_KEY"]) {
   AwsAccessKey = process.env["AWS_ACCESS_KEY"]
   AwsSecretKey = process.env["AWS_SECRET_KEY"]
   defaultFastModel = Models.Claude_3_5_Haiku
-  defaultBestModel = Models.Claude_3_5_SonnetV2
+  defaultBestModel = Models.Claude_3_7_Sonnet
 } else if (process.env["OPENAI_API_KEY"]) {
   OpenAIKey = process.env["OPENAI_API_KEY"]
   defaultFastModel = Models.Gpt_4o_mini


### PR DESCRIPTION
### Description
Added Claude 3.7.
It feels a lot faster than 3.5 in bedrock.

### Testing
Tested it locally.

### Additional Notes
We need a much better way to select models from the .env for AWS than simply modifying the config file.
Also faced the following error
```
{
      "type": "ThrottlingException",
      "message": "Too many tokens, please wait before trying again.",
      "stack":
          ThrottlingException: Too many tokens, please wait before trying again.
              at new ServiceException (/Users/sahebjotsingh/Code/Xyne/experiments/xyne-search/server/node_modules/@smithy/smithy-client/dist-cjs/index.js:810:5)
              at new BedrockRuntimeServiceException (/Users/sahebjotsingh/Code/Xyne/experiments/xyne-search/server/node_modules/@aws-sdk/client-bedrock-runtime/dist-cjs/index.js:286:5)
              at new ThrottlingException (/Users/sahebjotsingh/Code/Xyne/experiments/xyne-search/server/node_modules/@aws-sdk/client-bedrock-runtime/dist-cjs/index.js:346:5)
              at <anonymous> (/Users/sahebjotsingh/Code/Xyne/experiments/xyne-search/server/node_modules/@aws-sdk/client-bedrock-runtime/dist-cjs/index.js:1569:25)
              at de_ThrottlingExceptionRes (/Users/sahebjotsingh/Code/Xyne/experiments/xyne-search/server/node_modules/@aws-sdk/client-bedrock-runtime/dist-cjs/index.js:1562:63)
              at <anonymous> (/Users/sahebjotsingh/Code/Xyne/experiments/xyne-search/server/node_modules/@aws-sdk/client-bedrock-runtime/dist-cjs/index.js:1396:19)
              at processTicksAndRejections (native:7:39)
      "name": "ThrottlingException",
      "$fault": "client",
      "$metadata": {
        "httpStatusCode": 429,
        "requestId": "d1883997-5ebe-4b50-be02-9f33955fa325",
        "attempts": 3,
        "totalRetryDelay": 284
      }
    }

```