### PR TITLE
feat(vespa): random rank-profile

### DIFF
--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -225,7 +225,7 @@ const getProviderMap = (): Partial<Record<AIProviders, LLMProvider>> => {
   return providerMap
 }
 
-const getProviderByModel = (modelId: Models): LLMProvider => {
+export const getProviderByModel = (modelId: Models): LLMProvider => {
   const ProviderMap = getProviderMap()
 
   const providerType = ModelToProviderMap[modelId]

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -255,6 +255,7 @@ export enum SearchModes {
   NativeRank = "default_native",
   BM25 = "default_bm25",
   AI = "default_ai",
+  Random = "default_random",
 }
 
 type YqlProfile = {
@@ -478,6 +479,7 @@ type VespaQueryConfig = {
   rankProfile: SearchModes
   requestDebug: boolean
   span: Span | null
+  maxHits: number
 }
 
 export const searchVespa = async (
@@ -495,6 +497,7 @@ export const searchVespa = async (
     rankProfile = SearchModes.NativeRank,
     requestDebug = false,
     span = null,
+    maxHits = 400,
   }: Partial<VespaQueryConfig>,
 ): Promise<VespaSearchResponse> => {
   // Determine the timestamp cutoff based on lastUpdated
@@ -518,6 +521,7 @@ export const searchVespa = async (
     "ranking.profile": profile,
     "input.query(e)": "embed(@query)",
     "input.query(alpha)": alpha,
+    maxHits,
     hits: limit,
     ...(offset
       ? {

--- a/server/vespa/schemas/chat_message.sd
+++ b/server/vespa/schemas/chat_message.sd
@@ -247,6 +247,22 @@ schema chat_message {
     }
   }
 
+  rank-profile default_random inherits initial {
+
+    first-phase {
+        expression: random.match
+    }
+
+    match-features {
+      matchedFieldCount
+      vector_score
+      combined_nativeRank
+      nativeRank(text)
+      nativeRank(username)
+      nativeRank(name)
+    }
+  }
+
  rank-profile unranked inherits default {
     # Simple constant expression - returns same score for all documents
     first-phase {

--- a/server/vespa/schemas/event.sd
+++ b/server/vespa/schemas/event.sd
@@ -302,6 +302,20 @@ schema event {
           nativeRank(attendeesNames)
         }
     }
+    rank-profile default_random inherits initial {
+        first-phase {
+            expression: random.match
+        }
+
+        match-features {
+          combined_nativeRank
+          vector_score
+          nativeRank(name)
+          nativeRank(description)
+          nativeRank(attachmentFilenames)
+          nativeRank(attendeesNames)
+        }
+    }
     
     document-summary default {
         summary description {

--- a/server/vespa/schemas/file.sd
+++ b/server/vespa/schemas/file.sd
@@ -233,6 +233,20 @@ schema file {
     }
   }
 
+  rank-profile default_random inherits initial {
+    first-phase {
+        expression: random.match
+    }
+    match-features {
+      vector_score
+      combined_nativeRank
+      nativeRank(title)
+      nativeRank(chunks)
+      chunk_scores
+      doc_recency
+    }
+  }
+
   document-summary default {
     summary chunks_summary {
       bolding: on

--- a/server/vespa/schemas/mail.sd
+++ b/server/vespa/schemas/mail.sd
@@ -255,6 +255,21 @@ schema mail {
     }
   }
 
+  rank-profile default_random inherits initial {
+    first-phase {
+        expression: random.match
+    }
+
+    match-features {
+      matchedFieldCount
+      vector_score
+      combined_nativeRank
+      nativeRank(subject)
+      nativeRank(chunks)
+      chunk_scores
+    }
+  }
+
   document-summary default {
     summary subject {}
     summary chunks_summary {

--- a/server/vespa/schemas/mail_attachment.sd
+++ b/server/vespa/schemas/mail_attachment.sd
@@ -223,6 +223,21 @@ schema mail_attachment {
     }
   }
 
+  rank-profile default_random inherits initial {
+    first-phase {
+      expression: random.match
+    }
+
+    match-features {
+      matchedFieldCount
+      vector_score
+      combined_nativeRank
+      nativeRank(filename)
+      nativeRank(chunks)
+      chunk_scores
+    }
+  }
+
   document-summary default {
     summary filename {}
     summary chunks_summary {

--- a/server/vespa/schemas/user.sd
+++ b/server/vespa/schemas/user.sd
@@ -265,6 +265,19 @@ schema user {
         }
     }
 
+    rank-profile default_random inherits initial {
+        first-phase {
+            expression: random.match
+        }
+
+        match-features {
+            matchedFieldCount
+            nativeRank(name)
+            nativeRank(email)
+            vector_score
+        }
+    }
+
      rank-profile autocomplete {
         first-phase {
             expression: bm25(name_fuzzy) + bm25(email_fuzzy)


### PR DESCRIPTION
### Description
This PR addresses dependency for `work-evals` and added following updates:

- Exported the `getProviderByModel` function
- Added a new random rank profile to support random document retrieval
- Added support for the maxHits parameter in searchVespa
### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Random" search mode that allows search results to be returned in a randomized order across various content types.
  - Added the ability to control the maximum number of search results returned.

- **Improvements**
  - Enhanced search configuration options for greater flexibility in result ranking and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->