### PR TITLE
improved counting of pdf attachments and mails in general

### DIFF
--- a/server/integrations/google/gmail-worker.ts
+++ b/server/integrations/google/gmail-worker.ts
@@ -138,8 +138,8 @@ export const handleGmailIngestion = async (
     nextPageToken = resp.data.nextPageToken ?? ""
     if (resp.data.messages) {
       let messageBatch = resp.data.messages.slice(0, batchSize)
-      let successfulMessagesInBatch = 0; // Counter for successful messages
-      let successfulPdfAttachmentsInBatch = 0; // Counter for successful PDFs in this batch
+      let insertedMessagesInBatch = 0; // Counter for successful messages
+      let insertedPdfAttachmentsInBatch = 0; // Counter for successful PDFs in this batch
 
       let batchRequests = messageBatch.map((message) =>
         limit(async () => {


### PR DESCRIPTION
### Description
- add count of attachments that got inserted and were pdf
- only count mails that actually got inserted

### Testing
locally

### Additional Notes
the `%` in the service account and estimated time still have issues that this didn't solve but it's still a valid fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated email ingestion reporting now displays only successful messages and PDF attachments, offering clearer operational insights.
  
- **Refactor**
  - Streamlined processing logic to enhance error handling and ensure that reported statistics more accurately reflect successful operations.
  - Improved method to return both parsed mail data and count of inserted PDF attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->