### PR TITLE
fix(permission): Fix event permission for auto complete

### DIFF
--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -117,7 +117,7 @@ const htmlToText = require("html-to-text")
 const Logger = getLogger(Subsystem.Integrations).child({ module: "google" })
 
 const gmailWorker = new Worker(new URL("gmail-worker.ts", import.meta.url).href)
-Logger.info('Gmail worker initialized')
+Logger.info("Gmail worker initialized")
 
 export type GaxiosPromise<T = any> = Promise<GaxiosResponse<T>>
 

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -148,10 +148,13 @@ export const autocomplete = async (
   email: string,
   limit: number = 5,
 ): Promise<VespaAutocompleteResponse> => {
+  const sources = AllSources.split(", ")
+    .filter((s) => s !== chatMessageSchema)
+    .join(", ")
   // Construct the YQL query for fuzzy prefix matching with maxEditDistance:2
   // the drawback here is that for user field we will get duplicates, for the same
   // email one contact and one from user directory
-  const yqlQuery = `select * from sources ${AllSources}, ${userQuerySchema}
+  const yqlQuery = `select * from sources ${sources}, ${userQuerySchema}
     where
         (title_fuzzy contains ({maxEditDistance: 2, prefix: true} fuzzy(@query))
         and permissions contains @email)
@@ -181,8 +184,12 @@ export const autocomplete = async (
         (query_text contains ({maxEditDistance: 2, prefix: true} fuzzy(@query))
         and owner contains @email)
         or
-        (name_fuzzy contains ({maxEditDistance: 2, prefix: true} fuzzy(@query)) or email_fuzzy contains ({maxEditDistance: 2, prefix: true} fuzzy(@query))
-        and permissions contains @email
+        (
+          (
+            name_fuzzy contains ({maxEditDistance: 2, prefix: true} fuzzy(@query)) or
+            email_fuzzy contains ({maxEditDistance: 2, prefix: true} fuzzy(@query))
+          )
+          and permissions contains @email
         )
         `
 

--- a/server/tests/hybridDefaultYQL.test.ts
+++ b/server/tests/hybridDefaultYQL.test.ts
@@ -148,7 +148,13 @@ describe("HybridDefaultProfile", () => {
   test("query with null timestamp", () => {
     const timestampRange = { from: null, to: null }
     expect(() =>
-      HybridDefaultProfile(5, null, null, SearchModes.NativeRank, timestampRange),
+      HybridDefaultProfile(
+        5,
+        null,
+        null,
+        SearchModes.NativeRank,
+        timestampRange,
+      ),
     ).toThrow("Invalid timestamp range")
   })
 })


### PR DESCRIPTION
### Description

Due to missing parentheses around name_fuzzy OR email_fuzzy, causing the AND permissions condition to apply only to email_fuzzy. Added parentheses ensures both fuzzy matches require matching permissions

### Testing
Locally

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
