### PR TITLE
fix(ingestion-crash): Add catch to async functions that were running in background

### DIFF
--- a/server/api/admin.ts
+++ b/server/api/admin.ts
@@ -231,7 +231,13 @@ export const AddServiceConnection = async (c: Context) => {
     // })
 
     if (IsGoogleApp(app)) {
-      handleGoogleServiceAccountIngestion(SaasJobPayload)
+      // Start ingestion in the background, but catch any errors it might throw later
+      handleGoogleServiceAccountIngestion(SaasJobPayload).catch((error) => {
+        Logger.error(
+          error,
+          `Background Google Service Account ingestion failed for connector ${connector.id}: ${getErrorMessage(error)}`,
+        )
+      })
     }
 
     // Logger.info(`Job ${jobId} enqueued for connection ${connector.id}`)

--- a/server/server.ts
+++ b/server/server.ts
@@ -391,7 +391,16 @@ const server = Bun.serve({
 })
 Logger.info(`listening on port: ${config.port}`)
 
-process.on("uncaughtException", (error) => {
-  Logger.error(error, "uncaughtException")
-  // shutdown server?
+const errorEvents: string[] = [
+  `uncaughtException`,
+  `unhandledRejection`,
+  `rejectionHandled`,
+  `warning`,
+]
+errorEvents.forEach((eventType: string) => {
+  process.on(eventType, catchEvent.bind(null, eventType))
 })
+
+function catchEvent(eventType: string) {
+  console.log("Caught event...", { eventType })
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -397,10 +397,8 @@ const errorEvents: string[] = [
   `rejectionHandled`,
   `warning`,
 ]
-errorEvents.forEach((eventType: string) => {
-  process.on(eventType, catchEvent.bind(null, eventType))
-})
-
-function catchEvent(eventType: string) {
-  console.log("Caught event...", { eventType })
-}
+errorEvents.forEach((eventType: string) =>
+  process.on(eventType, (error: Error) => {
+    Logger.error(error, `Caught via event: ${eventType}`)
+  }),
+)


### PR DESCRIPTION
### Description
 - I had moved from job queue to async function calls but the issue was that any error that got thrown from it now would crash the whole server.
 - also added the generic unhandled error cases that now work correctly

### Testing
 - turned off vespa and then started OAuth ingestion
 - Also tested the uncaught exception that now works even if we don't put any `catch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling during background processes for service connections and authentication flows. This update ensures that any issues during data ingestion are logged more effectively, supporting improved system stability.

- **Chores**
  - Rolled out a centralized approach for tracking server runtime events. The new mechanism listens for various error and warning events, providing a more robust way to capture and log unexpected issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->