### PR TITLE
(feat/chatrace): button to copy json

### DIFF
--- a/frontend/src/components/RagTraceVirtualization.tsx
+++ b/frontend/src/components/RagTraceVirtualization.tsx
@@ -593,6 +593,7 @@ export function RagTraceVirtualization({
   } | null>(null)
   const contentRef = useRef<HTMLDivElement>(null)
   const isDragging = useRef(false)
+  const [isJsonCopied, setIsJsonCopied] = useState(false)
 
   const {
     data: rawTraceData,
@@ -1558,10 +1559,37 @@ export function RagTraceVirtualization({
     const totalDuration = traceData?.spans
       ? safeCalculateDuration(traceData.spans)
       : 0
+
+    const handleCopyJson = async () => {
+      try {
+        await navigator.clipboard.writeText(
+          JSON.stringify(rawTraceData, null, 2),
+        )
+        setIsJsonCopied(true)
+        setTimeout(() => setIsJsonCopied(false), 2000) // Reset after 2 seconds
+      } catch (err) {
+        console.error("Failed to copy JSON to clipboard:", err)
+      }
+    }
+
     return (
       <div className="w-full overflow-auto bg-gray-50 dark:bg-gray-800 p-6 rounded border border-gray-200 dark:border-gray-700">
-        <div className="mb-4 text-sm text-gray-600 dark:text-gray-200 pb-3 border-b border-gray-200 dark:border-gray-600">
-          Total Duration: {formatDuration(totalDuration)}
+        <div className="flex justify-between items-center mb-4 pb-3 border-b border-gray-200 dark:border-gray-600">
+          <div className="text-sm text-gray-600 dark:text-gray-200">
+            Total Duration: {formatDuration(totalDuration)}
+          </div>
+          <button
+            onClick={handleCopyJson}
+            className="p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-400 relative group text-sm flex items-center"
+            title={isJsonCopied ? "Copied!" : "Copy JSON to clipboard"}
+          >
+            <ClipboardCopy size={16} className="mr-1" />
+            {isJsonCopied && (
+                <span className="absolute top-full mt-2 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white text-xs rounded py-1 px-2">
+                  Copied!
+                </span>
+              )}
+          </button>
         </div>
         <pre className="text-sm whitespace-pre-wrap font-mono text-gray-700 dark:text-gray-200">
           {JSON.stringify(rawTraceData, null, 2)}

--- a/frontend/src/components/RagTraceVirtualization.tsx
+++ b/frontend/src/components/RagTraceVirtualization.tsx
@@ -1581,9 +1581,8 @@ export function RagTraceVirtualization({
           <button
             onClick={handleCopyJson}
             className="p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-400 relative group text-sm flex items-center"
-            title={isJsonCopied ? "Copied!" : "Copy JSON to clipboard"}
           >
-            <ClipboardCopy size={16} className="mr-1" />
+            <ClipboardCopy size={18} className="mr-1" />
             {isJsonCopied && (
                 <span className="absolute top-full mt-2 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white text-xs rounded py-1 px-2">
                   Copied!


### PR DESCRIPTION
### Description

added button to copy the json

### Testing

tested visually it's working

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Copy JSON to clipboard" button in the JSON view, allowing users to easily copy raw trace data.
  - Provided visual feedback with a "Copied!" tooltip when JSON is successfully copied.
  - Improved layout for better alignment of the total duration text and copy button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->