### PR TITLE
fix(contact-reference): fixed the user entity type icon issue

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -618,7 +618,8 @@ export const ChatBox = ({
       const pillHtmlString = renderToStaticMarkup(<Pill newRef={newRef} />)
       const tempDiv = document.createElement("div")
       tempDiv.innerHTML = pillHtmlString
-      const pillElement = tempDiv.firstChild
+      // Find the actual <a> tag, as renderToStaticMarkup might prepend other tags like <link>
+      const pillElement = tempDiv.querySelector("a.reference-pill")
 
       if (pillElement) {
         const clonedPill = pillElement.cloneNode(true)
@@ -718,7 +719,8 @@ export const ChatBox = ({
       const pillHtmlString = renderToStaticMarkup(<Pill newRef={newRef} />)
       const tempDiv = document.createElement("div")
       tempDiv.innerHTML = pillHtmlString
-      const pillElement = tempDiv.firstChild
+      // Find the actual <a> tag, as renderToStaticMarkup might prepend other tags like <link>
+      const pillElement = tempDiv.querySelector("a.reference-pill")
 
       if (pillElement) {
         const clonedPill = pillElement.cloneNode(true)
@@ -1323,9 +1325,16 @@ export const ChatBox = ({
                 anchor.href &&
                 anchor.closest('[contenteditable="true"]') === inputRef.current
               ) {
-                // If it's an anchor with an href *inside our contentEditable div*,
-                // prevent default contentEditable behavior and open the link.
-                e.preventDefault()
+                // If it's an anchor with an href *inside our contentEditable div*
+                e.preventDefault() // Prevent default contentEditable behavior first
+
+                // Check if the clicked anchor is an "OtherContacts" pill
+                if (anchor.dataset.entity === "OtherContacts") {
+                  // For "OtherContacts" pills, do nothing further (link should not open)
+                  return
+                }
+                
+                // For other pills or regular links, open the link in a new tab
                 window.open(anchor.href, "_blank", "noopener,noreferrer")
                 // Stop further processing to avoid @mention box logic if a link was clicked
                 return

--- a/frontend/src/components/Pill.tsx
+++ b/frontend/src/components/Pill.tsx
@@ -32,36 +32,47 @@ export const Pill: React.FC<PillProps> = ({ newRef }) => {
     currentPill.addEventListener("click", handleClick)
 
     return () => {
-      currentPill.removeEventListener("click", handleClick)
-    }
-  }, [newRef.url])
-
-  const iconNode =
-    newRef.app && newRef.entity
-      ? getIcon(newRef.app, newRef.entity, {
-          w: 14,
-          h: 14,
-          mr: 4,
-        })
-      : null
+      currentPill.removeEventListener("click", handleClick);
+    };
+  }, [newRef.url]);
 
   let displayIcon: React.ReactNode = null
 
-  if (React.isValidElement(iconNode)) {
+  if (newRef.entity === "OtherContacts" && newRef.photoLink) {
     displayIcon = (
-      <span
-        className="self-center inline-flex items-center"
-        dangerouslySetInnerHTML={{ __html: renderToStaticMarkup(iconNode) }}
+      <img
+        src={newRef.photoLink}
+        alt="" // Alt text can be empty if decorative or title provides context
+        className="self-center inline-flex items-center w-[14px] h-[14px] mr-1 rounded-sm" // Added rounded-sm for consistency if images are square
       />
     )
-  } else if (
-    typeof iconNode === "string" &&
-    (iconNode as string).trim() !== ""
-  ) {
-    displayIcon = <span className="self-center mr-1">{iconNode}</span>
-  } else if (newRef.app && newRef.entity) {
-    displayIcon = <span className="self-center mr-1">▫️</span>
+  } else {
+    const iconNode =
+      newRef.app && newRef.entity
+        ? getIcon(newRef.app, newRef.entity, {
+            w: 14,
+            h: 14,
+            mr: 4,
+          })
+        : null
+
+    if (React.isValidElement(iconNode)) {
+      displayIcon = (
+        <span
+          className="self-center inline-flex items-center"
+          dangerouslySetInnerHTML={{ __html: renderToStaticMarkup(iconNode) }}
+        />
+      )
+    } else if (
+      typeof iconNode === "string" &&
+      (iconNode as string).trim() !== ""
+    ) {
+      displayIcon = <span className="self-center mr-1">{iconNode}</span>
+    } else if (newRef.app && newRef.entity) {
+      displayIcon = <span className="self-center mr-1">▫️</span>
+    }
   }
+
   return (
     <a
       ref={pillRef}

--- a/frontend/src/components/Pill.tsx
+++ b/frontend/src/components/Pill.tsx
@@ -38,7 +38,7 @@ export const Pill: React.FC<PillProps> = ({ newRef }) => {
 
   let displayIcon: React.ReactNode = null
 
-  if (newRef.entity === "OtherContacts" && newRef.photoLink) {
+  if ((newRef.entity === "OtherContacts" || newRef.entity === "Contacts") && newRef.photoLink) {
     displayIcon = (
       <img
         src={newRef.photoLink}

--- a/frontend/src/components/Pill.tsx
+++ b/frontend/src/components/Pill.tsx
@@ -32,13 +32,16 @@ export const Pill: React.FC<PillProps> = ({ newRef }) => {
     currentPill.addEventListener("click", handleClick)
 
     return () => {
-      currentPill.removeEventListener("click", handleClick);
-    };
-  }, [newRef.url]);
+      currentPill.removeEventListener("click", handleClick)
+    }
+  }, [newRef.url])
 
   let displayIcon: React.ReactNode = null
 
-  if ((newRef.entity === "OtherContacts" || newRef.entity === "Contacts") && newRef.photoLink) {
+  if (
+    (newRef.entity === "OtherContacts" || newRef.entity === "Contacts") &&
+    newRef.photoLink
+  ) {
     displayIcon = (
       <img
         src={newRef.photoLink}

--- a/frontend/src/components/Pill.tsx
+++ b/frontend/src/components/Pill.tsx
@@ -42,8 +42,8 @@ export const Pill: React.FC<PillProps> = ({ newRef }) => {
     displayIcon = (
       <img
         src={newRef.photoLink}
-        alt="" // Alt text can be empty if decorative or title provides context
-        className="self-center inline-flex items-center w-[14px] h-[14px] mr-1 rounded-sm" // Added rounded-sm for consistency if images are square
+        alt=""
+        className="self-center inline-flex items-center w-[14px] h-[14px] mr-1 rounded-sm"
       />
     )
   } else {

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -110,7 +110,8 @@ const parseMessageInput = (htmlString: string): Array<ParsedMessagePart> => {
         (el.dataset.docId || el.dataset.referenceId)
       ) {
         const entity = el.dataset.entity
-        const isContactPill = entity === "OtherContacts" || entity === "Contacts"
+        const isContactPill =
+          entity === "OtherContacts" || entity === "Contacts"
         let imgSrc: string | null = null
         const imgElement = el.querySelector("img")
         if (imgElement) {
@@ -129,7 +130,12 @@ const parseMessageInput = (htmlString: string): Array<ParsedMessagePart> => {
         })
       } else if (el.tagName.toLowerCase() === "a" && el.getAttribute("href")) {
         // Ensure this link is not also a reference pill that we've already processed
-        if (!(el.classList.contains("reference-pill") && (el.dataset.docId || el.dataset.referenceId))) {
+        if (
+          !(
+            el.classList.contains("reference-pill") &&
+            (el.dataset.docId || el.dataset.referenceId)
+          )
+        ) {
           parts.push({
             type: "link",
             value: el.getAttribute("href") || "",

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -244,6 +244,7 @@ export const UserResponseSchema = VespaUserSchema.pick({
   app: true,
   entity: true,
   photoLink: true,
+  docId: true,
 })
   .strip()
   .extend({


### PR DESCRIPTION
### Description

fixed the user entity type icon in reference attaching issue
previously it was showing the lucide icon instead of actual photoLink of that contact.

### Testing

tested locally.

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pills representing "OtherContacts" and "Contacts" now display a photo as their icon when a photo link is available.
  - Pills in chat messages can include an associated image, enhancing their visual representation.

- **Bug Fixes**
  - Improved insertion of pills into the chat input to ensure the correct element is added.
  - Refined link click behavior in the chat input: links for "OtherContacts" pills no longer open, while other links open in a new tab as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->