### PR TITLE
fix(pdfs): hash the filename to avoid the invalid path and ensure privacy

### DIFF
--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -26,6 +26,7 @@ import {
   type SaaSOAuthJob,
 } from "@/types"
 import PgBoss from "pg-boss"
+import { hashPdfFilename } from "@/integrations/google/utils"
 import { getConnector, getOAuthConnectorWithCredentials } from "@/db/connector"
 import {
   GetDocument,
@@ -1772,9 +1773,13 @@ export const googlePDFsVespa = async (
         )
         return null
       }
-      const pdfFileName = `${userEmail}_${pdf.id}_${pdf.name}`
+
+      const pdfFileName = `${hashPdfFilename(`${userEmail}_${pdf.id}_${pdf.name}`)}.pdf`
       const pdfPath = `${downloadDir}/${pdfFileName}`
       try {
+        Logger.info(
+          `getting the data from the drive-> ${pdf.name}${pdfFileName}`,
+        )
         await downloadPDF(drive, pdf.id!, pdfFileName, client)
 
         const docs: Document[] = await safeLoadPDF(pdfPath)

--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -1777,7 +1777,7 @@ export const googlePDFsVespa = async (
       const pdfFileName = `${hashPdfFilename(`${userEmail}_${pdf.id}_${pdf.name}`)}.pdf`
       const pdfPath = `${downloadDir}/${pdfFileName}`
       try {
-        Logger.info(
+        Logger.debug(
           `getting the data from the drive-> ${pdf.name}${pdfFileName}`,
         )
         await downloadPDF(drive, pdf.id!, pdfFileName, client)

--- a/server/integrations/google/utils.ts
+++ b/server/integrations/google/utils.ts
@@ -31,11 +31,12 @@ import {
   safeLoadPDF,
 } from "@/integrations/google"
 import { getLogger } from "@/logger"
+
 import type PgBoss from "pg-boss"
 import fs from "node:fs/promises"
 import path from "path"
 import { retryWithBackoff } from "@/utils"
-
+import crypto from "node:crypto"
 const Logger = getLogger(Subsystem.Integrations).child({ module: "google" })
 
 // TODO: make it even more extensive
@@ -408,4 +409,15 @@ export const checkDownloadsFolder = async (
       `Error checking or deleting files in downloads folder: ${error} ${(error as Error).stack}`,
     )
   }
+}
+
+// Function to hash the filename to hide the filename while
+// Storing the data in the memory
+export const hashPdfFilename = (filename: string): string => {
+  const hashInput = filename
+  const hash = crypto.createHash("md5").update(hashInput).digest("hex")
+
+  const newFilename = hash
+  Logger.info(`Filename hashed: ${filename} -> ${newFilename}`)
+  return newFilename
 }


### PR DESCRIPTION
### Description

- Fixes an issue with incorrect file path i.e when the PDF file name contain `/` then it consider that part as folder and look for it in server/downloads Folder
- Hashed the file name to avoid that and also it ensure that file name visible on disk
- Created the util function which hash the file name
- Fixes for attachment pdfs as well as the drive pdf.

### Testing

- Tested Locally

### Additional Notes

<img width="1411" alt="Screenshot 2025-04-03 at 8 01 22 PM" src="https://github.com/user-attachments/assets/ad2c0fae-cf39-49b5-8b8c-e46632c90f71" />

- here the fileName was `document_BE/BTech/11125.pdf_1811abb8efc9f35d`
- it contains `/` in the filename


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Enhanced document downloads with secure, hashed file naming, ensuring greater uniqueness and protection.
  - Improved logging for more transparent tracking during file processing and download operations.

- **Refactor**
  - Updated the approach for handling file naming for documents and email attachments, streamlining the processing workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->