### PR TITLE
fix(integration): Show Slack messages for users if they have ingested data

### DIFF
--- a/frontend/src/lib/common.tsx
+++ b/frontend/src/lib/common.tsx
@@ -3,7 +3,7 @@ import DocsSvg from "@/assets/docs.svg" // Added this line
 import SlidesSvg from "@/assets/slides.svg"
 import SheetsSvg from "@/assets/sheets.svg"
 import DriveSvg from "@/assets/drive.svg"
-import NotionPageSvg from "@/assets/notionPage.svg"
+// import NotionPageSvg from "@/assets/notionPage.svg"
 import Gmail from "@/assets/gmail.svg"
 import Docx from "@/assets/docx.svg"
 import Pdf from "@/assets/pdf.svg"
@@ -16,7 +16,7 @@ import {
   Apps,
   DriveEntity,
   GooglePeopleEntity,
-  NotionEntity,
+  // NotionEntity,
   CalendarEntity,
   isMailAttachment,
 } from "shared/types"
@@ -80,11 +80,11 @@ export const getIcon = (
       return <Paperclip className={classNameVal} fill="rgb(196, 199, 197)" />
     }
     return <img className={classNameVal} src={Gmail} />
-  } else if (app === Apps.Notion) {
-    // ...existing Notion cases...
-    if (entity === NotionEntity.Page) {
-      return <img className={classNameVal} src={NotionPageSvg} />
-    }
+  // } else if (app === Apps.Notion) {
+  //   // ...existing Notion cases...
+  //   if (entity === NotionEntity.Page) {
+  //     return <img className={classNameVal} src={NotionPageSvg} />
+  //   }
   } else if (app === Apps.GoogleCalendar) {
     // ...existing GoogleCalendar cases...
     if (entity === CalendarEntity.Event) {

--- a/server/db/syncJob.ts
+++ b/server/db/syncJob.ts
@@ -6,7 +6,7 @@ import {
   type SelectSyncJob,
 } from "./schema"
 import { createId } from "@paralleldrive/cuid2"
-import type { Apps, AuthType } from "@/shared/types"
+import { Apps, AuthType } from "@/shared/types"
 import { and, eq } from "drizzle-orm"
 import { z } from "zod"
 
@@ -43,6 +43,20 @@ export const getAppSyncJobs = async (
     .where(and(eq(syncJobs.app, app), eq(syncJobs.authType, authType)))
   return z.array(selectSyncJobSchema).parse(jobs)
 }
+
+export const getAppSyncJobsByEmail = async (
+  trx: TxnOrClient,
+  app: Apps,
+  authType: AuthType,
+  email: string,
+): Promise<SelectSyncJob[]> => {
+  const jobs = await trx
+    .select()
+    .from(syncJobs)
+    .where(and(and(eq(syncJobs.app, app), eq(syncJobs.authType, authType)),eq(syncJobs.email, email)))
+  return z.array(selectSyncJobSchema).parse(jobs)
+}
+
 
 export const updateSyncJob = async (
   trx: TxnOrClient,

--- a/server/search/types.ts
+++ b/server/search/types.ts
@@ -42,7 +42,7 @@ export enum Apps {
 
   Gmail = "gmail",
 
-  Notion = "notion",
+  // Notion = "notion",  // Notion is not yet supported
   GoogleCalendar = "google-calendar",
 
   Slack = "slack",

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -269,6 +269,10 @@ type YqlProfile = {
   yql: string
 }
 
+const handleAppsNotInYql = (app:Apps | null) => {
+  Logger.error(`${app} is not supported in YQL queries yet`)
+}
+
 // TODO: it seems the owner part is complicating things
 export const HybridDefaultProfile = (
   hits: number,
@@ -292,6 +296,7 @@ export const HybridDefaultProfile = (
     return conditions.join(" and ")
   }
 
+  // ToDo we have to handle this filter as we are applying multiple times app filtering
   // Helper function to build app/entity filter
   const buildAppEntityFilter = () => {
     return `${app ? "and app contains @app" : ""} ${entity ? "and entity contains @entity" : ""}`.trim()
@@ -435,13 +440,8 @@ export const HybridDefaultProfile = (
   }
 
   // Start with all apps and filter out excluded ones
-  const allApps = [
-    Apps.GoogleWorkspace,
-    Apps.Gmail,
-    Apps.GoogleDrive,
-    Apps.GoogleCalendar,
-    Apps.Slack,
-  ]
+  const allApps = Object.values(Apps)
+
   const includedApps = allApps.filter(
     (appItem) => !excludedApps?.includes(appItem),
   )
@@ -465,6 +465,9 @@ export const HybridDefaultProfile = (
         break
       case Apps.Slack:
         appQueries.push(buildSlackYQL())
+        break
+      default:
+        handleAppsNotInYql(includedApp)
         break
     }
   }

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -572,7 +572,6 @@ export const groupVespaSearch = async (
   let excludedApps: Apps[] = []
   try {
     const slackSyncJobs = await getAppSyncJobsByEmail(db, Apps.Slack, AuthType.OAuth, email)
-    Logger.info(email)
     if (!slackSyncJobs || slackSyncJobs.length === 0) {
       excludedApps.push(Apps.Slack)
     }

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -269,8 +269,12 @@ type YqlProfile = {
   yql: string
 }
 
-const handleAppsNotInYql = (app:Apps | null) => {
+const handleAppsNotInYql = (app:Apps | null,includedApp:Apps[]) => {
   Logger.error(`${app} is not supported in YQL queries yet`)
+  throw new ErrorPerformingSearch({
+    message: `${app} is not supported in YQL queries yet`,
+    sources: includedApp.join(", "),
+  })
 }
 
 // TODO: it seems the owner part is complicating things
@@ -467,7 +471,7 @@ export const HybridDefaultProfile = (
         appQueries.push(buildSlackYQL())
         break
       default:
-        handleAppsNotInYql(includedApp)
+        handleAppsNotInYql(includedApp,includedApps)
         break
     }
   }

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -555,11 +555,6 @@ const HybridDefaultProfileAppEntityCounts = (
   notInMailLabels?: string[],
   excludedApps?: Apps[],
 ): YqlProfile => {
-  console.log(
-    "HybridDefaultProfileAppEntityCounts called with excludedApps:",
-    excludedApps,
-  )
-
   // Helper function to build timestamp conditions
   const buildTimestampConditions = (fromField: string, toField: string) => {
     const conditions: string[] = []


### PR DESCRIPTION
### Description
Previously due to the permission model of the `chat_container`, the moment a user would ingest a public channel all the participants would be part of the permission array. This would lead to someone who has not yet ingested slack to view some of the public messages.
Even though it is still secure, can lead to unnecessary surprises.
Now it will display the slack Messages only when the user has ingested slack i.e has a slack sync job.

### Testing
tested locally for search and chat

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Search results now automatically exclude Slack data if no Slack sync jobs are found for your account.
	- Improved search accuracy by dynamically filtering app-specific data sources based on your sync job status.
	- Added enhanced filtering of search sources with modular app-specific query construction for Google Workspace, Gmail, Drive, Calendar, and Slack.
	- Added ability to retrieve sync job data filtered by app, authentication type, and user email for improved backend data handling.
- **Bug Fixes**
	- Temporarily disabled Notion integration and icon rendering as Notion support is not yet available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->