### PR TITLE
fix(chat): delete chat

### DIFF
--- a/server/api/chat.ts
+++ b/server/api/chat.ts
@@ -82,7 +82,7 @@ import {
   type VespaUser,
 } from "@/search/types"
 import { APIError } from "openai"
-import { getChatTraceByExternalId, insertChatTrace } from "@/db/chatTrace"
+import { getChatTraceByExternalId, insertChatTrace ,deleteChatTracesByChatExternalId} from "@/db/chatTrace"
 const {
   JwtPayloadKey,
   chatHistoryPageSize,
@@ -191,6 +191,7 @@ export const ChatDeleteApi = async (c: Context) => {
     const { chatId } = c.req.valid("json")
     await db.transaction(async (tx) => {
       // First will have to delete all messages associated with that chat
+      await deleteChatTracesByChatExternalId(tx, chatId)
       await deleteMessagesByChatId(tx, chatId)
       await deleteChatByExternalId(tx, chatId)
     })
@@ -262,13 +263,10 @@ interface CitationResponse {
 }
 
 export const GetChatTraceApi = async (c: Context) => {
-  console.log(c)
   try {
     // @ts-ignore - Assume validation is handled by middleware in server.ts
     const { chatId, messageId } = c.req.valid("query")
-    console.log("chatId", chatId)
-    console.log("messageId", messageId)
-
+  
     if (!chatId || !messageId) {
       throw new HTTPException(400, {
         message: "chatId and messageId are required query parameters",

--- a/server/api/chat.ts
+++ b/server/api/chat.ts
@@ -190,8 +190,9 @@ export const ChatDeleteApi = async (c: Context) => {
     // @ts-ignore
     const { chatId } = c.req.valid("json")
     await db.transaction(async (tx) => {
-      // First will have to delete all messages associated with that chat
+      // First delete chat traces to avoid cascade violations
       await deleteChatTracesByChatExternalId(tx, chatId)
+      // Second we have to delete all messages associated with that chat
       await deleteMessagesByChatId(tx, chatId)
       await deleteChatByExternalId(tx, chatId)
     })

--- a/server/api/chat.ts
+++ b/server/api/chat.ts
@@ -82,7 +82,7 @@ import {
   type VespaUser,
 } from "@/search/types"
 import { APIError } from "openai"
-import { getChatTraceByExternalId, insertChatTrace ,deleteChatTracesByChatExternalId} from "@/db/chatTrace"
+import { getChatTraceByExternalId, insertChatTrace, deleteChatTracesByChatExternalId } from "@/db/chatTrace"
 const {
   JwtPayloadKey,
   chatHistoryPageSize,

--- a/server/db/chatTrace.ts
+++ b/server/db/chatTrace.ts
@@ -4,6 +4,7 @@ import type { InferInsertModel, InferSelectModel } from "drizzle-orm"
 import { z } from "zod"
 import { createInsertSchema } from "drizzle-zod"
 import { eq } from "drizzle-orm"
+import type { TxnOrClient } from "@/types"
 
 // Infer the schema, including workspaceId, userId, external IDs, and non-null traceJson
 export const insertChatTraceSchema = createInsertSchema(chatTrace).omit({
@@ -43,3 +44,10 @@ export async function getChatTraceByExternalId(
     )
   return trace
 }
+
+export const deleteChatTracesByChatExternalId = async (
+  tx: TxnOrClient,
+  chatExternalId: string,
+): Promise<void> => {
+  await tx.delete(chatTrace).where(eq(chatTrace.chatExternalId, chatExternalId));
+};


### PR DESCRIPTION
### Description
This fix handles the cascade violation introduced in PR https://github.com/xynehq/xyne/pull/389.
We didn't delete the chat trace when deleting a chat.

### Testing
Tested when chat_trace didn't exist as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured chat trace records are fully deleted when a chat is removed, preventing data inconsistencies.
- **Chores**
	- Removed debug logging from chat trace retrieval for cleaner operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->