### PR TITLE
feat(chunk): Sort and filter chunks based on score

### DIFF
--- a/frontend/src/components/SearchResult.tsx
+++ b/frontend/src/components/SearchResult.tsx
@@ -45,7 +45,7 @@ export const SearchResult = ({
         {result.chunks_summary &&
           result.chunks_summary?.length &&
           result.chunks_summary.map((summary, idx) => (
-            <HighlightedText key={idx} chunk_summary={summary} />
+            <HighlightedText key={idx} chunk_summary={summary.chunk} />
           ))}
       </div>
     )
@@ -93,7 +93,7 @@ export const SearchResult = ({
         {result.chunks_summary &&
           result.chunks_summary?.length &&
           result.chunks_summary.map((summary, idx) => (
-            <HighlightedText key={idx} chunk_summary={summary} />
+            <HighlightedText key={idx} chunk_summary={summary.chunk} />
           ))}
       </div>
     )
@@ -143,7 +143,7 @@ export const SearchResult = ({
         {result.chunks_summary &&
           result.chunks_summary?.length &&
           result.chunks_summary.map((summary, idx) => (
-            <HighlightedText key={idx} chunk_summary={summary} />
+            <HighlightedText key={idx} chunk_summary={summary.chunk} />
           ))}
       </div>
     )

--- a/server/ai/context.ts
+++ b/server/ai/context.ts
@@ -16,6 +16,7 @@ import {
 import { getRelativeTime } from "@/utils"
 import type { z } from "zod"
 import pc from "picocolors"
+import { getSortedScoredChunks } from "@/search/mappers"
 
 // Utility to capitalize the first letter of a string
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
@@ -29,6 +30,12 @@ const constructFileContext = (
   if (!maxSummaryChunks) {
     maxSummaryChunks = fields.chunks_summary?.length
   }
+
+  fields.chunks_summary = getSortedScoredChunks(
+    fields.matchfeatures,
+    fields.chunks_summary as string[],
+  ).map((v) => v.chunk)
+
   return `App: ${fields.app}
 Entity: ${fields.entity}
 Title: ${fields.title ? `Title: ${fields.title}` : ""}
@@ -64,6 +71,11 @@ const constructMailContext = (
   if (!maxSummaryChunks) {
     maxSummaryChunks = fields.chunks_summary?.length
   }
+  fields.chunks_summary = getSortedScoredChunks(
+    fields.matchfeatures,
+    fields.chunks_summary as string[],
+  ).map((v) => v.chunk)
+
   return `App: ${fields.app}
 Entity: ${fields.entity}
 Sent: ${getRelativeTime(fields.timestamp)}
@@ -85,6 +97,12 @@ const constructMailAttachmentContext = (
   if (!maxSummaryChunks) {
     maxSummaryChunks = fields.chunks_summary?.length
   }
+
+  fields.chunks_summary = getSortedScoredChunks(
+    fields.matchfeatures,
+    fields.chunks_summary as string[],
+  ).map((v) => v.chunk)
+
   return `App: ${fields.app}
 Entity: ${fields.entity}
 Sent: ${getRelativeTime(fields.timestamp)}

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -12,6 +12,7 @@ import {
   userQuerySchema,
   MailAttachmentResponseSchema,
   mailAttachmentSchema,
+  scoredChunk,
 } from "search/types"
 export {
   GooglePeopleEntity,
@@ -192,7 +193,7 @@ export const FileResponseSchema = VespaFileSchema.pick({
     chunk: z.string().optional(),
     chunkIndex: z.number().optional(),
     mimeType: z.string(),
-    chunks_summary: z.array(z.string()).optional(),
+    chunks_summary: z.array(scoredChunk).optional(),
     relevance: z.number(),
   })
   .strip()

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -205,6 +205,7 @@ export const IsGoogleApp = (app: Apps) => {
   )
 }
 
-export function scale(val: number): number {
+export function scale(val: number): number | null {
+  if (!val) return null
   return (2 * Math.atan(val / 4)) / Math.PI
 }

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -204,3 +204,7 @@ export const IsGoogleApp = (app: Apps) => {
     app === Apps.GoogleCalendar
   )
 }
+
+export function scale(val: number): number {
+  return (2 * Math.atan(val / 4)) / Math.PI
+}

--- a/server/vespa/schemas/file.sd
+++ b/server/vespa/schemas/file.sd
@@ -135,7 +135,10 @@ schema file {
     function combined_nativeRank() {
       expression: nativeRank(title,chunks)
     }
-  
+
+    function chunk_scores() {
+      expression: elementwise(bm25(chunks),x,double)
+    }
   }
 
  
@@ -162,6 +165,7 @@ schema file {
       combined_nativeRank
       nativeRank(title)
       nativeRank(chunks)
+      chunk_scores
       doc_recency
     }
   }
@@ -192,6 +196,7 @@ schema file {
       bm25(chunks)
       bm25(title)
       combined_bm25
+      chunk_scores
     }
   }
 

--- a/server/vespa/schemas/mail.sd
+++ b/server/vespa/schemas/mail.sd
@@ -220,6 +220,7 @@ schema mail {
       bm25(chunks)
       bm25(subject)
       combined_bm25
+      chunk_scores
     }
   }
 

--- a/server/vespa/schemas/mail.sd
+++ b/server/vespa/schemas/mail.sd
@@ -160,6 +160,10 @@ schema mail {
       function combined_nativeRank() {
         expression: nativeRank(subject,chunks)
       }
+
+      function chunk_scores() {
+        expression: elementwise(bm25(chunks),x,double)
+      }
       
     }
 
@@ -186,6 +190,7 @@ schema mail {
       combined_nativeRank
       nativeRank(subject)
       nativeRank(chunks)
+      chunk_scores
     }
   }
 

--- a/server/vespa/schemas/mail_attachment.sd
+++ b/server/vespa/schemas/mail_attachment.sd
@@ -127,6 +127,10 @@ schema mail_attachment {
     function combined_nativeRank() {
       expression: nativeRank(filename,chunks)
     }
+
+    function chunk_scores() {
+      expression: elementwise(bm25(chunks),x,double)
+    }
   }
 
   rank-profile default inherits initial {
@@ -152,6 +156,7 @@ schema mail_attachment {
       combined_nativeRank
       nativeRank(filename)
       nativeRank(chunks)
+      chunk_scores
     }
   }
 
@@ -182,6 +187,7 @@ schema mail_attachment {
       combined_bm25
       bm25(filename)
       bm25(chunks)
+      chunk_scores
     }
   }
 


### PR DESCRIPTION
### Description
Added a scoring for chunks via vespa [elementwise](https://docs.vespa.ai/en/reference/rank-features.html#rank-scores) and implemented sorting based on their scores. Only high-scored chunks are included in the AI context, and the search preview displays the highest-scored chunk.

### Testing
locally

### Additional Notes

Note: To use elementwise need to have vespa version >= `8.478.26`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced search results with improved summary highlighting, leading to more relevant file, mail, and attachment displays.
  
- **Refactor**
  - Optimized internal sorting and scoring mechanisms to deliver more accurate search rankings and improved result relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->