### PR TITLE
remove pg boss for ingestion job and add whitelist emails support for service account

### DIFF
--- a/server/api/admin.ts
+++ b/server/api/admin.ts
@@ -19,7 +19,8 @@ import { boss, SaaSQueue } from "@/queue"
 import config from "@/config"
 import { Apps, AuthType, ConnectorStatus } from "@/shared/types"
 import { createOAuthProvider, getOAuthProvider } from "@/db/oauthProvider"
-const { JwtPayloadKey, JobExpiryHours } = config
+const { JwtPayloadKey, JobExpiryHours, serviceAccountWhitelistedEmails } =
+  config
 import { generateCodeVerifier, generateState, Google } from "arctic"
 import type { SelectOAuthProvider, SelectUser } from "@/db/schema"
 import { getErrorMessage, IsGoogleApp, setCookieByEnv } from "@/utils"
@@ -30,6 +31,7 @@ import {
   ConnectorNotCreated,
   NoUserFound,
 } from "@/errors"
+import { handleGoogleServiceAccountIngestion } from "@/integrations/google"
 
 const Logger = getLogger(Subsystem.Api).child({ module: "admin" })
 
@@ -37,7 +39,7 @@ export const GetConnectors = async (c: Context) => {
   const { workspaceId, sub } = c.get(JwtPayloadKey)
   const users: SelectUser[] = await getUserByEmail(db, sub)
   if (users.length === 0) {
-    Logger.error({sub}, "No user found for sub in GetConnectors");
+    Logger.error({ sub }, "No user found for sub in GetConnectors")
     throw new NoUserFound({})
   }
   const user = users[0]
@@ -105,8 +107,8 @@ export const StartOAuth = async (c: Context) => {
   const { app }: OAuthStartQuery = c.req.valid("query")
   Logger.info(`${sub} started ${app} OAuth`)
   const userRes = await getUserByEmail(db, sub)
-  if(!userRes || !userRes.length) {
-    Logger.error('Could not find user by email when starting OAuth')
+  if (!userRes || !userRes.length) {
+    Logger.error("Could not find user by email when starting OAuth")
     throw new NoUserFound({})
   }
   const provider = await getOAuthProvider(db, userRes[0].id, app)
@@ -181,58 +183,63 @@ export const AddServiceConnection = async (c: Context) => {
   const app = form.app
 
   // Start a transaction
-  return await db.transaction(async (trx) => {
-    try {
-      // Insert the connection within the transaction
-      const connector = await insertConnector(
-        trx, // Pass the transaction object
-        user.workspaceId,
-        user.id,
-        user.workspaceExternalId,
-        `${app}-${ConnectorType.SaaS}-${AuthType.ServiceAccount}`,
-        ConnectorType.SaaS,
-        AuthType.ServiceAccount,
-        app,
-        {},
-        data,
-        subject,
-      )
+  // return await db.transaction(async (trx) => {
+  try {
+    // Insert the connection within the transaction
+    const connector = await insertConnector(
+      db, // Pass the transaction object
+      user.workspaceId,
+      user.id,
+      user.workspaceExternalId,
+      `${app}-${ConnectorType.SaaS}-${AuthType.ServiceAccount}`,
+      ConnectorType.SaaS,
+      AuthType.ServiceAccount,
+      app,
+      {},
+      data,
+      subject,
+    )
 
-      const SaasJobPayload: SaaSJob = {
-        connectorId: connector.id,
-        workspaceId: user.workspaceId,
-        userId: user.id,
-        app,
-        externalId: connector.externalId,
-        authType: connector.authType as AuthType,
-        email: sub,
-      }
-      // Enqueue the background job within the same transaction
-      const jobId = await boss.send(SaaSQueue, SaasJobPayload, {
-        singletonKey: connector.externalId,
-        priority: 1,
-        retryLimit: 0,
-        expireInHours: JobExpiryHours,
-      })
-
-      Logger.info(`Job ${jobId} enqueued for connection ${connector.id}`)
-
-      // Commit the transaction if everything is successful
-      return c.json({
-        success: true,
-        message: "Connection created, job enqueued",
-        id: connector.externalId,
-      })
-    } catch (error) {
-      const errMessage = getErrorMessage(error)
-      Logger.error(
-        error,
-        `${new AddServiceConnectionError({ cause: error as Error })} \n : ${errMessage} : ${(error as Error).stack}`,
-      )
-      // Rollback the transaction in case of any error
-      throw new HTTPException(500, {
-        message: "Error creating connection or enqueuing job",
-      })
+    const SaasJobPayload: SaaSJob = {
+      connectorId: connector.id,
+      workspaceId: user.workspaceId,
+      userId: user.id,
+      app,
+      externalId: connector.externalId,
+      authType: connector.authType as AuthType,
+      email: sub,
+      whiteListedEmails: serviceAccountWhitelistedEmails,
     }
-  })
+    // Enqueue the background job within the same transaction
+    // const jobId = await boss.send(SaaSQueue, SaasJobPayload, {
+    //   singletonKey: connector.externalId,
+    //   priority: 1,
+    //   retryLimit: 0,
+    //   expireInHours: JobExpiryHours,
+    // })
+
+    if (IsGoogleApp(app)) {
+      handleGoogleServiceAccountIngestion(SaasJobPayload)
+    }
+
+    // Logger.info(`Job ${jobId} enqueued for connection ${connector.id}`)
+
+    // Commit the transaction if everything is successful
+    return c.json({
+      success: true,
+      message: "Connection created, job enqueued",
+      id: connector.externalId,
+    })
+  } catch (error) {
+    const errMessage = getErrorMessage(error)
+    Logger.error(
+      error,
+      `${new AddServiceConnectionError({ cause: error as Error })} \n : ${errMessage} : ${(error as Error).stack}`,
+    )
+    // Rollback the transaction in case of any error
+    throw new HTTPException(500, {
+      message: "Error creating connection or enqueuing job",
+    })
+  }
+  // })
 }

--- a/server/api/oauth.ts
+++ b/server/api/oauth.ts
@@ -82,13 +82,13 @@ export const OAuthCallback = async (c: Context) => {
 
     if (IsGoogleApp(app)) {
       handleGoogleOAuthIngestion(SaasJobPayload)
+    } else {
+      // Enqueue the background job within the same transaction
+      const jobId = await boss.send(SaaSQueue, SaasJobPayload, {
+        expireInHours: JobExpiryHours,
+      })
+      Logger.info(`Job ${jobId} enqueued for connection ${connector.id}`)
     }
-    // Enqueue the background job within the same transaction
-    const jobId = await boss.send(SaaSQueue, SaasJobPayload, {
-      expireInHours: JobExpiryHours,
-    })
-
-    Logger.info(`Job ${jobId} enqueued for connection ${connector.id}`)
 
     // Commit the transaction if everything is successful
     return c.redirect(`${config.host}/oauth/success`)

--- a/server/config.ts
+++ b/server/config.ts
@@ -89,6 +89,11 @@ if (
   fastModelReasoning = true
 }
 
+let serviceAccountWhitelistedEmails: string[] = []
+if(process.env["SERVICE_ACCOUNT_WHITELISTED_EMAILS"]) {
+  serviceAccountWhitelistedEmails = process.env["SERVICE_ACCOUNT_WHITELISTED_EMAILS"].split(",").map(v => v.trim())
+}
+
 export default {
   // default page size for regular search
   page: 8,
@@ -127,4 +132,5 @@ export default {
   StartThinkingToken,
   EndThinkingToken,
   JobExpiryHours: 23,
+  serviceAccountWhitelistedEmails
 }

--- a/server/integrations/google/gmail-worker.ts
+++ b/server/integrations/google/gmail-worker.ts
@@ -128,6 +128,7 @@ export const handleGmailIngestion = async (
           maxResults: batchSize,
           pageToken: nextPageToken,
           fields: "messages(id), nextPageToken",
+          q: "-in:promotions",
         }),
       `Fetching Gmail messages list (pageToken: ${nextPageToken})`,
       Apps.Gmail,

--- a/server/integrations/google/gmail/index.ts
+++ b/server/integrations/google/gmail/index.ts
@@ -64,6 +64,7 @@ export const handleGmailIngestion = async (
           maxResults: batchSize,
           pageToken: nextPageToken,
           fields: "messages(id), nextPageToken",
+          q: "-in:promotions",
         }),
       `Fetching Gmail messages list (pageToken: ${nextPageToken})`,
       Apps.Gmail,

--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -694,7 +694,8 @@ export const handleGoogleOAuthIngestion = async (data: SaaSOAuthJob) => {
       error,
     )
     // await db.transaction(async (trx) => {
-    await db.update(connectors)
+    await db
+      .update(connectors)
       .set({
         status: ConnectorStatus.Failed,
       })
@@ -812,8 +813,9 @@ export const handleGoogleServiceAccountIngestion = async (data: SaaSJob) => {
     let users = allUsers
     const whiteListedEmails = data.whiteListedEmails || []
     if (whiteListedEmails.length) {
-      users = allUsers.filter((user) =>
-        user.primaryEmail && whiteListedEmails.includes(user.primaryEmail),
+      users = allUsers.filter(
+        (user) =>
+          user.primaryEmail && whiteListedEmails.includes(user.primaryEmail),
       )
     }
 

--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -109,6 +109,9 @@ import {
   updateUserStats,
 } from "./tracking"
 import { getOAuthProviderByConnectorId } from "@/db/oauthProvider"
+import config from "@/config"
+
+// const { serviceAccountWhitelistedEmails } = config
 const htmlToText = require("html-to-text")
 const Logger = getLogger(Subsystem.Integrations).child({ module: "google" })
 
@@ -560,12 +563,9 @@ const insertCalendarEvents = async (
   return { events, calendarEventsToken: newSyncTokenCalendarEvents }
 }
 
-export const handleGoogleOAuthIngestion = async (
-  boss: PgBoss,
-  job: PgBoss.Job<any>,
-) => {
-  Logger.info("handleGoogleOauthIngestion", job.data)
-  const data: SaaSOAuthJob = job.data as SaaSOAuthJob
+export const handleGoogleOAuthIngestion = async (data: SaaSOAuthJob) => {
+  // Logger.info("handleGoogleOauthIngestion", job.data)
+  // const data: SaaSOAuthJob = job.data as SaaSOAuthJob
   try {
     // we will first fetch the change token
     // and poll the changes in a new Cron Job
@@ -573,7 +573,7 @@ export const handleGoogleOAuthIngestion = async (
       db,
       data.connectorId,
     )
-    const userEmail = job.data.email
+    const userEmail = data.email
     const oauthTokens = (connector.oauthCredentials as OAuthCredentials).data
 
     const providers: SelectOAuthProvider[] =
@@ -683,7 +683,7 @@ export const handleGoogleOAuthIngestion = async (
         type: SyncCron.ChangeToken,
         status: SyncJobStatus.NotStarted,
       })
-      await boss.complete(SaaSQueue, job.id)
+      // await boss.complete(SaaSQueue, job.id)
       Logger.info("job completed")
       wsConnections.get(connector.externalId)?.close(1000, "Job finished")
     })
@@ -693,15 +693,14 @@ export const handleGoogleOAuthIngestion = async (
       `could not finish job successfully: ${(error as Error).message} ${(error as Error).stack}`,
       error,
     )
-    await db.transaction(async (trx) => {
-      trx
-        .update(connectors)
-        .set({
-          status: ConnectorStatus.Failed,
-        })
-        .where(eq(connectors.id, data.connectorId))
-      await boss.fail(job.name, job.id)
-    })
+    // await db.transaction(async (trx) => {
+    db.update(connectors)
+      .set({
+        status: ConnectorStatus.Failed,
+      })
+      .where(eq(connectors.id, data.connectorId))
+    // await boss.fail(job.name, job.id)
+    // })
     throw new CouldNotFinishJobSuccessfully({
       message: "Could not finish Oauth ingestion",
       integration: Apps.GoogleDrive,
@@ -723,7 +722,6 @@ type IngestionMetadata = {
 }
 
 import { z } from "zod"
-import config from "@/config"
 
 const stats = z.object({
   type: z.literal(WorkerResponseTypes.Stats),
@@ -794,12 +792,8 @@ const handleGmailIngestionForServiceAccount = async (
 
 // we make 2 sync jobs
 // one for drive and one for google workspace
-export const handleGoogleServiceAccountIngestion = async (
-  boss: PgBoss,
-  job: PgBoss.Job<any>,
-) => {
-  Logger.info("handleGoogleServiceAccountIngestion", job.data)
-  const data: SaaSJob = job.data as SaaSJob
+export const handleGoogleServiceAccountIngestion = async (data: SaaSJob) => {
+  Logger.info("handleGoogleServiceAccountIngestion", data)
   try {
     const connector = await getConnector(db, data.connectorId)
     const serviceAccountKey: GoogleServiceAccount = JSON.parse(
@@ -813,7 +807,16 @@ export const handleGoogleServiceAccountIngestion = async (
     })
 
     const workspace = await getWorkspaceById(db, connector.workspaceId)
-    const users = await listUsers(admin, workspace.domain)
+    const allUsers = await listUsers(admin, workspace.domain)
+
+    let users = allUsers
+    const whiteListedEmails = data.whiteListedEmails || []
+    if (whiteListedEmails.length) {
+      users = allUsers.filter((user) =>
+        whiteListedEmails.includes(user.primaryEmail!),
+      )
+    }
+
     setTotalUsers(users.length)
     const ingestionMetadata: IngestionMetadata[] = []
 
@@ -957,7 +960,7 @@ export const handleGoogleServiceAccountIngestion = async (
         })
         .where(eq(connectors.id, connector.id))
       Logger.info("status updated")
-      await boss.complete(SaaSQueue, job.id)
+      // await boss.complete(SaaSQueue, job.id)
       Logger.info("job completed")
     })
   } catch (error) {
@@ -973,7 +976,7 @@ export const handleGoogleServiceAccountIngestion = async (
           status: ConnectorStatus.Failed,
         })
         .where(eq(connectors.id, data.connectorId))
-      await boss.fail(job.name, job.id)
+      // await boss.fail(job.name, job.id)
     })
     throw new CouldNotFinishJobSuccessfully({
       message: "Could not finish Service Account ingestion",

--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -694,7 +694,7 @@ export const handleGoogleOAuthIngestion = async (data: SaaSOAuthJob) => {
       error,
     )
     // await db.transaction(async (trx) => {
-    db.update(connectors)
+    await db.update(connectors)
       .set({
         status: ConnectorStatus.Failed,
       })
@@ -813,7 +813,7 @@ export const handleGoogleServiceAccountIngestion = async (data: SaaSJob) => {
     const whiteListedEmails = data.whiteListedEmails || []
     if (whiteListedEmails.length) {
       users = allUsers.filter((user) =>
-        whiteListedEmails.includes(user.primaryEmail!),
+        user.primaryEmail && whiteListedEmails.includes(user.primaryEmail),
       )
     }
 

--- a/server/queue/index.ts
+++ b/server/queue/index.ts
@@ -77,12 +77,12 @@ const initWorkers = async () => {
       jobData.authType === AuthType.ServiceAccount
     ) {
       Logger.info("Handling Google Service Account Ingestion from Queue")
-      await handleGoogleServiceAccountIngestion(boss, job)
+      // await handleGoogleServiceAccountIngestion(boss, job)
     } else if (
       jobData.app === Apps.GoogleDrive &&
       jobData.authType === AuthType.OAuth
     ) {
-      await handleGoogleOAuthIngestion(boss, job)
+      // await handleGoogleOAuthIngestion(boss, job)
     } else {
       throw new Error("Unsupported job")
     }

--- a/server/types.ts
+++ b/server/types.ts
@@ -103,6 +103,7 @@ export type SaaSJob = {
   externalId: string
   authType: AuthType
   email: string
+  whiteListedEmails?: string[]
 }
 
 export type SaaSOAuthJob = Omit<SaaSJob, "userId" | "workspaceId">


### PR DESCRIPTION

### Description
 - pg boss has 23 hours as the max job expiry this leads to long running ingestion jobs to fail
 - currently we will just run async jobs but after #353 we will be able to abort it and start again
 - We wanted ability to white list emails for service account. Before we add it to UI we allow via env variable `SERVICE_ACCOUNT_WHITELISTED_EMAILS`

### Testing
- ingested data for OAuth
- ingested for single user in

### Additional Notes
For service account we are not able to see the user stats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced service account connections with support for whitelisted emails, improving integration with Google services.
  - Refined Gmail processing to automatically filter out promotional messages for cleaner results.
  - Improved handling of Google app workflows for OAuth and service account connections, streamlining the overall experience.

- **Refactor**
  - Simplified integration processes to promote more consistent and efficient functionality.
  
- **Bug Fixes**
  - Updated error logging for consistency across various components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->