### PR TITLE
fix(chat-area): auto chat area expansion

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -862,6 +862,17 @@ export const ChatBox = ({
     }
   }, [showReferenceBox, activeAtMentionIndex])
 
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.style.height = "auto"; // Reset height to allow scrollHeight to be calculated correctly
+      const scrollHeight = inputRef.current.scrollHeight;
+      const minHeight = 52; // As per inline style
+      const maxHeight = 320; // As per inline style
+      const newHeight = Math.max(minHeight, Math.min(scrollHeight, maxHeight));
+      inputRef.current.style.height = `${newHeight}px`;
+    }
+  }, [query]);
+
   return (
     <div className="relative flex flex-col w-full max-w-3xl pb-5">
       {showReferenceBox && (
@@ -1127,7 +1138,7 @@ export const ChatBox = ({
             }}
             style={{
               minHeight: "52px",
-              maxHeight: "150px",
+              maxHeight: "320px",
             }}
             onFocus={(e) => {
               const target = e.target

--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -29,6 +29,18 @@ export const ChatBox = ({
       }
     }
   }, [])
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.style.height = "auto"; // Reset height to allow scrollHeight to be calculated correctly
+      const scrollHeight = inputRef.current.scrollHeight;
+      const minHeight = 40; // As per inline style
+      const maxHeight = 320; // As per inline style
+      const newHeight = Math.max(minHeight, Math.min(scrollHeight, maxHeight));
+      inputRef.current.style.height = `${newHeight}px`;
+    }
+  }, [query]); // Adjust height when query changes
+
   return (
     <div className="flex flex-col w-full border rounded-[20px] sticky bottom-[20px] bg-white  max-w-3xl">
       <div className="relative flex items-center">
@@ -48,7 +60,7 @@ export const ChatBox = ({
           style={{
             height: "auto",
             minHeight: "40px",
-            maxHeight: "108px",
+            maxHeight: "320px",
           }}
         />
       </div>


### PR DESCRIPTION
### Description

fixed the chat area not expanding when passing a paragraph.

### Testing

tested visually it's expanding acc to the text now.

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The chat input box now automatically expands as you type, allowing for more text to be visible, up to a maximum height of 320px (previously 150px).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->