### PR TITLE
Feat/slack permissions

### DIFF
--- a/frontend/src/routes/_authenticated/admin/integrations/slack.tsx
+++ b/frontend/src/routes/_authenticated/admin/integrations/slack.tsx
@@ -618,7 +618,7 @@ export const Slack = ({ user, workspace }: IntegrationProps) => {
             <TableHead>Replies</TableHead>
             <TableHead>Conversations</TableHead>
             <TableHead>Users</TableHead>
-            <TableHead>msgs per second</TableHead>
+            <TableHead>msgs / s</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>

--- a/server/ai/context.ts
+++ b/server/ai/context.ts
@@ -95,13 +95,25 @@ const constructSlackMessageContext = (
   fields: VespaChatMessageSearch,
   relevance: number,
 ): string => {
-  return `App: ${fields.app}
+  let channelCtx = ``
+  if (fields.isIm && fields.permissions) {
+    channelCtx = `It's a DM between ${fields.permissions.join(", ")}`
+  } else if (!fields.isPrivate) {
+    // mpim and public channel
+    channelCtx = `It's a message in ${fields.channelName}`
+  } else {
+    channelCtx = `It's a in private channel ${fields.channelName}`
+  }
+  return `${channelCtx}
+    App: ${fields.app}
     Entity: ${fields.entity}
     User: ${fields.name}
     Username: ${fields.username}
     Message: ${fields.text}
-    vespa relevance score: ${relevance}
-    `
+    ${fields.threadId && "it's a message thread"}
+    Time: ${getRelativeTime(fields.createdAt)}
+    User is part of Workspace: ${fields.teamName}
+    vespa relevance score: ${relevance}`
 }
 
 const constructMailAttachmentContext = (

--- a/server/ai/context.ts
+++ b/server/ai/context.ts
@@ -110,7 +110,7 @@ const constructSlackMessageContext = (
     User: ${fields.name}
     Username: ${fields.username}
     Message: ${fields.text}
-    ${fields.threadId && "it's a message thread"}
+    ${fields.threadId ? "it's a message thread" : ""}
     Time: ${getRelativeTime(fields.createdAt)}
     User is part of Workspace: ${fields.teamName}
     vespa relevance score: ${relevance}`

--- a/server/ai/prompts.ts
+++ b/server/ai/prompts.ts
@@ -884,42 +884,40 @@ export const baselineReasoningPromptJson = (
 4. Calendar events
 5. Slack/Chat Messages
 The context provided will be formatted with specific fields for each type:
+- App and Entity type and the relevance score
 ## File Context Format
-- App and Entity type
 - Title
 - Creation and update timestamps
 - Owner information
 - Mime type
 - Permissions, this field just shows who has access to what, nothing more
 - Content chunks
-- Relevance score
 ## User Context Format
-- App and Entity type
 - Addition date
 - Name and email
 - Gender
 - Job title
 - Department
 - Location
-- Relevance score
 ## Email Context Format
-- App and Entity type
 - Timestamp
 - Subject
 - From/To/Cc/Bcc
 - Labels
 - Content chunks
-- Relevance score
 ## Event Context Format
-- App and Entity type
 - Event name and description
 - Location and URLs
 - Time information
 - Organizer and attendees
 - Recurrence patterns
 - Meeting links
-- Relevance score
 ## Slack Context Format
+- User's name and username
+- Message text
+- When it was written
+- Workspace user is part of
+
 # Context of the user talking to you
 ${userContext}
 This includes:

--- a/server/ai/prompts.ts
+++ b/server/ai/prompts.ts
@@ -882,6 +882,7 @@ export const baselineReasoningPromptJson = (
 2. User profiles
 3. Emails
 4. Calendar events
+5. Slack/Chat Messages
 The context provided will be formatted with specific fields for each type:
 ## File Context Format
 - App and Entity type
@@ -918,6 +919,7 @@ The context provided will be formatted with specific fields for each type:
 - Recurrence patterns
 - Meeting links
 - Relevance score
+## Slack Context Format
 # Context of the user talking to you
 ${userContext}
 This includes:

--- a/server/api/chat.ts
+++ b/server/api/chat.ts
@@ -294,7 +294,7 @@ const searchToCitation = (result: VespaSearchResults): Citation => {
   } else if (result.fields.sddocname === chatMessageSchema) {
     return {
       title: (fields as VespaChatMessage).text,
-      url: `https://google.com`,
+      url: `https://${(fields as VespaChatMessage).domain}.slack.com/archives/${(fields as VespaChatMessage).channelId}/p${(fields as VespaChatMessage).updatedAt}`,
       app: (fields as VespaChatMessage).app,
       entity: (fields as VespaChatMessage).entity,
     }

--- a/server/integrations/slack/index.ts
+++ b/server/integrations/slack/index.ts
@@ -428,6 +428,7 @@ const insertConversation = async (
   const vespaChatContainer: VespaChatContainer = {
     docId: conversation.id!,
     name: conversation.name!,
+    channelName: (conversation as Channel).name!,
     app: Apps.Slack,
     creator: conversation.creator!,
     isPrivate: conversation.is_private ?? false,
@@ -454,6 +455,7 @@ const insertConversations = async (
       const vespaChatContainer: VespaChatContainer = {
         docId: (conversation as Channel).id!,
         name: (conversation as Channel).name!,
+        channelName: (conversation as Channel).name!,
         app: Apps.Slack,
         creator: (conversation as Channel).creator!,
         isPrivate: (conversation as Channel).is_private!,

--- a/server/integrations/slack/index.ts
+++ b/server/integrations/slack/index.ts
@@ -297,7 +297,7 @@ async function insertChannelMessages(
           message.team = await getTeam(client, message)
           if (message.text == "") {
             message.text = "NA"
-          } 
+          }
           insertChatMessage(
             client,
             message,
@@ -360,18 +360,21 @@ async function insertChannelMessages(
                   )
                 }
               }
-              if(!memberMap.get(reply.user)){
-                memberMap.set(reply.user,
+              if (!memberMap.get(reply.user)) {
+                memberMap.set(
+                  reply.user,
                   (
                     await client.users.info({
                       user: reply.user,
                     })
-                  ).user!,)
-
+                  ).user!,
+                )
               }
               reply.mentions = mentions
               reply.text = text
-              if(reply.text==""){reply.text="NA"}//case when text is empty
+              if (reply.text == "") {
+                reply.text = "NA"
+              } //case when text is empty
               reply.team = await getTeam(client, reply)
               insertChatMessage(
                 client,
@@ -533,27 +536,28 @@ async function getConversationUsers(
   }
 }
 
-const getTeam = async(client: WebClient,
-  message: SlackMessage & { mentions?: string[] }) =>{
-    if(!message.team){
-      if(message.files){
-        for(const file of message.files) {
-          if (file.user_team) {
-            message.team = file.user_team
-            break
-          }
+const getTeam = async (
+  client: WebClient,
+  message: SlackMessage & { mentions?: string[] },
+) => {
+  if (!message.team) {
+    if (message.files) {
+      for (const file of message.files) {
+        if (file.user_team) {
+          message.team = file.user_team
+          break
         }
       }
     }
-    if(!message.team){
-      const res = await client.users.info({user: message.user!})
-      if(res.ok){
-        message.team = res.user?.team_id
-      }
+  }
+  if (!message.team) {
+    const res = await client.users.info({ user: message.user! })
+    if (res.ok) {
+      message.team = res.user?.team_id
     }
-    return message.team;
+  }
+  return message.team
 }
-
 
 const insertChatMessage = async (
   client: WebClient,
@@ -564,7 +568,6 @@ const insertChatMessage = async (
   image: string,
 ) => {
   const editedTimestamp = message.edited ? parseFloat(message?.edited?.ts!) : 0
-  
 
   return insertWithRetry(
     {

--- a/server/integrations/slack/index.ts
+++ b/server/integrations/slack/index.ts
@@ -768,22 +768,36 @@ export const handleSlackIngestion = async (data: SaaSOAuthJob) => {
             ingestionState,
           )
         } else if (conversation.is_channel) {
-          if (conversation.is_private) {
-            // stats.private++
+          // for public channel user has to be member
+          if (!conversation.is_private && conversation.is_member) {
+            await insertChannelMessages(
+              data.email,
+              client,
+              conversation.id!,
+              abortController,
+              memberMap,
+              teamMap,
+              permissionMap,
+              tracker,
+              ingestionState,
+            )
+          } else if (conversation.is_private) {
+            await insertChannelMessages(
+              data.email,
+              client,
+              conversation.id!,
+              abortController,
+              memberMap,
+              teamMap,
+              permissionMap,
+              tracker,
+              ingestionState,
+            )
           } else {
-            // stats.public++
+            Logger.info(
+              `not supported: ${conversation.id} ${conversation.name} ${conversation.is_private} ${conversation.is_member}`,
+            )
           }
-          await insertChannelMessages(
-            data.email,
-            client,
-            conversation.id!,
-            abortController,
-            memberMap,
-            teamMap,
-            permissionMap,
-            tracker,
-            ingestionState,
-          )
         } else {
           console.log("skipping conversation", conversation)
         }

--- a/server/search/types.ts
+++ b/server/search/types.ts
@@ -455,10 +455,10 @@ export const VespaChatMessageSchema = z.object({
   // messageType: z.string(), // Slack type (e.g., "message")
   threadId: z.string().default(""), // Slack thread_ts, null if not in thread
   attachmentIds: z.array(z.string()).default([]), // Slack file IDs (e.g., ["F0857N0FF4N"])
-  permissions: z.array(z.string()), // emails of all from the workspace who have access to that channel
   // reactions: z.array(z.string()), // Commented out in Vespa schema, so excluded
   mentions: z.array(z.string()), // Extracted from text (e.g., ["U032QT45V53"])
   updatedAt: z.number(), // Slack edited.ts (e.g., 1734442538.0), null if not edited
+  deletedAt: z.number(),
   metadata: z.string(), // JSON string for subtype, etc. (e.g., "{\"subtype\": null}")
 })
 
@@ -507,6 +507,8 @@ export const VespaChatContainerSchema = z.object({
   isGeneral: z.boolean(),
   isIm: z.boolean(),
   isMpim: z.boolean(),
+
+  permissions: z.array(z.string()),
 
   createdAt: z.number(),
   updatedAt: z.number(),

--- a/server/search/types.ts
+++ b/server/search/types.ts
@@ -449,10 +449,15 @@ export const VespaChatMessageSchema = z.object({
   name: z.string(),
   username: z.string(),
   image: z.string(),
-  domain: z.string().optional(), // probably should be made mandatory but for now making optional
+  channelName: z.string().optional(), // derived
+  isIm: z.boolean().optional(), // derived
+  isMpim: z.boolean().optional(), // derived
+  isPrivate: z.boolean().optional(), // derived
+  permissions: z.array(z.string()).optional(), // derived,
+  teamName: z.string().optional(), // derived
+  domain: z.string().optional(), // derived
   createdAt: z.number(), // Slack ts (e.g., 1734442791.514519)
   teamRef: z.string(), // vespa id for team
-  // messageType: z.string(), // Slack type (e.g., "message")
   threadId: z.string().default(""), // Slack thread_ts, null if not in thread
   attachmentIds: z.array(z.string()).default([]), // Slack file IDs (e.g., ["F0857N0FF4N"])
   // reactions: z.array(z.string()), // Commented out in Vespa schema, so excluded
@@ -499,6 +504,7 @@ export const VespaChatUserSearchSchema = VespaChatUserSchema.extend({
 export const VespaChatContainerSchema = z.object({
   docId: z.string(),
   name: z.string(),
+  channelName: z.string(),
   creator: z.string(),
   app: z.nativeEnum(Apps),
 

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -43,6 +43,7 @@ import {
 } from "@/errors"
 import crypto from "crypto"
 import VespaClient from "@/search/vespaClient"
+import pLimit from "p-limit"
 const vespa = new VespaClient()
 
 // Define your Vespa endpoint and schema name
@@ -83,6 +84,41 @@ export const insertDocument = async (document: VespaFile) => {
       sources: fileSchema,
     })
   }
+}
+
+// Renamed to reflect its purpose: retrying a single insert
+export const insertWithRetry = async (
+  document: Inserts,
+  schema: VespaSchema,
+  maxRetries = 5,
+) => {
+  let lastError: any
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      await vespa.insert(document, { namespace: NAMESPACE, schema })
+      Logger.debug(`Inserted document ${document.docId}`)
+      return
+    } catch (error) {
+      lastError = error
+      if (
+        (error as Error).message.includes("429 Too Many Requests") &&
+        attempt < maxRetries
+      ) {
+        const delayMs = Math.min(Math.pow(2, attempt) * 1000, 10000) // Cap at 10s
+        Logger.warn(
+          `Vespa 429 for ${document.docId}, retrying in ${delayMs}ms (attempt ${attempt + 1})`,
+        )
+        await new Promise((resolve) => setTimeout(resolve, delayMs))
+      } else {
+        throw new Error(
+          `Error inserting document ${document.docId}: ${(error as Error).message}`,
+        )
+      }
+    }
+  }
+  throw new Error(
+    `Failed to insert ${document.docId} after ${maxRetries} retries: ${lastError.message}`,
+  )
 }
 
 // generic insert method
@@ -620,6 +656,17 @@ export const ifDocumentsExist = async (
   }
 }
 
+export const ifDocumentsExistInSchema = async (
+  schema: string,
+  docIds: string[],
+): Promise<Record<string, { exists: boolean; updatedAt: number | null }>> => {
+  try {
+    return await vespa.ifDocumentsExistInSchema(schema, docIds)
+  } catch (error) {
+    throw error
+  }
+}
+
 const getNDocuments = async (n: number) => {
   // Encode the YQL query to ensure it's URL-safe
   const yql = encodeURIComponent(
@@ -739,7 +786,7 @@ export const searchUsersByNamesAndEmails = async (
   }
 
   try {
-    return await vespa.getUsersByNamesAndEmaisl(searchPayload)
+    return await vespa.getUsersByNamesAndEmails(searchPayload)
   } catch (error) {
     throw error
   }

--- a/server/search/vespaClient.ts
+++ b/server/search/vespaClient.ts
@@ -57,9 +57,13 @@ class VespaClient {
           )
         }
 
-        // For 5xx errors or network issues, we retry it
-        if (response.status >= 500 && retryCount < this.maxRetries) {
-          await this.delay(this.retryDelay * Math.pow(2, retryCount)) // Exponential backoff
+        // Retry for 429 (Too Many Requests) or 5xx errors
+        if (
+          (response.status === 429 || response.status >= 500) &&
+          retryCount < this.maxRetries
+        ) {
+          Logger.info("retrying due to status: ", response.status)
+          await this.delay(this.retryDelay * Math.pow(2, retryCount))
           return this.fetchWithRetry(url, options, retryCount + 1)
         }
       }
@@ -189,7 +193,7 @@ class VespaClient {
         //   `Error inserting document ${document.docId} for ${options.schema} ${data.message}`,
         // )
         throw new Error(
-          `Failed to fetch documents: ${response.status} ${response.statusText} - ${errorText}`,
+          `Failed to  insert document: ${response.status} ${response.statusText} - ${errorText}`,
         )
       }
 
@@ -529,12 +533,71 @@ class VespaClient {
     }
   }
 
+  // TODO: Add pagination if docId's are more than
+  // max hits and merge the finaly Record
   async ifDocumentsExist(
     docIds: string[],
   ): Promise<Record<string, { exists: boolean; updatedAt: number | null }>> {
     // Construct the YQL query
     const yqlIds = docIds.map((id) => `"${id}"`).join(", ")
     const yqlQuery = `select docId, updatedAt from sources * where docId in (${yqlIds})`
+
+    const url = `${this.vespaEndpoint}/search/?yql=${encodeURIComponent(yqlQuery)}&hits=${docIds.length}&maxHits=${docIds.length}`
+
+    try {
+      const response = await this.fetchWithRetry(url, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+
+      if (!response.ok) {
+        const errorText = response.statusText
+        throw new Error(
+          `Search query failed: ${response.status} ${response.statusText} - ${errorText}`,
+        )
+      }
+
+      const result = await response.json()
+
+      // Extract found documents with their docId and updatedAt
+      const foundDocs =
+        result.root?.children?.map((hit: any) => ({
+          docId: hit.fields.docId as string,
+          updatedAt: hit.fields.updatedAt as number | undefined, // undefined if not present
+        })) || []
+
+      // Build the result map
+      const existenceMap = docIds.reduce(
+        (acc, id) => {
+          const foundDoc = foundDocs.find(
+            (doc: { docId: string }) => doc.docId === id,
+          )
+          acc[id] = {
+            exists: !!foundDoc,
+            updatedAt: foundDoc?.updatedAt ?? null, // null if not found or no updatedAt
+          }
+          return acc
+        },
+        {} as Record<string, { exists: boolean; updatedAt: number | null }>,
+      )
+
+      return existenceMap
+    } catch (error) {
+      const errMessage = getErrorMessage(error)
+      Logger.error(error, `Error checking documents existence:  ${errMessage}`)
+      throw error
+    }
+  }
+
+  async ifDocumentsExistInSchema(
+    schema: string,
+    docIds: string[],
+  ): Promise<Record<string, { exists: boolean; updatedAt: number | null }>> {
+    // Construct the YQL query
+    const yqlIds = docIds.map((id) => `"${id}"`).join(", ")
+    const yqlQuery = `select docId, updatedAt from sources ${schema} where docId in (${yqlIds})`
 
     const url = `${this.vespaEndpoint}/search/?yql=${encodeURIComponent(yqlQuery)}&hits=${docIds.length}`
 
@@ -585,7 +648,7 @@ class VespaClient {
     }
   }
 
-  async getUsersByNamesAndEmaisl<T>(payload: T) {
+  async getUsersByNamesAndEmails<T>(payload: T) {
     try {
       const response = await this.fetchWithRetry(
         `${this.vespaEndpoint}/search/`,

--- a/server/search/vespaClient.ts
+++ b/server/search/vespaClient.ts
@@ -541,15 +541,21 @@ class VespaClient {
     // Construct the YQL query
     const yqlIds = docIds.map((id) => `"${id}"`).join(", ")
     const yqlQuery = `select docId, updatedAt from sources * where docId in (${yqlIds})`
-
-    const url = `${this.vespaEndpoint}/search/?yql=${encodeURIComponent(yqlQuery)}&hits=${docIds.length}&maxHits=${docIds.length}`
+    const url = `${this.vespaEndpoint}/search/`
 
     try {
+      const payload = {
+        yql: yqlQuery,
+        hits: docIds.length,
+        maxHits: docIds.length + 1,
+      }
+
       const response = await this.fetchWithRetry(url, {
-        method: "GET",
+        method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
+        body: JSON.stringify(payload),
       })
 
       if (!response.ok) {

--- a/server/vespa/schemas/chat_container.sd
+++ b/server/vespa/schemas/chat_container.sd
@@ -13,6 +13,11 @@ schema chat_container {
             index: enable-bm25
         }
 
+        # non indexed name for chat_message import
+        field channelName type string {
+            indexing: attribute | summary
+        }
+
         field teamId type string {
             indexing: attribute | summary
         }

--- a/server/vespa/schemas/chat_container.sd
+++ b/server/vespa/schemas/chat_container.sd
@@ -37,6 +37,11 @@ schema chat_container {
             indexing: attribute | summary
         }
 
+        field permissions type array<string> {
+            indexing: attribute | summary
+            attribute: fast-search
+        }
+
         field isPrivate type bool {
             indexing: attribute | summary
         }

--- a/server/vespa/schemas/chat_message.sd
+++ b/server/vespa/schemas/chat_message.sd
@@ -111,8 +111,12 @@ schema chat_message {
     }
   }
   import field teamRef.domain as domain {}
+  import field teamRef.teamName as teamName {}
   import field chatRef.isPrivate as isPrivate {}
   import field chatRef.permissions as permissions {}
+  import field chatRef.channelName as  channelName {}
+  import field chatRef.isIm as isIm {}
+  import field chatRef.isMpim as isMpim {}
 
   field text_embeddings type tensor<bfloat16>(v[DIMS]) {
     indexing: input text | embed | attribute | index
@@ -122,7 +126,7 @@ schema chat_message {
   }
 
   fieldset default {
-    fields: text, mentions, teamId, channelId, userId, threadId, app, entity, attachmentIds, domain, isPrivate
+    fields: text, mentions, teamId, channelId, userId, threadId, app, entity, attachmentIds, domain, channelName, isPrivate
   }
 
   rank-profile initial {

--- a/server/vespa/schemas/chat_message.sd
+++ b/server/vespa/schemas/chat_message.sd
@@ -79,11 +79,6 @@ schema chat_message {
       indexing: attribute | summary
     }
 
-    field permissions type array<string> {
-      indexing: attribute | summary
-      attribute: fast-search
-    }
-
     field reactions type int {
       indexing: attribute | summary
     }

--- a/server/vespa/schemas/chat_message.sd
+++ b/server/vespa/schemas/chat_message.sd
@@ -101,12 +101,18 @@ schema chat_message {
       attribute: fast-search
     }
 
+    field deletedAt type double {
+      indexing: attribute | summary
+      attribute: fast-search
+    }
+
     field metadata type string {
       indexing: attribute | summary
     }
   }
   import field teamRef.domain as domain {}
   import field chatRef.isPrivate as isPrivate {}
+  import field chatRef.permissions as permissions {}
 
   field text_embeddings type tensor<bfloat16>(v[DIMS]) {
     indexing: input text | embed | attribute | index

--- a/server/vespa/schemas/chat_team.sd
+++ b/server/vespa/schemas/chat_team.sd
@@ -30,6 +30,11 @@ schema chat_team {
             index: enable-bm25
         }
 
+        # non indexed name for chat_message import
+        field teamName type string {
+            indexing: attribute | summary
+        }
+
         field app type string {
             indexing: attribute | summary
             attribute: fast-search


### PR DESCRIPTION
### Description

Fix the issue of search result of slack showing different image and name of the user.
Fix the issue of Team_id having the value undefined.

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Slack/Chat Messages as a searchable and contextual data type, including workspace, channel, and permission metadata.
  - Enhanced Slack message ingestion to improve user mention handling, team assignment, and conversation metadata.
  - Slack message citations now link directly to the relevant Slack message.

- **Improvements**
  - Slack message context descriptions now provide richer details, including channel type, thread info, and workspace membership.
  - Retry logic added for Vespa document insertion on rate limits, improving reliability.
  - Expanded chat schemas to include new metadata fields such as channel name, permissions, and deletion timestamps.
  - Simplified Slack ingestion flow by removing incremental state management and improving conversation and user info handling.

- **Bug Fixes**
  - Corrected typos in user search and API error messages.
  - Fixed formatting and labeling in Slack user stats and context prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->