### PR TITLE
fix(ratelimit): handle 403 rate limit reasons

### DIFF
--- a/server/integrations/google/config.ts
+++ b/server/integrations/google/config.ts
@@ -16,8 +16,8 @@ export const MAX_GD_SHEET_ROWS = 3000
 export const MAX_GD_SHEET_TEXT_LEN = 300000
 export const MAX_GD_SLIDES_TEXT_LEN = 300000
 export const ServiceAccountUserConcurrency = 2
-export const GoogleDocsConcurrency = 3
-export const GmailConcurrency = 3
-export const PDFProcessingConcurrency = 3
+export const GoogleDocsConcurrency = 8
+export const GmailConcurrency = 8
+export const PDFProcessingConcurrency = 8
 
 export const MAX_ATTACHMENT_PDF_SIZE = 15

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -116,6 +116,13 @@ export const retryWithBackoff = async <T>(
     const isQuotaError =
       error.message.includes("Quota exceeded") || error.code === 429
     // error.code === 403
+    // Check for specific 403 Rate Limit errors that benefit from backoff
+    const is403RetryableRateLimitError =
+      error.code === 403 &&
+      ["userRateLimitExceeded", "rateLimitExceeded"].includes(
+        error.errors?.[0]?.reason,
+      )
+
     const isGoogleTimeoutError =
       error.code === "ETIMEDOUT" ||
       error.code === "ECONNABORTED" ||
@@ -125,13 +132,23 @@ export const retryWithBackoff = async <T>(
       // Specific Google API timeout indicators
       error.code === 504 || // Gateway Timeout
       error.code === 503 // Service Unavailable
-    if ((isQuotaError || isGoogleTimeoutError) && retries < MAX_RETRIES) {
+
+    // Combine checks for retryable errors
+    if (
+      (isQuotaError || isGoogleTimeoutError || is403RetryableRateLimitError) &&
+      retries < MAX_RETRIES
+    ) {
       const baseWaitTime = Math.pow(2, retries) * 3000 // Exponential backoff
       const jitter = Math.random() * 800 // Add jitter for randomness
       const waitTime = baseWaitTime + jitter
 
+      let reason = "Quota/Timeout"
+      if (is403RetryableRateLimitError) {
+        reason = "403 Rate Limit"
+      }
+
       Logger.info(
-        `[${context}] Quota error. Retrying after ${waitTime.toFixed(
+        `[${context}] ${reason} error. Retrying after ${waitTime.toFixed(
           0,
         )}ms (Attempt ${retries + 1}/${MAX_RETRIES})`,
       )


### PR DESCRIPTION
### Description
I had removed #362 403 errors from ratelimit as forbidden case no point in retrying but it seems there are bunch of 403 ratelimit cases that we can handle https://developers.google.com/workspace/gmail/api/guides/handle-errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Increased the maximum concurrent processing for documents, emails, and PDF tasks to boost operation throughput.
	- Enhanced error handling by detecting specific rate limit conditions, resulting in clearer feedback during retry events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->