### PR TITLE
feat(search): Add decay weights to de-prioritize social and updates emails

### DIFF
--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -463,6 +463,9 @@ export const searchVespa = async (
     "ranking.profile": profile,
     "input.query(e)": "embed(@query)",
     "input.query(alpha)": alpha,
+    // mail decay weights
+    "input.query(social_decay)": 0.6,
+    "input.query(updates_decay)": 0.8,
     hits: limit,
     ...(offset
       ? {

--- a/server/vespa/schemas/mail.sd
+++ b/server/vespa/schemas/mail.sd
@@ -95,7 +95,8 @@ schema mail {
     attribute: fast-search
   }
   }
-  field chunk_embeddings type tensor<bfloat16>(p{}, v[DIMS])  {
+  
+  field chunk_embeddings type tensor<bfloat16>(p{}, v[384])  {
     indexing: input chunks | embed | attribute | index
     attribute {
       distance-metric: angular
@@ -124,8 +125,10 @@ schema mail {
   # Hybrid search rank profile combining BM25 for subject and chunks, and vector search for chunk embeddings
     rank-profile initial {
       inputs {
-        query(e) tensor<bfloat16>(v[DIMS])  # Query embedding
+        query(e) tensor<bfloat16>(v[384])  # Query embedding
         query(alpha) double  # Alpha parameter for hybrid weight
+        query(social_decay) double
+        query(updates_decay) double
       }
 
       constants {
@@ -164,6 +167,14 @@ schema mail {
         expression: elementwise(bm25(chunks), x, double)
       }
       
+      function isSocial(){
+        # converting array<string> to tensors{} 
+        expression: tensorFromLabels(attribute(labels),dimension){"CATEGORY_SOCIAL"}
+      }
+
+      function isUpdates(){
+        expression: tensorFromLabels(attribute(labels),dimension){"CATEGORY_UPDATES"}
+      }
     }
 
   rank-profile default_native inherits initial {
@@ -175,6 +186,14 @@ schema mail {
       global-phase {
         expression {
           (
+            if (isSocial == 1, 
+              query(social_decay),
+              if (isUpdates == 1, 
+                query(updates_decay), 
+                1
+              )
+            )
+          ) * (
             (query(alpha) * vector_score) + 
             ((1 - query(alpha)) *  combined_nativeRank)
           )
@@ -183,6 +202,10 @@ schema mail {
       }
 
     match-features {
+      isSocial
+      isUpdates
+      query(social_decay)
+      query(updates_decay)
       vector_score
       combined_nativeRank
       nativeRank(subject)


### PR DESCRIPTION
### Description
Added decay weights for mails categorized as social and updates to reduce their influence in search rankings

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
