### PR TITLE
fix(searchResults) : Reset pagination offset to zero on filter change

### DIFF
--- a/frontend/src/routes/_authenticated/search.tsx
+++ b/frontend/src/routes/_authenticated/search.tsx
@@ -236,6 +236,7 @@ export const Search = ({ user, workspace }: IndexProps) => {
   }, [search])
 
   useEffect(() => {
+    setOffset(0)
     handleSearch()
   }, [filter, offset])
 

--- a/frontend/src/routes/_authenticated/search.tsx
+++ b/frontend/src/routes/_authenticated/search.tsx
@@ -236,9 +236,13 @@ export const Search = ({ user, workspace }: IndexProps) => {
   }, [search])
 
   useEffect(() => {
+    handleSearch()
+  }, [offset])
+
+  useEffect(() => {
     setOffset(0)
     handleSearch()
-  }, [filter, offset])
+  }, [filter])
 
   const handleAnswer = async (newFilter = filter) => {
     if (!query) return // If the query is empty, do nothing


### PR DESCRIPTION
### Description

This PR ensures that when filters are changed in the UI, the pagination offset is reset to 0, so that results always begin from the first page.

---
### Testing

Applied different filters in the UI and confirmed the result list resets to the first page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search results accuracy by ensuring the results start from the first page when filters are changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->