### PR TITLE
fix(oauth-ingestion): Fix 401 error (invalid credentials) during OAuth ingestion

### DIFF
--- a/server/api/oauth.ts
+++ b/server/api/oauth.ts
@@ -16,8 +16,6 @@ const { JwtPayloadKey } = config
 
 const Logger = getLogger(Subsystem.Api).child({ module: "oauth" })
 
-const JOB_EXPIRY_HOURS = 23
-
 interface OAuthCallbackQuery {
   state: string
   code: string
@@ -74,9 +72,7 @@ export const OAuthCallback = async (c: Context) => {
       email: sub,
     }
     // Enqueue the background job within the same transaction
-    const jobId = await boss.send(SaaSQueue, SaasJobPayload, {
-      expireInHours: JOB_EXPIRY_HOURS,
-    })
+    const jobId = await boss.send(SaaSQueue, SaasJobPayload)
 
     Logger.info(`Job ${jobId} enqueued for connection ${connector.id}`)
 

--- a/server/api/oauth.ts
+++ b/server/api/oauth.ts
@@ -72,7 +72,9 @@ export const OAuthCallback = async (c: Context) => {
       email: sub,
     }
     // Enqueue the background job within the same transaction
-    const jobId = await boss.send(SaaSQueue, SaasJobPayload)
+    const jobId = await boss.send(SaaSQueue, SaasJobPayload, {
+      expireInHours: 23,
+    })
 
     Logger.info(`Job ${jobId} enqueued for connection ${connector.id}`)
 

--- a/server/api/oauth.ts
+++ b/server/api/oauth.ts
@@ -16,6 +16,8 @@ const { JwtPayloadKey } = config
 
 const Logger = getLogger(Subsystem.Api).child({ module: "oauth" })
 
+const JOB_EXPIRY_HOURS = 23
+
 interface OAuthCallbackQuery {
   state: string
   code: string
@@ -73,7 +75,7 @@ export const OAuthCallback = async (c: Context) => {
     }
     // Enqueue the background job within the same transaction
     const jobId = await boss.send(SaaSQueue, SaasJobPayload, {
-      expireInHours: 23,
+      expireInHours: JOB_EXPIRY_HOURS,
     })
 
     Logger.info(`Job ${jobId} enqueued for connection ${connector.id}`)

--- a/server/db/connector.ts
+++ b/server/db/connector.ts
@@ -23,6 +23,7 @@ import {
   UpdateConnectorFailed,
 } from "@/errors"
 import { IsGoogleApp } from "@/utils"
+import { getOAuthProviderByConnectorId } from "@/db/oauthProvider"
 const Logger = getLogger(Subsystem.Db).child({ module: "connector" })
 
 export const insertConnector = async (
@@ -169,11 +170,8 @@ export const getOAuthConnectorWithCredentials = async (
     // update it in place
     if (IsGoogleApp(oauthRes.app)) {
       // we will need the provider now to refresh the token
-      const providers: SelectOAuthProvider[] = await trx
-        .select()
-        .from(oauthProviders)
-        .where(eq(oauthProviders.connectorId, oauthRes.id))
-        .limit(1)
+      const providers: SelectOAuthProvider[] =
+        await getOAuthProviderByConnectorId(trx, connectorId)
 
       if (!providers.length) {
         Logger.error("Could not fetch provider while refreshing Google Token")

--- a/server/db/oauthProvider.ts
+++ b/server/db/oauthProvider.ts
@@ -48,3 +48,19 @@ export const getOAuthProvider = async (
     throw new Error("Could not get the connector")
   }
 }
+
+export const getOAuthProviderByConnectorId = async (
+  trx: TxnOrClient,
+  connectorId: number,
+): Promise<SelectOAuthProvider[]> => {
+  const res = await trx
+    .select()
+    .from(oauthProviders)
+    .where(eq(oauthProviders.connectorId, connectorId))
+    .limit(1)
+  if (res.length) {
+    return res
+  } else {
+    throw new Error("Could not get the provider")
+  }
+}

--- a/server/integrations/google/gmail-worker.ts
+++ b/server/integrations/google/gmail-worker.ts
@@ -110,6 +110,7 @@ export const handleGmailIngestion = async (
   const profile = await retryWithBackoff(
     () => gmail.users.getProfile({ userId: "me" }),
     "Fetching Gmail user profile",
+    Apps.Gmail,
     0,
     client,
   )
@@ -129,6 +130,7 @@ export const handleGmailIngestion = async (
           fields: "messages(id), nextPageToken",
         }),
       `Fetching Gmail messages list (pageToken: ${nextPageToken})`,
+      Apps.Gmail,
       0,
       client,
     )
@@ -148,6 +150,7 @@ export const handleGmailIngestion = async (
                   format: "full",
                 }),
               `Fetching Gmail message (id: ${message.id})`,
+              Apps.Gmail,
               0,
               client,
             )

--- a/server/integrations/google/gmail/index.ts
+++ b/server/integrations/google/gmail/index.ts
@@ -46,6 +46,7 @@ export const handleGmailIngestion = async (
   const profile = await retryWithBackoff(
     () => gmail.users.getProfile({ userId: "me" }),
     "Fetching Gmail user profile",
+    Apps.Gmail,
     0,
     client,
   )
@@ -65,6 +66,7 @@ export const handleGmailIngestion = async (
           fields: "messages(id), nextPageToken",
         }),
       `Fetching Gmail messages list (pageToken: ${nextPageToken})`,
+      Apps.Gmail,
       0,
       client,
     )
@@ -84,6 +86,7 @@ export const handleGmailIngestion = async (
                   format: "full",
                 }),
               `Fetching Gmail message (id: ${message.id})`,
+              Apps.Gmail,
               0,
               client,
             )

--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -138,6 +138,7 @@ const listUsers = async (
               ...(nextPageToken! ? { pageToken: nextPageToken } : {}),
             }),
           `Fetching all users`,
+          Apps.GoogleDrive,
         )
       if (res.data.users) {
         users = users.concat(res.data.users)
@@ -446,6 +447,7 @@ const insertCalendarEvents = async (
           fields: eventFields,
         }),
       `Fetching all calendar events`,
+      Apps.GoogleCalendar,
       0,
       client,
     )
@@ -1050,6 +1052,7 @@ export const getPresentationToBeIngested = async (
           presentationId: presentation.id!,
         }),
       `Fetching presentation with id ${presentation.id}`,
+      Apps.GoogleDrive,
       0,
       client,
     )
@@ -1329,6 +1332,7 @@ export const getAllSheetsFromSpreadSheet = async (
             valueRenderOption: "FORMATTED_VALUE",
           }),
         `Fetching sheets '${ranges.join(", ")}' from spreadsheet`,
+        Apps.GoogleDrive,
         0,
         client,
       )
@@ -1372,6 +1376,7 @@ export const getSpreadsheet = async (
     return retryWithBackoff(
       () => sheets.spreadsheets.get({ spreadsheetId: id }),
       `Fetching spreadsheet with ID ${id}`,
+      Apps.GoogleDrive,
       0,
       client,
     )
@@ -1622,6 +1627,7 @@ export const downloadPDF = async (
         { responseType: "stream" },
       ),
     `Getting PDF content of fileId ${fileId}`,
+    Apps.GoogleDrive,
     0,
     client,
   )
@@ -1829,6 +1835,7 @@ const listAllContacts = async (
           requestSyncToken: true,
         }),
       `Fetching contacts with pageToken ${pageToken}`,
+      Apps.GoogleDrive,
       0,
       client,
     )
@@ -1855,6 +1862,7 @@ const listAllContacts = async (
           sources: ["READ_SOURCE_TYPE_PROFILE", "READ_SOURCE_TYPE_CONTACT"],
         }),
       `Fetching other contacts with pageToken ${pageToken}`,
+      Apps.GoogleDrive,
       0,
       client,
     )
@@ -2029,6 +2037,7 @@ export async function* listFiles(
             pageToken: nextPageToken,
           }),
         `Fetching all files from Google Drive`,
+        Apps.GoogleDrive,
         0,
         client,
       )
@@ -2070,6 +2079,7 @@ export const googleDocsVespa = async (
                 documentId: doc.id as string,
               }),
             `Fetching document with documentId ${doc.id}`,
+            Apps.GoogleDrive,
             0,
             client,
           )

--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -40,12 +40,10 @@ import type { WSContext } from "hono/ws"
 import { db } from "@/db/client"
 import {
   connectors,
-  oauthProviders,
-  selectConnectorSchema,
   type SelectConnector,
   type SelectOAuthProvider,
 } from "@/db/schema"
-import { and, eq } from "drizzle-orm"
+import { eq } from "drizzle-orm"
 import { getWorkspaceById } from "@/db/workspace"
 import {
   Apps,
@@ -83,9 +81,6 @@ import {
   DeleteDocumentError,
   DownloadDocumentError,
   CalendarEventsListingError,
-  NoOauthConnectorFound,
-  MissingOauthConnectorCredentialsError,
-  FetchProviderFailed,
 } from "@/errors"
 import fs, { existsSync, mkdirSync } from "node:fs"
 import path, { join } from "node:path"

--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -38,8 +38,14 @@ import { SaaSQueue } from "@/queue"
 import { wsConnections } from "@/integrations/google/ws"
 import type { WSContext } from "hono/ws"
 import { db } from "@/db/client"
-import { connectors, type SelectConnector } from "@/db/schema"
-import { eq } from "drizzle-orm"
+import {
+  connectors,
+  oauthProviders,
+  selectConnectorSchema,
+  type SelectConnector,
+  type SelectOAuthProvider,
+} from "@/db/schema"
+import { and, eq } from "drizzle-orm"
 import { getWorkspaceById } from "@/db/workspace"
 import {
   Apps,
@@ -77,6 +83,9 @@ import {
   DeleteDocumentError,
   DownloadDocumentError,
   CalendarEventsListingError,
+  NoOauthConnectorFound,
+  MissingOauthConnectorCredentialsError,
+  FetchProviderFailed,
 } from "@/errors"
 import fs, { existsSync, mkdirSync } from "node:fs"
 import path, { join } from "node:path"
@@ -437,6 +446,8 @@ const insertCalendarEvents = async (
           fields: eventFields,
         }),
       `Fetching all calendar events`,
+      0,
+      client,
     )
     if (res.data.items) {
       events = events.concat(res.data.items)
@@ -566,7 +577,50 @@ export const handleGoogleOAuthIngestion = async (
     )
     const userEmail = job.data.email
     const oauthTokens = (connector.oauthCredentials as OAuthCredentials).data
-    const oauth2Client = new google.auth.OAuth2()
+
+    const connectorId = data.connectorId
+    const res = await db
+      .select()
+      .from(connectors)
+      .where(
+        and(
+          eq(connectors.id, connectorId),
+          eq(connectors.authType, AuthType.OAuth),
+        ),
+      )
+      .limit(1)
+
+    if (!res.length) {
+      throw new NoOauthConnectorFound({
+        message: `Could not get the oauth connector with id:  ${connectorId}`,
+      })
+    }
+
+    const oauthRes: SelectConnector = selectConnectorSchema.parse(res[0])
+
+    if (!oauthRes.oauthCredentials) {
+      throw new MissingOauthConnectorCredentialsError({})
+    }
+
+    const providers: SelectOAuthProvider[] = await db
+      .select()
+      .from(oauthProviders)
+      .where(eq(oauthProviders.connectorId, oauthRes.id))
+      .limit(1)
+
+    if (!providers.length) {
+      Logger.error("Could not fetch provider while refreshing Google Token")
+      throw new FetchProviderFailed({
+        message: "Could not fetch provider while refreshing Google Token",
+      })
+    }
+    const [googleProvider] = providers
+
+    const oauth2Client = new google.auth.OAuth2({
+      clientId: googleProvider.clientId!,
+      clientSecret: googleProvider.clientSecret,
+      redirectUri: `${config.host}/oauth/callback`,
+    })
 
     setOAuthUser(userEmail)
     const interval = setInterval(() => {
@@ -581,7 +635,10 @@ export const handleGoogleOAuthIngestion = async (
 
     // we have guarantee that when we started this job access Token at least
     // hand one hour, we should increase this time
-    oauth2Client.setCredentials({ access_token: oauthTokens.access_token })
+    oauth2Client.setCredentials({
+      access_token: oauthTokens.access_token,
+      refresh_token: oauthTokens.refresh_token,
+    })
     const driveClient = google.drive({ version: "v3", auth: oauth2Client })
     const { contacts, otherContacts, contactsToken, otherContactsToken } =
       await listAllContacts(oauth2Client)
@@ -701,6 +758,7 @@ type IngestionMetadata = {
 }
 
 import { z } from "zod"
+import config from "@/config"
 
 const stats = z.object({
   type: z.literal(WorkerResponseTypes.Stats),
@@ -992,6 +1050,8 @@ export const getPresentationToBeIngested = async (
           presentationId: presentation.id!,
         }),
       `Fetching presentation with id ${presentation.id}`,
+      0,
+      client,
     )
     const slidesData = presentationData?.data?.slides!
     let chunks: string[] = []
@@ -1247,6 +1307,7 @@ export const getAllSheetsFromSpreadSheet = async (
   sheets: sheets_v4.Sheets,
   spreadsheet: sheets_v4.Schema$Spreadsheet,
   spreadsheetId: string,
+  client: GoogleClient,
 ) => {
   const allSheets = []
 
@@ -1268,6 +1329,8 @@ export const getAllSheetsFromSpreadSheet = async (
             valueRenderOption: "FORMATTED_VALUE",
           }),
         `Fetching sheets '${ranges.join(", ")}' from spreadsheet`,
+        0,
+        client,
       )
 
       const valueRanges = response?.data?.valueRanges
@@ -1303,11 +1366,14 @@ export const getAllSheetsFromSpreadSheet = async (
 export const getSpreadsheet = async (
   sheets: sheets_v4.Sheets,
   id: string,
+  client: GoogleClient,
 ): Promise<GaxiosResponse<sheets_v4.Schema$Spreadsheet> | null> => {
   try {
     return retryWithBackoff(
       () => sheets.spreadsheets.get({ spreadsheetId: id }),
       `Fetching spreadsheet with ID ${id}`,
+      0,
+      client,
     )
   } catch (error) {
     if (error instanceof GaxiosError) {
@@ -1383,7 +1449,11 @@ export const getSheetsListFromOneSpreadsheet = async (
 ): Promise<VespaFileWithDrivePermission[]> => {
   const sheetsArr = []
   try {
-    const spreadSheetData = await getSpreadsheet(sheets, spreadsheet.id!)
+    const spreadSheetData = await getSpreadsheet(
+      sheets,
+      spreadsheet.id!,
+      client,
+    )
 
     if (spreadSheetData) {
       // Now we should get all sheets inside this spreadsheet using the spreadSheetData
@@ -1391,6 +1461,7 @@ export const getSheetsListFromOneSpreadsheet = async (
         sheets,
         spreadSheetData.data,
         spreadsheet.id!,
+        client,
       )
 
       // There can be multiple parents
@@ -1539,6 +1610,7 @@ export const downloadPDF = async (
   drive: drive_v3.Drive,
   fileId: string,
   fileName: string,
+  client: GoogleClient,
 ): Promise<void> => {
   const filePath = path.join(downloadDir, fileName)
   const file = Bun.file(filePath)
@@ -1550,6 +1622,8 @@ export const downloadPDF = async (
         { responseType: "stream" },
       ),
     `Getting PDF content of fileId ${fileId}`,
+    0,
+    client,
   )
   return new Promise((resolve, reject) => {
     res.data.on("data", (chunk) => {
@@ -1606,7 +1680,7 @@ export const googlePDFsVespa = async (
       const pdfFileName = `${userEmail}_${pdf.id}_${pdf.name}`
       const pdfPath = `${downloadDir}/${pdfFileName}`
       try {
-        await downloadPDF(drive, pdf.id!, pdfFileName)
+        await downloadPDF(drive, pdf.id!, pdfFileName, client)
 
         const docs: Document[] = await safeLoadPDF(pdfPath)
         if (!docs || docs.length === 0) {
@@ -1755,6 +1829,8 @@ const listAllContacts = async (
           requestSyncToken: true,
         }),
       `Fetching contacts with pageToken ${pageToken}`,
+      0,
+      client,
     )
 
     if (response.data.connections) {
@@ -1779,6 +1855,8 @@ const listAllContacts = async (
           sources: ["READ_SOURCE_TYPE_PROFILE", "READ_SOURCE_TYPE_CONTACT"],
         }),
       `Fetching other contacts with pageToken ${pageToken}`,
+      0,
+      client,
     )
 
     if (response.data.otherContacts) {
@@ -1951,6 +2029,8 @@ export async function* listFiles(
             pageToken: nextPageToken,
           }),
         `Fetching all files from Google Drive`,
+        0,
+        client,
       )
 
     if (res.data.files) {
@@ -1990,6 +2070,8 @@ export const googleDocsVespa = async (
                 documentId: doc.id as string,
               }),
             `Fetching document with documentId ${doc.id}`,
+            0,
+            client,
           )
         if (!docResponse || !docResponse.data) {
           throw new DocsParsingError(

--- a/server/integrations/google/sync.ts
+++ b/server/integrations/google/sync.ts
@@ -409,6 +409,7 @@ const getDriveChanges = async (
     const response = await retryWithBackoff(
       () => driveClient.changes.list({ pageToken: config.driveToken }),
       `Fetching drive changes with pageToken ${config.driveToken}`,
+      Apps.GoogleDrive,
       0,
       oauth2Client,
     )
@@ -515,6 +516,7 @@ export const handleGoogleOAuthChanges = async (
                 pageToken: nextPageToken, // Use the nextPageToken for pagination
               }),
             `Fetching contacts changes with syncToken ${config.contactsToken}`,
+            Apps.GoogleDrive,
             0,
             oauth2Client,
           )
@@ -559,6 +561,7 @@ export const handleGoogleOAuthChanges = async (
                 ],
               }),
             `Fetching other contacts changes with syncToken ${otherContactsToken}`,
+            Apps.GoogleDrive,
             0,
             oauth2Client,
           )
@@ -924,6 +927,7 @@ const handleGoogleCalendarEventsChanges = async (
             fields: eventFields,
           }),
         `Fetching calendar events changes with syncToken ${syncToken}`,
+        Apps.GoogleCalendar,
         0,
         oauth2Client,
       )
@@ -1125,6 +1129,7 @@ const handleGmailChanges = async (
             pageToken: nextPageToken,
           }),
         `Fetching gmail changes with historyId ${historyId}`,
+        Apps.Gmail,
         0,
         client,
       )
@@ -1156,6 +1161,7 @@ const handleGmailChanges = async (
                       format: "full",
                     }),
                   `Fetching gmail email with id ${message?.id}`,
+                  Apps.Gmail,
                   0,
                   client,
                 )
@@ -1310,6 +1316,7 @@ const syncContacts = async (
                   personFields: contactKeys.join(","),
                 }),
               `Fetching contact with resourceName ${contact.resourceName}`,
+              Apps.GoogleDrive,
               0,
               oauth2Client,
             )
@@ -1361,6 +1368,7 @@ export const handleGoogleServiceAccountChanges = async (
         await retryWithBackoff(
           () => driveClient.changes.list({ pageToken: config.driveToken }),
           `Fetching drive changes with pageToken ${config.driveToken}`,
+          Apps.GoogleDrive,
         )
       ).data
       // there are changes
@@ -1413,6 +1421,7 @@ export const handleGoogleServiceAccountChanges = async (
                 pageToken: nextPageToken, // Use the nextPageToken for pagination
               }),
             `Fetching contacts changes with syncToken ${config.contactsToken}`,
+            Apps.GoogleDrive,
           )
           if (response.data.connections && response.data.connections.length) {
             Logger.info(
@@ -1465,6 +1474,7 @@ export const handleGoogleServiceAccountChanges = async (
                 ],
               }),
             `Fetching other contacts changes with syncToken ${otherContactsToken}`,
+            Apps.GoogleDrive,
           )
           otherContactsToken = response.data.nextSyncToken ?? otherContactsToken
           if (

--- a/server/integrations/google/utils.ts
+++ b/server/integrations/google/utils.ts
@@ -101,8 +101,9 @@ export const getFile = async (
           fields,
         }),
       `Getting file with fileId ${fileId}`,
+      Apps.GoogleDrive,
       0,
-      client
+      client,
     )
 
     return file?.data
@@ -138,8 +139,9 @@ export const getFileContent = async (
             documentId: file.id as string,
           }),
         `Getting document with documentId ${file.id}`,
+        Apps.GoogleDrive,
         0,
-        client
+        client,
       )
     const documentContent: docs_v1.Schema$Document = docResponse.data
     const rawTextContent = documentContent?.body?.content

--- a/server/integrations/google/utils.ts
+++ b/server/integrations/google/utils.ts
@@ -101,6 +101,8 @@ export const getFile = async (
           fields,
         }),
       `Getting file with fileId ${fileId}`,
+      0,
+      client
     )
 
     return file?.data
@@ -136,6 +138,8 @@ export const getFileContent = async (
             documentId: file.id as string,
           }),
         `Getting document with documentId ${file.id}`,
+        0,
+        client
       )
     const documentContent: docs_v1.Schema$Document = docResponse.data
     const rawTextContent = documentContent?.body?.content
@@ -198,7 +202,7 @@ export const getPDFContent = async (
     return
   }
   try {
-    await downloadPDF(drive, pdfFile.id!, pdfFile.name!)
+    await downloadPDF(drive, pdfFile.id!, pdfFile.name!, client)
     const pdfPath = `${downloadDir}/${pdfFile?.name}`
     let docs: Document[] = []
 

--- a/server/integrations/google/worker-utils.ts
+++ b/server/integrations/google/worker-utils.ts
@@ -1,4 +1,4 @@
-import { Subsystem } from "@/types"
+import { Subsystem, type GoogleClient } from "@/types"
 import fs from "node:fs/promises"
 import { getLogger } from "@/logger"
 import { gmail_v1 } from "googleapis"
@@ -44,6 +44,7 @@ export const getGmailAttachmentChunks = async (
     filename: string
     size: number
   },
+  client: GoogleClient,
 ): Promise<string[] | null> => {
   const { attachmentId, filename, messageId, size } = attachmentMetadata
   let attachmentChunks: string[] = []
@@ -68,6 +69,8 @@ export const getGmailAttachmentChunks = async (
           userId: "me",
         }),
       "Fetching Gmail Attachments",
+      0,
+      client,
     )
 
     await saveGmailAttachment(

--- a/server/integrations/google/worker-utils.ts
+++ b/server/integrations/google/worker-utils.ts
@@ -10,7 +10,7 @@ import {
 } from "@/integrations/google/pdf-utils"
 import { retryWithBackoff } from "@/utils"
 import { chunkDocument } from "@/chunks"
-import type { Attachment } from "@/search/types"
+import { Apps, type Attachment } from "@/search/types"
 import { MAX_ATTACHMENT_PDF_SIZE } from "@/integrations/google/config"
 import path from "node:path"
 const Logger = getLogger(Subsystem.Integrations).child({ module: "google" })
@@ -69,6 +69,7 @@ export const getGmailAttachmentChunks = async (
           userId: "me",
         }),
       "Fetching Gmail Attachments",
+      Apps.Gmail,
       0,
       client,
     )

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -6,6 +6,7 @@ import { getLogger } from "@/logger"
 import { Subsystem } from "@/types"
 import { stopwords as englishStopwords } from "@orama/stopwords/english"
 import { Apps } from "@/search/types"
+import type { OAuth2Client } from "google-auth-library"
 
 const Logger = getLogger(Subsystem.Utils)
 
@@ -105,6 +106,7 @@ export const retryWithBackoff = async <T>(
   fn: () => Promise<T>,
   context: string,
   retries = 0,
+  oauth2Client?: OAuth2Client,
 ): Promise<T> => {
   try {
     return await fn() // Attempt the function
@@ -133,8 +135,12 @@ export const retryWithBackoff = async <T>(
         )}ms (Attempt ${retries + 1}/${MAX_RETRIES})`,
       )
       await delay(waitTime)
-
-      return retryWithBackoff(fn, context, retries + 1) // Retry recursively
+      return retryWithBackoff(fn, context, retries + 1, oauth2Client) // Retry recursively
+    } else if (error.code === 401 && retries < MAX_RETRIES) {
+      Logger.info(`401 encountered, refreshing OAuth access token...`)
+      const { credentials } = await oauth2Client?.refreshAccessToken()!
+      oauth2Client?.setCredentials(credentials)
+      return retryWithBackoff(fn, context, retries + 1, oauth2Client)
     } else {
       Logger.error(
         `[${context}] Failed after ${retries} retries: ${error.message}`,


### PR DESCRIPTION
### Description

A 401 error (invalid credentials) was encountered when the Google OAuth access token expired during OAuth ingestion. Now, upon encountering this error, new credentials are generated, and the oauthClient uses those newly generated credentials.

### Testing

Tested locally.