### PR TITLE
fix(json-parse): improve json parsing and fix grouped citations

### DIFF
--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -374,6 +374,9 @@ export const jsonParseLLMOutput = (text: string, jsonKey?: string): any => {
   let jsonVal
   try {
     text = text.trim()
+    // edge case where ```json is prepended to the text
+    text = text.replace(/^```(json)?\s*/i, '');
+    text = text.trim();
     // edge case "null\n} or ": "null\n}
     if (text.indexOf("{") === -1 && nullCloseBraceRegex.test(text)) {
       text = text.replaceAll(/[\n"}:`]/g, "")
@@ -419,10 +422,17 @@ export const jsonParseLLMOutput = (text: string, jsonKey?: string): any => {
       // returning an empty object when newlines are present in the content.
       if (Object.keys(jsonVal).length === 0 && text.length > 2) {
         // Replace newlines with \n in content between quotes
-        const withNewLines = text.replace(/: "(.*?)"/gs, (match, content) => {
+        let withNewLines = text.replace(/: "(.*?)"/gs, (match, content) => {
           const escaped = content.replace(/\n/g, "\\n").replace(/\r/g, "\\r")
           return `: "${escaped}"`
         })
+        if(jsonKey && withNewLines.startsWith("{")) {
+          const startBraceIndex = withNewLines.indexOf("{")
+          const keyIndex = withNewLines.indexOf(jsonKey)
+          if(keyIndex > startBraceIndex) {
+            withNewLines = withNewLines.slice(0,startBrace+1) + withNewLines.slice(keyIndex)
+          }
+        }
         jsonVal = parse(withNewLines.trim())
       }
 

--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -430,7 +430,7 @@ export const jsonParseLLMOutput = (text: string, jsonKey?: string): any => {
           const startBraceIndex = withNewLines.indexOf("{")
           const keyIndex = withNewLines.indexOf(jsonKey)
           if(keyIndex > startBraceIndex) {
-            withNewLines = withNewLines.slice(0,startBrace+1) + withNewLines.slice(keyIndex)
+            withNewLines = withNewLines.slice(0,startBraceIndex+1) + withNewLines.slice(keyIndex)
           }
         }
         jsonVal = parse(withNewLines.trim())

--- a/server/api/chat.ts
+++ b/server/api/chat.ts
@@ -412,11 +412,12 @@ export const processMessage = (
 // the Set is passed by reference so that singular object will get updated
 // but need to be kept in mind
 const checkAndYieldCitations = function* (
-  text: string,
+  textInput: string,
   yieldedCitations: Set<number>,
   results: any[],
   baseIndex: number = 0,
 ) {
+  const text = splitGroupedCitationsWithSpaces(textInput)
   let match
   while ((match = textToCitationIndex.exec(text)) !== null) {
     const citationIndex = parseInt(match[1], 10)

--- a/server/tests/citations.test.ts
+++ b/server/tests/citations.test.ts
@@ -80,6 +80,18 @@ describe("Grouped Citation Splitting", () => {
     expect(result).toBe("Good [1] [2] bad [a,b] ok [3] [4]")
   })
 
+  test("should correctly split grouped citations with spaces and multiple digits", () => {
+    const text = "This is a test [3, 20, 22] for citations.";
+    const result = splitGroupedCitationsWithSpaces(text);
+    expect(result).toBe("This is a test [3] [20] [22] for citations.");
+  })
+
+  test("should correctly split grouped citations with no spaces and multiple digits", () => {
+    const text = "This is a test [3,20,22] for citations.";
+    const result = splitGroupedCitationsWithSpaces(text);
+    expect(result).toBe("This is a test [3] [20] [22] for citations.");
+  })
+
   // this fails for now
   test.skip("should handle mixed valid and invalid citations", () => {
     const text = "Mixed [1,2.5,3] and [a,2,b] citations"

--- a/server/tests/jsonParse.test.ts
+++ b/server/tests/jsonParse.test.ts
@@ -139,18 +139,30 @@ describe("jsonParseLLMOutput", () => {
     const result = jsonParseLLMOutput(input, ANSWER_TOKEN)
     expect(result.answer).toEqual(null)
   })
-  //   test("null and closing brace", () => {
-  //     const input = ` null
-  //     }`
-  //     const ANSWER_TOKEN = '"answer":'
-  //     const result = jsonParseLLMOutput(input, ANSWER_TOKEN)
-  //     expect(result).toEqual({ answer: null })
-  //   })
-  //   test("null, colon and closing brace", () => {
-  //     const input = `": null
-  // }`
-  //     const ANSWER_TOKEN = '"answer":'
-  //     const result = jsonParseLLMOutput(input, ANSWER_TOKEN)
-  //     expect(result).toEqual({ answer: null })
-  //   })
+
+  test("should handle unterminated string with newlines and convert newlines to spaces in value", () => {
+    const input = `{
+  "answer": "kalp
+and for this one"}
+`;
+    const ANSWER_TOKEN = '"answer":';
+    const result = jsonParseLLMOutput(input, ANSWER_TOKEN);
+    expect(result).toEqual({ answer: "kalp\nand for this one" });
+  });
+
+  test("should handle ```json prefix without newline before JSON object", () => {
+    const input = '```json{"name": "direct"}';
+    const result = jsonParseLLMOutput(input);
+    expect(result).toEqual({ name: "direct" });
+  });
+
+  test("should handle JSON with a full line comment before a key-value pair", () => {
+    const input = `{
+      // This is a full line comment explaining the answer
+      "answer": "The value itself is simple."
+    }`;
+    const ANSWER_TOKEN = '"answer":';
+    const result = jsonParseLLMOutput(input, ANSWER_TOKEN);
+    expect(result).toEqual({ answer: "The value itself is simple." });
+  });
 })


### PR DESCRIPTION
### Description
If LLM would start the stream with \`\`\`json
this case for gpt4o would lead to `json` word streamed to the user.
Also [20, 19, 10] such format we were not formatting at the appropriate part.

### Testing
added more tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of JSON outputs with markdown code block wrappers, multiline strings, and comments for more robust parsing.
- **Tests**
	- Added new tests to verify correct splitting of grouped citations and enhanced coverage for edge cases in JSON parsing.
- **Refactor**
	- Updated parameter naming for improved clarity in citation processing functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->