### PR TITLE
feat(temporal-window-fix)

### DIFF
--- a/server/ai/prompts.ts
+++ b/server/ai/prompts.ts
@@ -716,12 +716,31 @@ export const searchQueryPrompt = (userContext: string): string => {
        - If the user asks for events within a range of time (e.g., "from April 1st to April 10th"), set:
          "temporalDirection": { "direction": "from-to", "from": "<start date>", "to": "<end date>" }
 
-       - If the user asks for events only on a specific date (e.g., "on April 1st"), set:
-         "temporalDirection": { "direction": "from-to", "from": "<date>", "to": "<same date>" }
+       - If the user asks for events on a **specific date** (e.g., "on April 1st") or uses **relative terms** like:
+         - "tomorrow"
+         - "yesterday"
+         - "on Monday"
 
-       - When using specific dates, format "from" as the **start of the day** in ISO 8601 (e.g., "2025-04-23T00:00:00.000Z") and "to" as the **end of the day** (e.g., "2025-04-23T23:59:59.999Z").
+         Then also use:
+         "temporalDirection": { 
+           "direction": "from-to", 
+           "from": "<start of that day in ISO 8601 at 00:00:00.000Z>", 
+           "to": "<end of that day in ISO 8601 at 23:59:59.999Z>" 
+         }
 
-       - If none of the above apply, set "temporalDirection" to null.
+         - For "tomorrow", use:
+           from = date of tomorrow at "T00:00:00.000Z"
+           to = same date at "T23:59:59.999Z"
+
+         - For "yesterday", use:
+           from = date of yesterday at "T00:00:00.000Z"
+           to = same date at "T23:59:59.999Z"
+
+       - When using any specific or relative dates, **always format**:
+         - "from" as "YYYY-MM-DDT00:00:00.000Z"
+         - "to" as "YYYY-MM-DDT23:59:59.999Z"
+
+       - If none of the above apply, set "temporalDirection" to "null".
 
     5. Output JSON in the following structure:
        {

--- a/server/ai/prompts.ts
+++ b/server/ai/prompts.ts
@@ -698,33 +698,57 @@ export const searchQueryPrompt = (userContext: string): string => {
        If the query is conversational, respond naturally and appropriately. 
     3. If the user’s query is about the conversation itself (e.g., “What did I just now ask?”, “What was my previous question?”, “Could you summarize the conversation so far?”, “Which topic did we discuss first?”, etc.), use the conversation history to answer if possible.
     4. Determine if the query is about tracking down a calendar event or email interaction that either last occurred or will next occur.
-      - If asking about an upcoming event or meeting, set "temporalDirection" to "next". For example:
-        - ✓ "When is my next meeting with John?"
-        - ✓ "When's my next review?"
-        - ✗ "Next quarter's goals"
-        - ✗ "Next version release"
+       - If asking about an upcoming event or meeting, set "temporalDirection" to { "direction": "next" }.
+         Examples:
+         - ✓ "When is my next meeting with John?"
+         - ✓ "When's my next review?"
+         - ✗ "Next quarter's goals"
+         - ✗ "Next version release"
 
-       - If asking about a past event or meeting,set "temporalDirection" to "prev". For example:
-       - ✓ " When was the last time I had lunch with the team"
-       - ✓ "When was my last call with Sarah?"
-       - ✓ "Previous board meeting date"
-       - ✗ "When did junaid join?",
-       - ✗ "Last time we updated the docs"
-       - Otherwise, set "temporalDirection" to null.
+       - If asking about a past event or meeting, set "temporalDirection" to { "direction": "prev" }.
+         Examples:
+         - ✓ "When was the last time I had lunch with the team?"
+         - ✓ "When was my last call with Sarah?"
+         - ✓ "Previous board meeting date"
+         - ✗ "When did Junaid join?"
+         - ✗ "Last time we updated the docs"
+
+       - If the user asks for events within a range of time (e.g., "from April 1st to April 10th"), set:
+         "temporalDirection": { "direction": "from-to", "from": "<start date>", "to": "<end date>" }
+
+       - If the user asks for events only on a specific date (e.g., "on April 1st"), set:
+         "temporalDirection": { "direction": "from-to", "from": "<date>", "to": "<same date>" }
+
+       - When using specific dates, format "from" as the **start of the day** in ISO 8601 (e.g., "2025-04-23T00:00:00.000Z") and "to" as the **end of the day** (e.g., "2025-04-23T23:59:59.999Z").
+
+       - If none of the above apply, set "temporalDirection" to null.
+
     5. Output JSON in the following structure:
        {
          "answer": "<string or null>",
          "queryRewrite": "<string or null>",
-         "temporalDirection": "next" | "prev" | null
+         "temporalDirection": {
+           "direction": "next" | "prev" | "from-to" | null,
+           "from": "<string or null>",
+           "to": "<string or null>"
+         }
        }
        - "answer" should only contain a conversational response only if it’s a greeting or a conversational statement or basic calculation. Otherwise, "answer" must be null.
        - "queryRewrite" should contain the fully resolved query only if there was ambiguity. Otherwise, "queryRewrite" must be null.
-       - "temporalDirection" indicates if the query refers to an upcoming ("next") or past ("prev") event, or null if unrelated.
+       - "temporalDirection" indicates if the query refers to:
+         - a future event ("next")
+         - a past event ("prev")
+         - a specific date or range ("from-to", with "from" and "to" specified)
+         - or is unrelated (null)
+
     6. If there is no ambiguity and no direct answer in the conversation, both "answer" and "queryRewrite" must be null.
-    7. If user makes a statement leading to a regular conversation then you can put response in answer
+
+    7. If user makes a statement leading to a regular conversation, then you can put a response in the answer.
+
     Make sure you always comply with these steps and only produce the JSON output described.
   `
 }
+
 
 export const searchQueryReasoningPrompt = (userContext: string): string => {
   return `

--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -1031,6 +1031,8 @@ export const temporalEventClassification = async (
     const parsedResponse = jsonParseLLMOutput(text)
     return {
       direction: parsedResponse.direction || null,
+      from: null,
+      to: null,
       cost: cost!,
     }
   } else {

--- a/server/ai/types.ts
+++ b/server/ai/types.ts
@@ -55,10 +55,14 @@ export type Cost = {
   pricePerThousandOutputTokens: number
 }
 
-export type TimeDirection = "next" | "prev"
+export type TimeDirection = "next" | "prev" | "from-to" | null;
 export interface TemporalClassifier {
-  direction: TimeDirection | null
+  direction: TimeDirection | null,
+  from: string | null;
+  to: string | null;
 }
+
+
 
 export interface ModelParams {
   max_new_tokens?: number

--- a/server/ai/types.ts
+++ b/server/ai/types.ts
@@ -55,14 +55,12 @@ export type Cost = {
   pricePerThousandOutputTokens: number
 }
 
-export type TimeDirection = "next" | "prev" | "from-to" | null;
+export type TimeDirection = "next" | "prev" | "from-to" | null
 export interface TemporalClassifier {
-  direction: TimeDirection | null,
-  from: string | null;
-  to: string | null;
+  direction: TimeDirection | null
+  from: string | null
+  to: string | null
 }
-
-
 
 export interface ModelParams {
   max_new_tokens?: number

--- a/server/api/chat.ts
+++ b/server/api/chat.ts
@@ -956,7 +956,7 @@ async function* generatePointQueryTimeExpansion(
     let lastSearchedTime = direction === "prev" ? from : to
 
     let previousResultsLength = 0
-    const loopLimit = direction === "from-to" ? 1 : maxIterations;
+    const loopLimit = direction === "from-to" ? 2 : maxIterations;
 
     for (let iteration = 0; iteration < loopLimit; iteration++) {
         const windowSize = (2 + iteration) * weekInMs
@@ -964,7 +964,6 @@ async function* generatePointQueryTimeExpansion(
         if (direction === "prev") {
           to = lastSearchedTime
           from = to - windowSize
-          Logger.info(`Time given : ${to} and ${from}`)
           lastSearchedTime = from
         } else if(direction === "next") {
           from = lastSearchedTime

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -241,10 +241,12 @@ export const hashPdfFilename = (filename: string): string => {
   return newFilename
 }
 
-export const interpretDateFromReturnedTemporalValue = (value: TemporalClassifier) => {
+export const interpretDateFromReturnedTemporalValue = (
+  value: TemporalClassifier,
+) => {
   // Convert UTC timestamps to local time zone
-  const from = value.from ? new Date(value.from) : null;
-  const to = value.to ? new Date(value.to) : null;
-    
-  return { fromDate: from, toDate: to };
+  const from = value.from ? new Date(value.from) : null
+  const to = value.to ? new Date(value.to) : null
+
+  return { fromDate: from, toDate: to }
 }

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -8,6 +8,7 @@ import { stopwords as englishStopwords } from "@orama/stopwords/english"
 import { Apps } from "@/search/types"
 import type { OAuth2Client } from "google-auth-library"
 import crypto from "node:crypto"
+import type { TemporalClassifier } from "@/ai/types"
 
 const Logger = getLogger(Subsystem.Utils)
 
@@ -239,3 +240,15 @@ export const hashPdfFilename = (filename: string): string => {
   Logger.info(`Filename hashed: ${filename} -> ${newFilename}`)
   return newFilename
 }
+
+  export const interpretDateFromReturnedTemporalValue = (value: TemporalClassifier) => {
+
+    const from = value.from ? new Date(value.from) : null
+    const to = value.to ? new Date(value.to) : null
+
+    return {
+      fromDate: from,
+      toDate: to
+    }
+
+  }

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -241,14 +241,21 @@ export const hashPdfFilename = (filename: string): string => {
   return newFilename
 }
 
-  export const interpretDateFromReturnedTemporalValue = (value: TemporalClassifier) => {
-
-    const from = value.from ? new Date(value.from) : null
-    const to = value.to ? new Date(value.to) : null
-
-    return {
-      fromDate: from,
-      toDate: to
-    }
-
+export const interpretDateFromReturnedTemporalValue = (value: TemporalClassifier) => {
+  // Convert UTC timestamps to local time zone
+  const from = value.from ? new Date(value.from) : null;
+  const to = value.to ? new Date(value.to) : null;
+  
+  // Ensure dates are interpreted in the local time zone
+  if (from) {
+    // Convert to the local time with the same time values
+    from.setMinutes(from.getMinutes() + from.getTimezoneOffset());
   }
+  
+  if (to) {
+    // Convert to the local time with the same time values
+    to.setMinutes(to.getMinutes() + to.getTimezoneOffset());
+  }
+  
+  return { fromDate: from, toDate: to };
+}

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -245,17 +245,6 @@ export const interpretDateFromReturnedTemporalValue = (value: TemporalClassifier
   // Convert UTC timestamps to local time zone
   const from = value.from ? new Date(value.from) : null;
   const to = value.to ? new Date(value.to) : null;
-  
-  // Ensure dates are interpreted in the local time zone
-  if (from) {
-    // Convert to the local time with the same time values
-    from.setMinutes(from.getMinutes() + from.getTimezoneOffset());
-  }
-  
-  if (to) {
-    // Convert to the local time with the same time values
-    to.setMinutes(to.getMinutes() + to.getTimezoneOffset());
-  }
-  
+    
   return { fromDate: from, toDate: to };
 }


### PR DESCRIPTION
### Description

Related to this backlog :  https://github.com/orgs/xynehq/projects/2?pane=issue&itemId=107595131 

Brief Description : Previously we had only two directions (`prev` - for past temporal searches and `next` - for future temporal searches). This was not handling specific time range searches, that is, if someone specifically asked for data of a specific date or date range, it would search for a long time window.

Solution : Fixed handling case for specific time range (now the app searches only for the provided search date) - and if the user doesn't give a date, it proceeds with the normal flow.

### Testing

Tested changes locally

### Additional Notes

None
