### PR TITLE
feat(integration): if data is already ingested and same updated at then don't reingest the file

### DIFF
--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -595,9 +595,11 @@ export interface AppEntityCounts {
   [app: string]: EntityCounts
 }
 
-export const ifDocumentsExist = async (docIds: string[]) => {
+export const ifDocumentsExist = async (
+  docIds: string[],
+): Promise<Record<string, { exists: boolean; updatedAt: number | null }>> => {
   try {
-    return await vespa.isDocumentExist(docIds)
+    return await vespa.ifDocumentsExist(docIds)
   } catch (error) {
     throw error
   }

--- a/server/search/vespaClient.ts
+++ b/server/search/vespaClient.ts
@@ -577,7 +577,7 @@ class VespaClient {
         {} as Record<string, { exists: boolean; updatedAt: number | null }>,
       )
 
-      return existenceMap // { "id:namespace:doctype::1": true, "id:namespace:doctype::2": false, ... }
+      return existenceMap
     } catch (error) {
       const errMessage = getErrorMessage(error)
       Logger.error(error, `Error checking documents existence:  ${errMessage}`)


### PR DESCRIPTION

### Description
 - recent crash of bun causes issue in ingestion
 - instead of starting from scratch now at least we check if the data already exists
### Testing
 - locally
### Additional Notes
 - I don't think this is working well for sheets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved email ingestion by verifying document status to skip duplicate or already processed messages.
  - Enhanced file processing through filtering based on modification times, ensuring that only updated files are handled.

- **Refactor**
  - Updated internal document lookup to provide detailed status information with timestamps, optimizing overall processing efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->