### PR TITLE
fix(chats): Fix query rewrite

### DIFF
--- a/server/api/chat.ts
+++ b/server/api/chat.ts
@@ -514,9 +514,10 @@ async function* generateIterativeTimeFilterAndQueryRewrite(
       queryRewriteSpan.setAttribute("queries", JSON.stringify(queries))
       queryRewriteSpan.end()
       rewriteSpan.end()
-      for (const [queryIndex, query] of queries) {
-        const querySpan = pageSpan.startSpan(`query_${queryIndex}`)
-        querySpan.setAttribute("query_index", queryIndex)
+      for (let idx = 0; idx < queries.length; idx++) {
+        const query = queries[idx]
+        const querySpan = pageSpan.startSpan(`query_${idx}`)
+        querySpan.setAttribute("query_index", idx)
         querySpan.setAttribute("query_text", query)
 
         const latestSearchSpan = querySpan.startSpan("latest_results_search")
@@ -1417,9 +1418,9 @@ export const MessageApi = async (c: Context) => {
               costArr.push(chunk.cost)
             }
           }
-          conversationSpan.setAttribute("answer_found", parsed.answer);
-          conversationSpan.setAttribute("answer", answer);
-          conversationSpan.setAttribute("query_rewrite", parsed.queryRewrite);
+          conversationSpan.setAttribute("answer_found", parsed.answer)
+          conversationSpan.setAttribute("answer", answer)
+          conversationSpan.setAttribute("query_rewrite", parsed.queryRewrite)
 
           if (parsed.answer === null || parsed.answer === "") {
             const ragSpan = streamSpan.startSpan("rag_processing")
@@ -1507,7 +1508,10 @@ export const MessageApi = async (c: Context) => {
             )
             understandSpan.end()
             const answerSpan = ragSpan.startSpan("process_final_answer")
-            answerSpan.setAttribute("final_answer", processMessage(answer, citationMap))
+            answerSpan.setAttribute(
+              "final_answer",
+              processMessage(answer, citationMap),
+            )
             answerSpan.setAttribute("actual_answer", answer)
             answerSpan.setAttribute("final_answer_length", answer.length)
             answerSpan.end()


### PR DESCRIPTION
### Description

The previous destructuring in `for of loop` causing queries to be interpreted as single characters when they were actually strings.
This led to trace spans and query rewrites using only the single character of query.

Replaced with a index-based loop to ensure each query is correctly accessed
and its index properly set in the span attributes.


### Testing
Tested locally

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated code formatting for improved consistency, including changes to loop structure and attribute setting style. No changes to app functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->