### PR TITLE
feat(search): Recency for search results

### DIFF
--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -521,6 +521,7 @@ export const searchVespa = async (
     "ranking.profile": profile,
     "input.query(e)": "embed(@query)",
     "input.query(alpha)": alpha,
+    "input.query(recency_decay_rate)": 0.02,
     maxHits,
     hits: limit,
     ...(offset

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -480,6 +480,7 @@ type VespaQueryConfig = {
   requestDebug: boolean
   span: Span | null
   maxHits: number
+  recencyDecayRate: number
 }
 
 export const searchVespa = async (
@@ -498,6 +499,7 @@ export const searchVespa = async (
     requestDebug = false,
     span = null,
     maxHits = 400,
+    recencyDecayRate = 0.02
   }: Partial<VespaQueryConfig>,
 ): Promise<VespaSearchResponse> => {
   // Determine the timestamp cutoff based on lastUpdated
@@ -521,7 +523,7 @@ export const searchVespa = async (
     "ranking.profile": profile,
     "input.query(e)": "embed(@query)",
     "input.query(alpha)": alpha,
-    "input.query(recency_decay_rate)": 0.02,
+    "input.query(recency_decay_rate)": recencyDecayRate,
     maxHits,
     hits: limit,
     ...(offset

--- a/server/vespa/schemas/event.sd
+++ b/server/vespa/schemas/event.sd
@@ -160,6 +160,7 @@ schema event {
         inputs {
             query(e) tensor<bfloat16>(v[DIMS])
             query(alpha) double 
+            query(recency_decay_rate) double
         }
 
         constants {
@@ -174,13 +175,13 @@ schema event {
         }
 
         function document_age() {
-            # Default document age assuming to 3 months when no createdAt timestamp is present
-            expression: max(if(isNan(attribute(createdAt)) == 1, THREE_MONTHS_IN_SECONDS, now() - (attribute(createdAt) / 1000)) / ONE_YEAR_IN_SECONDS, 0)
+            # Default document age assuming to 3 months when no updatedAt timestamp is present
+            expression: max(if(isNan(attribute(updatedAt)) == 1, THREE_MONTHS_IN_SECONDS, now() - (attribute(updatedAt) / 1000)) / ONE_YEAR_IN_SECONDS, 0)
         }
 
         # Document score decays min to 0.5
         function doc_recency() {
-            expression: max(1 / (1 + query(beta) * sqrt(document_age)), MAX_DOC_DECAY)
+            expression: max(1 / (1 + query(recency_decay_rate) * sqrt(document_age)), MAX_DOC_DECAY)
         }
 
         function vector_score() {
@@ -228,12 +229,13 @@ schema event {
               (
                 (query(alpha) * vector_score) + 
                 ((1 - query(alpha)) *  combined_nativeRank)
-              )
+              ) * doc_recency
             }
             rerank-count: 1000
         }
 
         match-features {
+          doc_recency
           matchedFieldCount
           combined_nativeRank
           vector_score

--- a/server/vespa/schemas/file.sd
+++ b/server/vespa/schemas/file.sd
@@ -101,6 +101,7 @@ schema file {
     inputs {
       query(e) tensor<bfloat16>(v[DIMS])  # Query embedding
       query(alpha) double  # Alpha parameter for hybrid weight
+      query(recency_decay_rate) double
     }
 
     constants {
@@ -121,7 +122,7 @@ schema file {
 
     # Document score decays min to 0.5
     function doc_recency() {
-      expression: max(1 / (1 + 0.5 * document_age), MAX_DOC_DECAY)
+        expression: max(1 / (1 + query(recency_decay_rate) * sqrt(document_age)), MAX_DOC_DECAY)
     }
 
     function vector_score() {
@@ -160,7 +161,7 @@ schema file {
         (
           (query(alpha) * vector_score) + 
           ((1 - query(alpha)) *  combined_nativeRank)
-        )
+        ) * doc_recency
       }
       rerank-count: 1000
     }

--- a/server/vespa/schemas/mail.sd
+++ b/server/vespa/schemas/mail.sd
@@ -126,6 +126,7 @@ schema mail {
       inputs {
         query(e) tensor<bfloat16>(v[DIMS])  # Query embedding
         query(alpha) double  # Alpha parameter for hybrid weight
+        query(recency_decay_rate) double
       }
 
       constants {
@@ -145,7 +146,7 @@ schema mail {
 
       # Document score decays min to 0.5
       function doc_recency() {
-        expression: max(1 / (1 + 0.5 * document_age), MAX_DOC_DECAY)
+        expression: max(1 / (1 + query(recency_decay_rate) * sqrt(document_age)), MAX_DOC_DECAY)
       }
       
       function vector_score() {
@@ -184,12 +185,13 @@ schema mail {
           (
             (query(alpha) * vector_score) + 
             ((1 - query(alpha)) *  combined_nativeRank)
-          )
+          ) * doc_recency
         }
         rerank-count: 1000
       }
 
     match-features {
+      doc_recency
       matchedFieldCount
       vector_score
       combined_nativeRank

--- a/server/vespa/schemas/mail_attachment.sd
+++ b/server/vespa/schemas/mail_attachment.sd
@@ -94,6 +94,7 @@ schema mail_attachment {
     inputs {
       query(e) tensor<bfloat16>(v[DIMS])
       query(alpha) double
+      query(recency_decay_rate) double
     }
 
     constants {
@@ -113,7 +114,7 @@ schema mail_attachment {
 
     # Document score decays min to 0.5
     function doc_recency() {
-        expression: max(1 / (1 + 0.5 * document_age), MAX_DOC_DECAY)
+      expression: max(1 / (1 + query(recency_decay_rate) * sqrt(document_age)), MAX_DOC_DECAY)
     }
 
     function vector_score() {
@@ -151,12 +152,13 @@ schema mail_attachment {
         0.8 * (
           (query(alpha) * vector_score) + 
           ((1 - query(alpha)) * combined_nativeRank)
-        )
+        ) * doc_recency
       }
       rerank-count: 1000
     }
 
     match-features {
+      doc_recency
       matchedFieldCount
       vector_score
       combined_nativeRank


### PR DESCRIPTION
### Description
- Added `recency_decay_rate` parameter for vespa to tune document recency
- Penalize older documents to improve result freshness

### Testing
Locally

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced recency-based ranking across search results, allowing newer documents to be prioritized using a configurable decay rate.
- **Improvements**
    - Enhanced recency calculations to use the last updated time for more accurate document age assessment.
    - Exposed recency scoring details for improved transparency in ranking and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->