### PR TITLE
fix(search): correct group count handling and prevent infinite scroll bug due to dynamic pageSize

### DIFF
--- a/frontend/src/routes/_authenticated/search.tsx
+++ b/frontend/src/routes/_authenticated/search.tsx
@@ -183,6 +183,7 @@ export const Search = ({ user, workspace }: IndexProps) => {
       if (bottomRef.current) {
         observer.unobserve(bottomRef.current)
       }
+      observer.disconnect()
     }
   }, [results, filterPageSize, page, isLoading, handleNext])
 

--- a/frontend/src/routes/_authenticated/search.tsx
+++ b/frontend/src/routes/_authenticated/search.tsx
@@ -163,7 +163,6 @@ export const Search = ({ user, workspace }: IndexProps) => {
     if (!bottomRef.current) return
     const observer = new IntersectionObserver(
       (entries) => {
-        console.log("IntersectionObserver entries:", entries)
         const [entry] = entries
         if (
           entry.isIntersecting &&

--- a/frontend/src/routes/_authenticated/search.tsx
+++ b/frontend/src/routes/_authenticated/search.tsx
@@ -166,17 +166,15 @@ export const Search = ({ user, workspace }: IndexProps) => {
           }
         }
       },
-      { threshold: 1.0 },
+      {
+        threshold: 0.5,
+      },
     )
-
     if (observerTargetRef.current) {
       observer.observe(observerTargetRef.current)
     }
-
     return () => {
-      if (observerTargetRef.current) {
-        observer.unobserve(observerTargetRef.current)
-      }
+      observer.disconnect()
     }
   }, [results, isLoadingMore, groups, searchMeta, filter])
 
@@ -388,7 +386,6 @@ export const Search = ({ user, workspace }: IndexProps) => {
       setResults([]) // Clear results on error
     } finally {
       if (newOffset > 0) {
-        // only set loading more to false if it was a "load more" operation
         setIsLoadingMore(false)
       }
     }
@@ -532,13 +529,14 @@ export const Search = ({ user, workspace }: IndexProps) => {
                     />
                   ))}
                 </div>
-                <div ref={observerTargetRef} style={{ height: "1px" }} />{" "}
-                {/* Sentinel element */}
-              </div>
-            )}
-            {isLoadingMore && (
-              <div className="flex justify-center items-center p-4 text-[#464B53]">
-                <LoaderContent />
+                <div ref={observerTargetRef} style={{ height: "1px" }}>
+                  {isLoadingMore && (
+                    <div className="flex justify-center items-center p-4 text-[#464B53]">
+                      <LoaderContent />
+                    </div>
+                  )}
+                </div>{" "}
+                {/* Sentinel element with loader inside */}
               </div>
             )}
           </div>


### PR DESCRIPTION
### Description

This PR addresses multiple issues in the **search results pagination logic**, particularly when filters like `app`, `entity`, and `lastUpdated` are used.

#### Changes:

* **Fixed incorrect `group all count`** computation when the `lastUpdated` filter is changed. The logic now correctly respects the filtered result counts returned by Vespa.

* **Avoided overriding `pageSize`** from the frontend, as the backend (Vespa) already enforces the appropriate size. This prevents inconsistencies in paginated results and eliminates unnecessary query behavior.

* **Removed a redundant `useEffect`** that ran on `filter` changes — it was causing multiple calls due to its interaction with pagination. This logic has been combined with the `offset`-based `useEffect` (as it was originally).

  Now, `offset` is reset to `0` when `lastUpdated` changes:

  ```ts
  onLastUpdated={(value: LastUpdated) => {
    const updatedFilter = { ...filter, lastUpdated: value }
    setFilter(updatedFilter)
    setOffset(0)
  }}
  ```

* **Resolved an infinite scroll issue**:

  * Previously, changing filters (e.g., from `pastDay` with 1 result to `pastWeek` with 10) led to a mismatch in page size vs result length.
  * Vespa would return fewer results than the frontend expected, causing the intersection observer to repeatedly trigger unnecessary fetches.
  * Now we treat `page` as a constant across all searches, avoiding artificial modifications based on group count.

---

### Testing

**Manual Testing:**

* Applied various combinations of `app`, `entity`, and `lastUpdated` filters.
* Verified correct number of paginated results were returned.
* Ensured the infinite scroll stops after all results are fetched.
* Confirmed no extra or redundant queries were fired during filter changes or scrolling.

---

### Additional Notes
* Since Vespa does not return the global group count when filters like lastUpdated or app are applied, we now manually compute the group all count by iterating over the returned results. This ensures consistent pagination and accurate count tracking.