### PR TITLE
fix(chat-stream): scrolling up wouldn't work correctly while streaming

### DIFF
--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -250,6 +250,10 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
   const handleSend = async (messageToSend: string) => {
     if (!messageToSend || isStreaming) return
 
+    // Reset userHasScrolled to false when a new message is sent.
+    // This ensures that the view will scroll down automatically as the new message streams in,
+    // unless the user manually scrolls up during the streaming.
+    setUserHasScrolled(false);
     setQuery("")
     setMessages((prevMessages) => [
       ...prevMessages,
@@ -829,11 +833,16 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
 
   const handleScroll = () => {
     const isAtBottom = isScrolledToBottom()
+    // Set userHasScrolled to true if the user scrolls up from the bottom.
+    // This will prevent the automatic scrolling behavior while the user is manually scrolling.
     setUserHasScrolled(!isAtBottom)
   }
 
   useEffect(() => {
     const container = messagesContainerRef.current
+    // Only scroll to the bottom if the container exists and the user has not manually scrolled up.
+    // This prevents the view from jumping to the bottom if the user is trying to read previous messages
+    // while a new message is streaming in.
     if (!container || userHasScrolled) return
 
     container.scrollTop = container.scrollHeight
@@ -935,13 +944,15 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
           </div>
         </div>
 
+        {/* The onScroll event handler is attached to this div because it's the scrollable container for messages. */}
+        {/* This ensures that scroll events are captured correctly to manage the auto-scroll behavior. */}
         <div
           className={`h-full w-full flex items-end overflow-y-auto justify-center transition-all duration-250 ${showSources ? "pr-[18%]" : ""}`}
           ref={messagesContainerRef}
+          onScroll={handleScroll}
         >
           <div className={`w-full h-full flex flex-col items-center`}>
             <div
-              onScroll={handleScroll}
               className="flex flex-col w-full  max-w-3xl flex-grow mb-[60px] mt-[56px]"
             >
               {messages.map((message, index) => {


### PR DESCRIPTION
### Description

fixed the bug, when a user scrolls up it does not allow to scroll up due to active stream.

### Testing

tested visually it's working fine.
also tried the retry case it's working fine.

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved chat experience by preventing automatic scrolling to the bottom when users manually scroll up to read previous messages.
- **Style**
  - Enhanced scroll event handling for more reliable auto-scroll behavior in the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->