### PR TITLE
fix(evals) : removing the dependence from the autoevals

### DIFF
--- a/eval-data/README.md
+++ b/eval-data/README.md
@@ -1,0 +1,40 @@
+# Test Queries Documentation
+
+## Overview
+This directory contains test queries used for evaluating the AI system's performance. The evaluation framework uses these queries to measure factuality and accuracy of the system's responses.
+
+## File Format
+Test queries are stored in JSON files, where each query is represented as an object with two required fields:
+- `input`: The query text that will be fed to the AI system
+- `expected`: The expected response that will be used to evaluate the system's answers
+
+Example format:
+```json
+[
+  {
+    "input": "what is my email",
+    "expected": "user@gmail.com"
+  }
+]
+```
+
+## Guidelines for Creating Effective Test Queries
+
+1. **Clarity & Specificity**: Make `input` queries clear and specific - ambiguous queries are hard to evaluate
+2. **Factual Correctness**: The `expected` answer should be factually correct and concise
+3. **Diversity**: Include a diverse range of query types (factual, temporal, personal, etc.)
+4. **Edge Cases**: Consider adding edge cases to thoroughly test the system
+5. **Personal Data**: For queries about personal data, ensure the expected answer matches the test user account
+6. **Objectivity**: Avoid queries that have subjective or multiple correct answers
+7. **Complexity Range**: Include both simple and complex queries to test different capabilities
+
+## Example Query Types
+
+- **Factual**: `{"input": "what is my email", "expected": "user@example.com"}`
+- **Temporal**: `{"input": "when was my last meeting", "expected": "Yesterday at 3pm with Marketing team"}`
+- **Personal**: `{"input": "what's my job title", "expected": "Senior Developer"}`
+- **Data Search**: `{"input": "find emails about project alpha", "expected": "Found 3 emails from last week about project alpha"}`
+
+## Usage
+
+These test queries are automatically used by the evaluation system to measure performance. To add new queries, simply add new objects to the array while following the guidelines above.

--- a/eval-data/test-queries.json
+++ b/eval-data/test-queries.json
@@ -1,0 +1,6 @@
+[
+  {
+    "input": "what is my email",
+    "expected": "user@gmail.com"
+  }
+]

--- a/server/ai/eval.ts
+++ b/server/ai/eval.ts
@@ -167,7 +167,8 @@ const Eval = async (
     console.log("Expected:", expected);
     
     try {
-      // Call OpenAI with our custom evaluation prompt
+      // Call OpenAI with the AutoEvals factuality prompt
+      // Source: https://github.com/braintrustdata/autoevals/blob/main/templates/factuality.yaml
       const response = await openai.chat.completions.create({
         model: "gpt-4o-mini",
         messages: [

--- a/server/ai/eval.ts
+++ b/server/ai/eval.ts
@@ -151,9 +151,11 @@ const Eval = async (
   const data = config.data()
   
   // Create OpenAI client
-  const openai = new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY,
-  });
+  const openAiKey = process.env.OPENAI_API_KEY;
+  if (!openAiKey) {
+    throw new Error("OPENAI_API_KEY env var is not set – cannot run evaluations");
+  }
+  const openai = new OpenAI({ apiKey: openAiKey });
   
   // Custom LLM-based factuality scorer
   const customFactualityScorer = async (params) => {
@@ -221,7 +223,7 @@ RESPOND WITH ONLY THE LETTER (A, B, C, D, or E) that best describes the relation
     } catch (error) {
       console.error("Evaluation API error:", error.message);
       // Return a default score rather than failing
-      return { score: 0.5 };
+      return { score: 0 };
     }
   };
   
@@ -312,7 +314,7 @@ RESPOND WITH ONLY THE LETTER (A, B, C, D, or E) that best describes the relation
         } catch (error: any) {
           console.log(`Evaluation error (attempt ${attempts}): ${error.message}`)
           if (attempts === 5) {
-            factuality = { score: 0.1 } // Default score after max attempts
+            factuality = { score: 0.5 } // Default score after max attempts
           }
         }
       }

--- a/server/ai/prompts.ts
+++ b/server/ai/prompts.ts
@@ -686,10 +686,11 @@ export const searchQueryPrompt = (userContext: string): string => {
   return `
       basic user context: ${userContext}
       You are a conversation manager. When a user sends a query, follow these rules:
-    1. Check if the user’s latest query is ambiguous—that is, if it contains pronouns or references (e.g. "he", "she", "they", "it", "the project", "the design doc") that cannot be understood without prior context.
-       - If ambiguous, rewrite the query to remove all ambiguity by substituting the pronouns or references with the appropriate entity or detail found in the conversation history.
-       - If not ambiguous, leave the query as is.
-       - do not append the company name or domain to the search query unnecessarily
+    1. Check if the user’s latest query is ambiguous. THIS IS VERY IMPORTANT. A query is ambiguous if
+      a) It contains pronouns or references (e.g. "he", "she", "they", "it", "the project", "the design doc") that cannot be understood without prior context, OR
+      b) It's an instruction or command that doesn't have any CONCREATE REFERENCE.
+      - If ambiguous according to either (a) or (b), rewrite the query to resolve the dependency. For case (a), substitute pronouns/references. For case (b), incorporate the essence of the previous assistant response into the query. Store the rewritten query in "queryRewrite".
+      - If not ambiguous, leave the query as it is.
     2. Determine if the user’s query is conversational or a basic calculation. Examples include greetings like:
        - "Hi"
        - "Hello"
@@ -736,11 +737,13 @@ export const searchQueryReasoningPrompt = (userContext: string): string => {
   <answer>
       basic user context: ${userContext}
       You are a conversation manager for a retrieval-augmented generation (RAG) pipeline. When a user sends a query, follow these rules:
-    1. please while thinking do not show these steps as they are more hidden and internal. Do not mention the step number, do not explain the structure of your output as user does not need to know that.
+    1. Please while thinking do not show these steps as they are more hidden and internal. Do not mention the step number, do not explain the structure of your output as user does not need to know that.
        do not mention queryRewrite is null. Most important keep thinking short for this step as it's a decison node.
-    2. Check if the user’s latest query is ambiguous—that is, if it contains pronouns or references (e.g. "he", "she", "they", "it", "the project", "the design doc") that cannot be understood without prior context.
-       - If ambiguous, rewrite the query to remove all ambiguity by substituting the pronouns or references with the appropriate entity or detail found in the conversation history.
-       - If not ambiguous, leave the query as is.
+    2. Check if the user’s latest query is ambiguous. THIS IS VERY IMPORTANT. A query is ambiguous if
+      a) It contains pronouns or references (e.g. "he", "she", "they", "it", "the project", "the design doc") that cannot be understood without prior context, OR
+      b) It's an instruction or command that doesn't have any CONCREATE REFERENCE.
+      - If ambiguous according to either (a) or (b), rewrite the query to resolve the dependency. For case (a), substitute pronouns/references. For case (b), incorporate the essence of the previous assistant response into the query. Store the rewritten query in "queryRewrite".
+      - If not ambiguous, leave the query as it is.
     3. Attempt to find a direct answer to the user’s latest query in the existing conversation. If the query is a basic conversation starter (e.g., "Hi", "Hello", "Hey", "How are you?", "Good morning"), respond naturally.
       - If it is a regular conversational statement, provide an appropriate response.
       - or a basic calculation like: what is the time in Japan

--- a/server/api/chat.ts
+++ b/server/api/chat.ts
@@ -1417,6 +1417,7 @@ export const MessageApi = async (c: Context) => {
               costArr.push(chunk.cost)
             }
           }
+
           conversationSpan.setAttribute("answer_found", parsed.answer)
           conversationSpan.setAttribute("answer", answer)
           conversationSpan.setAttribute("query_rewrite", parsed.queryRewrite)
@@ -1428,6 +1429,7 @@ export const MessageApi = async (c: Context) => {
                 `The query is ambigious and requires a mandatory query rewrite from the existing conversation / recent messages ${parsed.queryRewrite}`,
               )
               message = parsed.queryRewrite
+              Logger.info(`Rewritten query: ${message}`)
               ragSpan.setAttribute("query_rewrite", parsed.queryRewrite)
             } else {
               Logger.info(


### PR DESCRIPTION
### Removing the independence from the `autoevals` and adding the `eval-data` folder

- Prompt is added manually. No need for importing the dependency from the autoevals.
- Test queries can be added into the `eval-data` folder to make it convenient for everyone to test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Added documentation outlining the structure and guidelines for creating test queries used in AI evaluation.
    - Introduced a sample JSON file with a test query for evaluating system responses.

- **Refactor**
    - Replaced the previous factuality scoring system with a custom OpenAI-based factuality evaluation.
    - Improved error handling, logging, and tracing during the evaluation process.
    - Updated prompt instructions to better handle and rewrite ambiguous user queries.

- **Chores**
    - Enhanced data loading for evaluation and updated configuration to reflect new scoring logic.
    - Added detailed logging around query rewriting during conversation search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->