### PR TITLE
feat(google): add estimated time for google service account

### DIFF
--- a/frontend/src/routes/_authenticated/admin/integrations.tsx
+++ b/frontend/src/routes/_authenticated/admin/integrations.tsx
@@ -414,7 +414,7 @@ const UserStatsTable = ({
             ).toFixed(2),
           )
           const elapsed = (new Date().getTime() - stats.startedAt) / (60 * 1000)
-          const eta = (elapsed * 100) / percentage - elapsed
+          const eta = percentage !== 0 ? (elapsed * 100) / percentage - elapsed : 0
           return (
             <TableRow key={email}>
               {type !== AuthType.OAuth && (

--- a/frontend/src/routes/_authenticated/admin/integrations.tsx
+++ b/frontend/src/routes/_authenticated/admin/integrations.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button"
+import { RotateCcw } from "lucide-react"
 import {
   createFileRoute,
   redirect,
@@ -218,7 +219,10 @@ export const OAuthForm = ({ onSuccess }: { onSuccess: any }) => {
 export const ServiceAccountForm = ({
   onSuccess,
   refetch,
-}: { onSuccess: any; refetch: any }) => {
+}: {
+  onSuccess: any
+  refetch: any
+}) => {
   //@ts-ignore
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
   const { toast } = useToast()
@@ -321,7 +325,11 @@ export const OAuthButton = ({
   app,
   text,
   setOAuthIntegrationStatus,
-}: { app: Apps; text: string; setOAuthIntegrationStatus: any }) => {
+}: {
+  app: Apps
+  text: string
+  setOAuthIntegrationStatus: any
+}) => {
   const handleOAuth = async () => {
     const oauth = new OAuthModal()
     try {
@@ -373,7 +381,10 @@ export const getConnectors = async (): Promise<any> => {
 const UserStatsTable = ({
   userStats,
   type,
-}: { userStats: { [email: string]: any }; type: AuthType }) => {
+}: {
+  userStats: { [email: string]: any }
+  type: AuthType
+}) => {
   return (
     <Table
       className={
@@ -390,25 +401,37 @@ const UserStatsTable = ({
           <TableHead>Contacts</TableHead>
           <TableHead>Events</TableHead>
           <TableHead>Attachments</TableHead>
-          {/* <TableHead>Status</TableHead> */}
+          <TableHead>%</TableHead>
+          <TableHead>Est (minutes)</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {Object.entries(userStats).map(([email, stats]) => (
-          <TableRow key={email}>
-            {type !== AuthType.OAuth && (
-              <TableCell className={`${stats.done ? "text-lime-600" : ""}`}>
-                {email}
-              </TableCell>
-            )}
-            <TableCell>{stats.gmailCount}</TableCell>
-            <TableCell>{stats.driveCount}</TableCell>
-            <TableCell>{stats.contactsCount}</TableCell>
-            <TableCell>{stats.eventsCount}</TableCell>
-            <TableCell>{stats.mailAttachmentCount}</TableCell>
-            {/* <TableCell className={`${stats.done ? "text-lime-600": ""}`}>{stats.done ? "Done" : "In Progress"}</TableCell> */}
-          </TableRow>
-        ))}
+        {Object.entries(userStats).map(([email, stats]) => {
+          const percentage: number = parseFloat(
+            (
+              ((stats.gmailCount + stats.driveCount) * 100) /
+              (stats.totalDrive + stats.totalMail)
+            ).toFixed(2),
+          )
+          const elapsed = (new Date().getTime() - stats.startedAt) / (60 * 1000)
+          const eta = (elapsed * 100) / percentage - elapsed
+          return (
+            <TableRow key={email}>
+              {type !== AuthType.OAuth && (
+                <TableCell className={`${stats.done ? "text-lime-600" : ""}`}>
+                  {email}
+                </TableCell>
+              )}
+              <TableCell>{stats.gmailCount}</TableCell>
+              <TableCell>{stats.driveCount}</TableCell>
+              <TableCell>{stats.contactsCount}</TableCell>
+              <TableCell>{stats.eventsCount}</TableCell>
+              <TableCell>{stats.mailAttachmentCount}</TableCell>
+              <TableCell>{percentage}</TableCell>
+              <TableCell>{eta.toFixed(0)}</TableCell>
+            </TableRow>
+          )
+        })}
       </TableBody>
     </Table>
   )
@@ -457,9 +480,20 @@ const ServiceAccountTab = ({
           </>
         ) : (
           <>
-            <CardDescription>Connected</CardDescription>
+            <CardDescription>
+              Status: {googleSAConnector.status}
+            </CardDescription>
           </>
         )}
+
+        <button
+          className="flex justify-end w-full"
+          onClick={() => {
+            // restart the ingestion of that connector
+          }}
+        >
+          <RotateCcw stroke={"hsl(220 8.9% 46.1%)"} size={18} />
+        </button>
       </CardHeader>
     )
   }

--- a/server/integrations/google/config.ts
+++ b/server/integrations/google/config.ts
@@ -11,13 +11,13 @@ export const scopes = [
   "https://www.googleapis.com/auth/calendar.events.readonly",
 ]
 
-export const MAX_GD_PDF_SIZE = 20 // In MB
+export const MAX_GD_PDF_SIZE = 15 // In MB
 export const MAX_GD_SHEET_ROWS = 3000
 export const MAX_GD_SHEET_TEXT_LEN = 300000
 export const MAX_GD_SLIDES_TEXT_LEN = 300000
 export const ServiceAccountUserConcurrency = 2
-export const GoogleDocsConcurrency = 15
-export const GmailConcurrency = 15
-export const PDFProcessingConcurrency = 15
+export const GoogleDocsConcurrency = 3
+export const GmailConcurrency = 3
+export const PDFProcessingConcurrency = 3
 
-export const MAX_ATTACHMENT_PDF_SIZE = 20
+export const MAX_ATTACHMENT_PDF_SIZE = 15

--- a/server/integrations/google/tracking.ts
+++ b/server/integrations/google/tracking.ts
@@ -16,6 +16,8 @@ interface StatMetadata {
   startedAt: number
   doneAt: number
   type: AuthType
+  totalMail: number
+  totalDrive: number
 }
 
 type UserStats = Record<StatType, number> & StatMetadata
@@ -54,6 +56,8 @@ const initializeUserStats = (email: string) => {
       startedAt: new Date().getTime(),
       doneAt: 0,
       type: AuthType.ServiceAccount,
+      totalMail: 0,
+      totalDrive: 0,
     }
   }
   if (!oAuthTracker.userStats[email]) {
@@ -67,6 +71,8 @@ const initializeUserStats = (email: string) => {
       startedAt: new Date().getTime(),
       doneAt: 0,
       type: AuthType.OAuth,
+      totalMail: 0,
+      totalDrive: 0,
     }
   }
 }
@@ -79,6 +85,18 @@ export const updateUserStats = (
   initializeUserStats(email)
   serviceAccountTracker.userStats[email][type] += count
   oAuthTracker.userStats[email][type] += count
+}
+
+export const updateTotal = (
+  email: string,
+  totalMail: number,
+  totalDrive: number,
+) => {
+  initializeUserStats(email)
+  serviceAccountTracker.userStats[email].totalMail = totalMail
+  serviceAccountTracker.userStats[email].totalDrive = totalDrive
+  oAuthTracker.userStats[email].totalMail = totalMail
+  oAuthTracker.userStats[email].totalDrive = totalDrive
 }
 
 export const markUserComplete = (email: string) => {

--- a/server/integrations/google/utils.ts
+++ b/server/integrations/google/utils.ts
@@ -200,7 +200,9 @@ export const getPDFContent = async (
   const pdfSizeInMB = parseInt(pdfFile.size!) / (1024 * 1024)
   // Ignore the PDF files larger than Max PDF Size
   if (pdfSizeInMB > MAX_GD_PDF_SIZE) {
-    Logger.error(`Ignoring ${pdfFile.name} as its more than 20 MB`)
+    Logger.error(
+      `Ignoring ${pdfFile.name} as its more than ${MAX_GD_PDF_SIZE} MB`,
+    )
     return
   }
   try {

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -112,7 +112,7 @@ export const retryWithBackoff = async <T>(
   try {
     return await fn() // Attempt the function
   } catch (error: any) {
-    Logger.error(error)
+    Logger.warn(error)
     const isQuotaError =
       error.message.includes("Quota exceeded") || error.code === 429
     // error.code === 403

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -112,10 +112,10 @@ export const retryWithBackoff = async <T>(
   try {
     return await fn() // Attempt the function
   } catch (error: any) {
+    Logger.error(error)
     const isQuotaError =
-      error.message.includes("Quota exceeded") ||
-      error.code === 429 ||
-      error.code === 403
+      error.message.includes("Quota exceeded") || error.code === 429
+    // error.code === 403
     const isGoogleTimeoutError =
       error.code === "ETIMEDOUT" ||
       error.code === "ECONNABORTED" ||


### PR DESCRIPTION
### Description
- get the count of all the mail and drive files
- create an estimate and provide % of amount done
- reduce the concurrency requirements, due to too many concurrent pdf files the memory was getting filed and would lead to bun to crash (segmentation fault)
- our retry backoff function was also doing it for 403 error which I don't think it should and added a log of the error

### Testing
- tested ~100k files successfully on a 32GB machine
- haven't tested OAuth

### Additional Notes
probably need to fix for OAuth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced integrations panel with an improved statistics table now showing task completion percentage and estimated processing time.
  - Dynamic status updates for service connections and a new restart ingestion button for greater user control.
  - New metrics for Gmail and Google Drive integration, allowing for better user statistics tracking.

- **Chores**
  - Refined PDF attachment limits and API request handling to boost overall integration efficiency.
  - Upgraded tracking for email and drive activity to deliver more accurate user performance metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->