### PR TITLE
fix(chat-response): fixed the reasoning not working for claude 4 model

### DIFF
--- a/server/ai/provider/bedrock.ts
+++ b/server/ai/provider/bedrock.ts
@@ -69,7 +69,7 @@ export class BedrockProvider extends BaseProvider {
   ): AsyncIterableIterator<ConverseResponse> {
     const modelParams = this.getModelParams(params)
 
-    // Configure reasoning parameters only if reasoning is enabled AND using Claude 3.7
+    // Configure reasoning parameters only if reasoning is enabled AND using (Claude 4 or Claude 3.7)
     const reasoningModel = modelParams.modelId === Models.Claude_Sonnet_4 || modelParams.modelId === Models.Claude_3_7_Sonnet
     const isThinkingEnabled = params.reasoning
 


### PR DESCRIPTION
### Description

fixed reasoning not working for claude 4 version.

### Testing

tested locally.

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Extended reasoning (thinking) mode support to include both Claude_Sonnet_4 and Claude_3_7_Sonnet models, enhancing AI response capabilities for users selecting either model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->