### PR TITLE
fix(search-filter) : search filter fix and UserStats(added email for Service Account ingestion)

### DIFF
--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -86,7 +86,7 @@ export const SearchBar = forwardRef<HTMLDivElement, any>(
                       if (trimmedQuery) {
                         setOffset(0)
                         navigateToSearch()
-                        setFilter({}) // Use empty object instead of null
+                        setFilter((prevFilter: { lastUpdated?: string }) => ({ lastUpdated: prevFilter.lastUpdated || "anytime" }))
                         // we only want to look for answer if at least
                         // 3 words are there in the query
                       }

--- a/frontend/src/components/ui/userStatsTable.tsx
+++ b/frontend/src/components/ui/userStatsTable.tsx
@@ -10,6 +10,7 @@ import { AuthType } from "shared/types"
 
 export const UserStatsTable = ({
   userStats,
+  type,
 }: {
   userStats: { [email: string]: any }
   type: AuthType
@@ -18,6 +19,7 @@ export const UserStatsTable = ({
     <Table className="ml-[10px] mt-[10px] max-h-[400px]">
       <TableHeader>
         <TableRow>
+          {type === AuthType.ServiceAccount && <TableHead> User Email </TableHead>}
           <TableHead>Gmail</TableHead>
           <TableHead>Drive</TableHead>
           <TableHead>Contacts</TableHead>
@@ -40,6 +42,7 @@ export const UserStatsTable = ({
             percentage !== 0 ? (elapsed * 100) / percentage - elapsed : 0
           return (
             <TableRow key={email}>
+              {type === AuthType.ServiceAccount && <TableCell>{email}</TableCell>}
               <TableCell>{stats.gmailCount}</TableCell>
               <TableCell>{stats.driveCount}</TableCell>
               <TableCell>{stats.contactsCount}</TableCell>

--- a/frontend/src/components/ui/userStatsTable.tsx
+++ b/frontend/src/components/ui/userStatsTable.tsx
@@ -43,6 +43,11 @@ export const UserStatsTable = ({
           return (
             <TableRow key={email}>
               {type === AuthType.ServiceAccount && <TableCell>{email}</TableCell>}
+              {type !== AuthType.OAuth && (
+                <TableCell className={`${stats.done ? "text-lime-600" : ""}`}>
+                  {email}
+                </TableCell>
+              )}
               <TableCell>{stats.gmailCount}</TableCell>
               <TableCell>{stats.driveCount}</TableCell>
               <TableCell>{stats.contactsCount}</TableCell>


### PR DESCRIPTION
### Description

* **Bug Fix: Date Range Filter Persistence Issue**
  Previously, when a user searched for a query (e.g., `"xyz"`) with a date range filter (e.g., `"Past Day"`), results were correctly filtered. However, on entering a new query (e.g., `"abc"`), while the date range filter remained *visually* selected in the UI, it was **not applied** to the new search — causing incorrect/unfiltered results.

* **Fix:**
  This PR ensures that the active filters (like date range) are **re-applied correctly** to every new search query, not just retained visually in the UI.

* Also includes a minor improvement in `UserStats` tracking by adding email when ingesting via a Service Account and a green style for completed users
---

### Testing

* Search query + "Past Day" filter tested across multiple queries.
* Verified that results remain consistently filtered on every new search input.
* Confirmed Service Account ingestion properly logs email to `UserStats`.

---

### Additional Notes

* No breaking changes; fix is scoped to frontend query handling logic and minor backend stat tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - User statistics table now displays a "User Email" column when viewing service account data.

- **Bug Fixes**
  - Improved filter behavior in search: the "last updated" filter is now consistently set when searching, ensuring more reliable filtering results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->