### PR TITLE
fix(streaming):  backslash would get replaced by Quotes due to partial library

### DIFF
--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -425,6 +425,19 @@ export const jsonParseLLMOutput = (text: string, jsonKey?: string): any => {
         })
         jsonVal = parse(withNewLines.trim())
       }
+
+      /* Edge case: If the last two characters are \\", Json.parse replaces \\ with ". We need to remove the last " from the value.
+          Example:
+          Input text: '{"answer": "Prasad \\""}'
+          After JSON.parse: { answer: 'Prasad "' }  // Note the extra quote at the end
+          After this fix: { answer: 'Prasad' }     // Extra quote removed
+          
+          This happens because: The original string has an escaped quote: \\".JSON.parse converts \\ to \ and " to ", resulting in an extra quote.
+      */
+      if (jsonKey && text.slice(-2) === `\\"` && jsonVal[jsonKey.slice(1, -2)][jsonVal[jsonKey.slice(1, -2)].length - 1] === `"`) {
+        jsonVal[jsonKey.slice(1, -2)] = jsonVal[jsonKey.slice(1, -2)].slice(0, -1)
+      }
+
       // edge case "null\n}
       if (jsonKey) {
         const key = jsonKey.slice(0, -1).replaceAll('"', "")

--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -401,7 +401,7 @@ export const jsonParseLLMOutput = (text: string, jsonKey?: string): any => {
     }
     // we only want to do this if enough text has accumulated
     // we don't want to do case where just `json` comes and we wrap it as answer
-    if (startBrace === -1 && jsonKey && text.length > 10) {
+    if (startBrace === -1 && jsonKey && text.trim() !== "json") {
       if (text.trim() === "answer null" && jsonKey) {
         text = `{${jsonKey} null}`
       } else {

--- a/server/tests/jsonParse.test.ts
+++ b/server/tests/jsonParse.test.ts
@@ -107,6 +107,14 @@ describe("jsonParseLLMOutput", () => {
     const result = jsonParseLLMOutput(input, ANSWER_TOKEN)
     expect(result).toEqual({ answer: "This is a plain text answer." })
   })
+  
+  test("backslash would get replaced by Quotes due to partial library", () => {
+    const input = '{"answer": "This is a plain text answer \\ '
+    const ANSWER_TOKEN = '"answer":'
+    const result = jsonParseLLMOutput(input, ANSWER_TOKEN)
+    expect(result).toEqual({ answer: "This is a plain text answer \\ " })
+  })
+
   test("string not closed and multiline inside answer key", () => {
     const input = `{
     "answer": "This is a plain text answer.

--- a/server/tests/jsonParse.test.ts
+++ b/server/tests/jsonParse.test.ts
@@ -107,12 +107,12 @@ describe("jsonParseLLMOutput", () => {
     const result = jsonParseLLMOutput(input, ANSWER_TOKEN)
     expect(result).toEqual({ answer: "This is a plain text answer." })
   })
-  
+
   test("backslash would get replaced by Quotes due to partial library", () => {
-    const input = '{"answer": "This is a plain text answer \\ '
+    const input = '{"answer": "This is a plain text answer \\\\"}' //Extra Backslash added as an escape character, thus 4 backslashes
     const ANSWER_TOKEN = '"answer":'
     const result = jsonParseLLMOutput(input, ANSWER_TOKEN)
-    expect(result).toEqual({ answer: "This is a plain text answer \\ " })
+    expect(result).toEqual({ answer: "This is a plain text answer \\" })
   })
 
   test("string not closed and multiline inside answer key", () => {


### PR DESCRIPTION
### Description
Backslash `\` would probably come at the end of a chunk probably cut off from `\n`
but leads to an extra `"` getting added at the end in-place of the `\`.

### Testing
Added tests

### Additional Notes
Issue is because of the partial library we are using.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON parsing to correctly handle cases with escaped quotes at the end of input, preventing unwanted extra quote characters in parsed results.
  - Enhanced handling of JSON strings with trailing backslashes to ensure accurate parsing without unintended modifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->