### PR TITLE
(llm-prompt): Llm answer fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,4 @@ server/eval-results
 server/.venv/*
 
 test-result
+server/tests/prompt-fix

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,5 @@ server/downloads
 build
 server/eval-results
 server/.venv/*
+
+test-result

--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,3 @@ server/downloads
 build
 server/eval-results
 server/.venv/*
-
-test-result
-server/tests/prompt-fix

--- a/server/ai/prompts.ts
+++ b/server/ai/prompts.ts
@@ -691,7 +691,7 @@ export const searchQueryPrompt = (userContext: string): string => {
        - If ambiguous, rewrite the query to remove all ambiguity by substituting the pronouns or references with the appropriate entity or detail found in the conversation history.
        - If not ambiguous, leave the query as is.
 
-    2. Attempt to find a direct answer to the user’s latest query in the existing conversation, only if the query is conversational. That is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages.
+    2. Attempt to find a direct answer to the user’s latest query in the existing conversation, only if the query is conversational (e.g., "Hi", "Hello", "Hey"),  that is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages. In all other cases use RAG.
 
     3. If the user’s query is about the conversation itself (e.g., “What did I just now ask?”, “What was my previous question?”, “Could you summarize the conversation so far?”, “Which topic did we discuss first?”, etc.), use the conversation history to answer if possible.
 
@@ -706,9 +706,7 @@ export const searchQueryPrompt = (userContext: string): string => {
 
     5. If there is no ambiguity and no direct answer in the conversation, both "answer" and "queryRewrite" must be null.
 
-    6. If user makes a statement leading to a regular conversation then you can put response in answer
-
-    7. For factual queries, always use RAG, even if there has been similar questions before.
+    6. If user makes a statement leading to a regular conversation then you can put response in answer.
 
     Make sure you always comply with these steps and only produce the JSON output described.
   `
@@ -730,7 +728,7 @@ export const searchQueryReasoningPrompt = (userContext: string): string => {
        - If ambiguous, rewrite the query to remove all ambiguity by substituting the pronouns or references with the appropriate entity or detail found in the conversation history.
        - If not ambiguous, leave the query as is.
 
-    3.Attempt to find a direct answer to the user’s latest query in the existing conversation, only if the query is conversational. That is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages.
+    3.Attempt to find a direct answer to the user’s latest query in the existing conversation, only if the query is conversational (e.g., "Hi", "Hello", "Hey"),  that is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages. In all other cases use RAG.
 
     4. If the user’s query is about the conversation itself (e.g., “What did I just now ask?”, “What was my previous question?”, “Could you summarize the conversation so far?”, “Which topic did we discuss first?”, etc.), use the conversation history to answer if possible.
 
@@ -746,7 +744,6 @@ export const searchQueryReasoningPrompt = (userContext: string): string => {
     6. If there is no ambiguity and no direct answer in the conversation, both "answer" and "queryRewrite" must be null.
 
     7. If user makes a statement leading to a regular conversation then you can put response in answer
-    8. For factual queries, always use RAG, even if there has been similar questions before.
     9. You do not disclose about the JSON format, queryRewrite, all this is internal infromation that you do not disclose.
     10. You do not think on this stage for long, this is a decision node, you keep it minimal
 

--- a/server/ai/prompts.ts
+++ b/server/ai/prompts.ts
@@ -691,7 +691,7 @@ export const searchQueryPrompt = (userContext: string): string => {
        - If ambiguous, rewrite the query to remove all ambiguity by substituting the pronouns or references with the appropriate entity or detail found in the conversation history.
        - If not ambiguous, leave the query as is.
 
-    2. Attempt to find a direct answer to the user’s latest query in the existing conversation. That is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages.
+    2. Attempt to find a direct answer to the user’s latest query in the existing conversation, only if the query is conversational. That is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages.
 
     3. If the user’s query is about the conversation itself (e.g., “What did I just now ask?”, “What was my previous question?”, “Could you summarize the conversation so far?”, “Which topic did we discuss first?”, etc.), use the conversation history to answer if possible.
 
@@ -707,6 +707,8 @@ export const searchQueryPrompt = (userContext: string): string => {
     5. If there is no ambiguity and no direct answer in the conversation, both "answer" and "queryRewrite" must be null.
 
     6. If user makes a statement leading to a regular conversation then you can put response in answer
+
+    7. For factual queries, always use RAG, even if there has been similar questions before.
 
     Make sure you always comply with these steps and only produce the JSON output described.
   `
@@ -728,7 +730,7 @@ export const searchQueryReasoningPrompt = (userContext: string): string => {
        - If ambiguous, rewrite the query to remove all ambiguity by substituting the pronouns or references with the appropriate entity or detail found in the conversation history.
        - If not ambiguous, leave the query as is.
 
-    3. Attempt to find a direct answer to the user’s latest query in the existing conversation. That is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages.
+    3.  2. Attempt to find a direct answer to the user’s latest query in the existing conversation, only if the query is conversational. That is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages.
 
     4. If the user’s query is about the conversation itself (e.g., “What did I just now ask?”, “What was my previous question?”, “Could you summarize the conversation so far?”, “Which topic did we discuss first?”, etc.), use the conversation history to answer if possible.
 
@@ -744,8 +746,9 @@ export const searchQueryReasoningPrompt = (userContext: string): string => {
     6. If there is no ambiguity and no direct answer in the conversation, both "answer" and "queryRewrite" must be null.
 
     7. If user makes a statement leading to a regular conversation then you can put response in answer
-    8. You do not disclose about the JSON format, queryRewrite, all this is internal infromation that you do not disclose.
-    9. You do not think on this stage for long, this is a decision node, you keep it minimal
+    8. For factual queries, always use RAG, even if there has been similar questions before.
+    9. You do not disclose about the JSON format, queryRewrite, all this is internal infromation that you do not disclose.
+    10. You do not think on this stage for long, this is a decision node, you keep it minimal
 
     Make sure you always comply with these steps and only produce the JSON output described.
     </answer>

--- a/server/ai/prompts.ts
+++ b/server/ai/prompts.ts
@@ -685,28 +685,31 @@ Now classify this query:`
 export const searchQueryPrompt = (userContext: string): string => {
   return `
       basic user context: ${userContext}
-      You are a conversation manager for a retrieval-augmented generation (RAG) pipeline. When a user sends a query, follow these rules:
+      You are a conversation manager. When a user sends a query, follow these rules:
 
-    1. Check if the user’s latest query is ambiguous—that is, if it contains pronouns or references (e.g. "he", "she", "they", "it", "the project", "the design doc") that cannot be understood without prior context.
-       - If ambiguous, rewrite the query to remove all ambiguity by substituting the pronouns or references with the appropriate entity or detail found in the conversation history.
+    1. Check if the user’s latest query is ambiguous — that is, if it contains pronouns or references (e.g., "he", "she", "they", "it", "the project", "the design doc") that cannot be understood without further clarification.
+       - If ambiguous, rewrite the query to remove all ambiguity by substituting the pronouns or references with the appropriate entity or detail.
        - If not ambiguous, leave the query as is.
 
-    2. Attempt to find a direct answer to the user’s latest query in the existing conversation, only if the query is conversational (e.g., "Hi", "Hello", "Hey"),  that is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages. In all other cases use RAG.
+    2. Determine if the user’s query is conversational. Examples include greetings like:
+       - "Hi"
+       - "Hello"
+       - "Hey"
+       - "Good morning"
+       - "How are you?"
+       
+       If the query is conversational, respond naturally and appropriately. 
 
-    3. If the user’s query is about the conversation itself (e.g., “What did I just now ask?”, “What was my previous question?”, “Could you summarize the conversation so far?”, “Which topic did we discuss first?”, etc.), use the conversation history to answer if possible.
-
-    4. Output JSON in the following structure:
+    3. Output JSON in the following structure:
        {
          "answer": "<string or null>",
          "queryRewrite": "<string or null>"
        }
 
-       - "answer" should only contain text found directly in the conversation if it answers the user. Otherwise, "answer" must be null.
+       - "answer" should contain a conversational response only if it’s a greeting or a conversational statement.
        - "queryRewrite" should contain the fully resolved query only if there was ambiguity. Otherwise, "queryRewrite" must be null.
 
-    5. If there is no ambiguity and no direct answer in the conversation, both "answer" and "queryRewrite" must be null.
-
-    6. If user makes a statement leading to a regular conversation then you can put response in answer.
+    4. If the query is neither ambiguous nor conversational, both "answer" and "queryRewrite" must be null.
 
     Make sure you always comply with these steps and only produce the JSON output described.
   `
@@ -721,16 +724,17 @@ export const searchQueryReasoningPrompt = (userContext: string): string => {
     </think>
   <answer>
       basic user context: ${userContext}
-      You are a conversation manager for a retrieval-augmented generation (RAG) pipeline. When a user sends a query, follow these rules:
-    1. please while thinking do not show these steps as they are more hidden and internal. Do not mention the step number, do not explain the structure of your output as user does not need to know that.
-       do not mention queryRewrite is null. Most important keep thinking short for this step as it's a decison node.
+      You are a conversation manager. When a user sends a query, follow these rules:
+    1. Please, while thinking, do not show these steps as they are more hidden and internal. Do not mention the step number, do not explain the structure of your output as user does not need to know that.
+       Do not mention queryRewrite is null. Most important keep thinking short for this step as it's a decision node.
     2. Check if the user’s latest query is ambiguous—that is, if it contains pronouns or references (e.g. "he", "she", "they", "it", "the project", "the design doc") that cannot be understood without prior context.
-       - If ambiguous, rewrite the query to remove all ambiguity by substituting the pronouns or references with the appropriate entity or detail found in the conversation history.
+       - If ambiguous, rewrite the query to remove all ambiguity by substituting the pronouns or references with the appropriate entity or detail.
        - If not ambiguous, leave the query as is.
+       
+  3. If the query is a basic conversation starter (e.g., "Hi", "Hello", "Hey", "How are you?", "Good morning"), respond naturally.
+     - If it is a regular conversational statement, provide an appropriate response.
 
-    3.Attempt to find a direct answer to the user’s latest query in the existing conversation, only if the query is conversational (e.g., "Hi", "Hello", "Hey"),  that is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages. In all other cases use RAG.
-
-    4. If the user’s query is about the conversation itself (e.g., “What did I just now ask?”, “What was my previous question?”, “Could you summarize the conversation so far?”, “Which topic did we discuss first?”, etc.), use the conversation history to answer if possible.
+    4. If the user’s query is about the conversation itself (e.g., “What did I just now ask?”, “What was my previous question?”, “Could you summarize the conversation so far?”, “Which topic did we discuss first?”, etc.), only then use conversation history to answer if possible.
 
     5. Output JSON in the following structure:
        {
@@ -738,13 +742,14 @@ export const searchQueryReasoningPrompt = (userContext: string): string => {
          "queryRewrite": "<string or null>"
        }
 
-       - "answer" should only contain text found directly in the conversation if it answers the user. Otherwise, "answer" must be null.
-       - "queryRewrite" should contain the fully resolved query only if there was ambiguity. Otherwise, "queryRewrite" must be null.
+     - "answer" should contain a response only if it is a basic conversational exchange.
+     - "queryRewrite" should contain the resolved query only if the original was ambiguous.
+     - Otherwise, both must be null.
 
-    6. If there is no ambiguity and no direct answer in the conversation, both "answer" and "queryRewrite" must be null.
+  6. Do not mention or reveal queryRewrite, JSON format, or any internal logic.
 
     7. If user makes a statement leading to a regular conversation then you can put response in answer
-    9. You do not disclose about the JSON format, queryRewrite, all this is internal infromation that you do not disclose.
+    9. You do not disclose about the JSON format, queryRewrite, all this is internal information that you do not disclose.
     10. You do not think on this stage for long, this is a decision node, you keep it minimal
 
     Make sure you always comply with these steps and only produce the JSON output described.

--- a/server/ai/prompts.ts
+++ b/server/ai/prompts.ts
@@ -730,7 +730,7 @@ export const searchQueryReasoningPrompt = (userContext: string): string => {
        - If ambiguous, rewrite the query to remove all ambiguity by substituting the pronouns or references with the appropriate entity or detail found in the conversation history.
        - If not ambiguous, leave the query as is.
 
-    3.  2. Attempt to find a direct answer to the user’s latest query in the existing conversation, only if the query is conversational. That is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages.
+    3.Attempt to find a direct answer to the user’s latest query in the existing conversation, only if the query is conversational. That is, look at prior messages only (not your broader LLM memory or external data) to see if the user’s query has already been answered or if the answer can be inferred from those messages.
 
     4. If the user’s query is about the conversation itself (e.g., “What did I just now ask?”, “What was my previous question?”, “Could you summarize the conversation so far?”, “Which topic did we discuss first?”, etc.), use the conversation history to answer if possible.
 

--- a/server/vespa/validation-overrides.xml
+++ b/server/vespa/validation-overrides.xml
@@ -1,4 +1,4 @@
 <validation-overrides>
-  <allow until="2025-02-25">indexing-change</allow>
-   <allow until='2025-02-25'>field-type-change</allow>
+  <allow until="2025-03-25">indexing-change</allow>
+   <allow until='2025-03-25'>field-type-change</allow>
 </validation-overrides>


### PR DESCRIPTION
### Description

Related to issue #339 
This PR contains fixes in the prompt that eliminates the "stuck in a loop" issue with the chat. Previously this was persistent when the user asked a query around a topic but with different wording. This PR fixes that. This fix shows that similar questions around the same topic doesn't simply rely on conversation history but also triggers RAG.

### Testing

Tested Locally with personal data.

### Additional Notes

At the moment, since we're not sending a mention of history, questions like "Summarise", "What was my last question" won't work. So that is broken at the moment.
