### PR TITLE
fix(chat): input disappearing when previous query result received

### DIFF
--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -226,7 +226,6 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
       currentRespRef.current = null
     }
     inputRef.current?.focus()
-    // setQuery("") // it was causing the input to be cleared
   }, [
     data?.chat?.isBookmarked,
     data?.chat?.title,

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -226,7 +226,7 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
       currentRespRef.current = null
     }
     inputRef.current?.focus()
-    setQuery("")
+    // setQuery("") // it was causing the input to be cleared
   }, [
     data?.chat?.isBookmarked,
     data?.chat?.title,


### PR DESCRIPTION
### Description

fixed the bug of  input disappearing when previous query result received

### Testing

tested visually it's working.

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the chat input field from being unintentionally cleared when chat data or parameters update. User input in the chat box will now be preserved during these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->