### PR TITLE
fix(json): bug introduced in the clean up function being lenient

### DIFF
--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -369,16 +369,17 @@ export const analyzeQueryMetadata = async (
   }
 }
 
-// better to parametr
+const nullCloseBraceRegex = /null\s*\n\s*\}/
 export const jsonParseLLMOutput = (text: string, jsonKey?: string): any => {
   let jsonVal
   try {
     text = text.trim()
     // edge case "null\n}
-    if(text.indexOf("}") !== -1 && text.trim().includes(`null\n`)) {
+    if (text.indexOf("{") === -1 && nullCloseBraceRegex.test(text)) {
+      console.log("here1")
       text = text.replaceAll("\n", "")
       text = text.replaceAll('"', "")
-      text = text.replaceAll('}', "")
+      text = text.replaceAll("}", "")
     }
     // If the trimmed text does not start with '{' but contains jsonKey, wrap it in braces
     if (jsonKey && !text.startsWith("{") && text.includes(jsonKey)) {
@@ -422,10 +423,10 @@ export const jsonParseLLMOutput = (text: string, jsonKey?: string): any => {
         jsonVal = parse(withNewLines.trim())
       }
       // edge case "null\n}
-      if(jsonKey) {
-        const key = jsonKey.slice(0, -1).replaceAll('"',"")
-        if(jsonVal[key].trim() === "null") {
-          jsonVal = {[key]: null}
+      if (jsonKey) {
+        const key = jsonKey.slice(0, -1).replaceAll('"', "")
+        if (jsonVal[key].trim() === "null") {
+          jsonVal = { [key]: null }
         }
       }
       return jsonVal

--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -376,7 +376,6 @@ export const jsonParseLLMOutput = (text: string, jsonKey?: string): any => {
     text = text.trim()
     // edge case "null\n}
     if (text.indexOf("{") === -1 && nullCloseBraceRegex.test(text)) {
-      console.log("here1")
       text = text.replaceAll("\n", "")
       text = text.replaceAll('"', "")
       text = text.replaceAll("}", "")

--- a/server/api/chat.ts
+++ b/server/api/chat.ts
@@ -373,6 +373,10 @@ export const processMessage = (
   text: string,
   citationMap: Record<number, number>,
 ) => {
+  if (!text) {
+    return ""
+  }
+
   text = splitGroupedCitationsWithSpaces(text)
   return text.replace(textToCitationIndex, (match, num) => {
     const index = citationMap[num]

--- a/server/package.json
+++ b/server/package.json
@@ -24,8 +24,8 @@
     "format": "bunx biome format --write ../"
   },
   "dependencies": {
-    "@aws-sdk/client-bedrock": "^3.721.0",
-    "@aws-sdk/client-bedrock-runtime": "^3.721.0",
+    "@aws-sdk/client-bedrock": "^3.797.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.797.0",
     "@google/generative-ai": "^0.21.0",
     "@hono/event-emitter": "^2.0.0",
     "@hono/oauth-providers": "^0.6.2",


### PR DESCRIPTION
### Description
So just to handle the weird case of `null\n }` which LLM generated once I added an if condition that was matching all the conversations/json. So now made it more regex based.

### Testing
tested manually