### PR TITLE
fix(vespa): insert in vespa with exponential backoff retry to avoid too many requests

### DIFF
--- a/server/integrations/google/sync.ts
+++ b/server/integrations/google/sync.ts
@@ -21,6 +21,7 @@ import {
   UpdateDocument,
   UpdateDocumentPermissions,
   UpdateEventCancelledInstances,
+  insertWithRetry,
 } from "@/search/vespa"
 import { db } from "@/db/client"
 import {
@@ -351,14 +352,14 @@ const handleGoogleDriveChange = async (
                 },
               )
               for (const data of allData) {
-                insertDocument(data)
+                await insertWithRetry(data, fileSchema)
               }
             } else {
               vespaData.permissions = toPermissionsList(
                 vespaData.permissions,
                 email,
               )
-              insertDocument(vespaData)
+              await insertWithRetry(vespaData, fileSchema)
             }
           }
         } catch (err) {
@@ -890,7 +891,7 @@ const insertEventIntoVespa = async (event: calendar_v3.Schema$Event) => {
       defaultStartTime: isDefaultStartTime,
     }
 
-    await insert(eventToBeIngested, eventSchema)
+    await insertWithRetry(eventToBeIngested, eventSchema)
   } catch (e) {
     Logger.error(
       e,

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -93,7 +93,7 @@ export const insertDocument = async (document: VespaFile) => {
 export const insertWithRetry = async (
   document: Inserts,
   schema: VespaSchema,
-  maxRetries = 5,
+  maxRetries = 8,
 ) => {
   let lastError: any
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -107,7 +107,7 @@ export const insertWithRetry = async (
         (error as Error).message.includes("429 Too Many Requests") &&
         attempt < maxRetries
       ) {
-        const delayMs = Math.min(Math.pow(2, attempt) * 1000, 10000) // Cap at 10s
+        const delayMs = Math.pow(2, attempt) * 2000
         Logger.warn(
           `Vespa 429 for ${document.docId}, retrying in ${delayMs}ms (attempt ${attempt + 1})`,
         )


### PR DESCRIPTION
### Description

Vespa showing too many request error (429) for drive files. To avoid it, I've used `InsertWithRetry` that internally used insert but with exponential backoff.

### Testing
Tested locally




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability when adding Google Calendar events and Drive files by introducing a retry mechanism for data insertion.
- **Refactor**
	- Updated insertion methods to use a new retry-enabled process for handling Google integrations.
- **Chores**
	- Increased the maximum number of retry attempts and adjusted the retry timing for better handling of temporary server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->