### PR TITLE
fix(duplicateEmails):Avoid inserting emails into Vespa if they already exist based on mailId

### DIFF
--- a/server/integrations/google/gmail-worker.ts
+++ b/server/integrations/google/gmail-worker.ts
@@ -176,11 +176,8 @@ export const handleGmailIngestion = async (
       let insertedMessagesInBatch = 0 // Counter for successful messages
       let insertedPdfAttachmentsInBatch = 0 // Counter for successful PDFs in this batch
 
-      const messageIds = messageBatch.map((msg) => msg.id!)
-
       let batchRequests = messageBatch.map((message) =>
         limit(async () => {
-          const messageId = message.id!
           let msgResp
           try {
             msgResp = await retryWithBackoff(

--- a/server/integrations/google/gmail-worker.ts
+++ b/server/integrations/google/gmail-worker.ts
@@ -15,7 +15,7 @@ import {
   type Mail,
   type MailAttachment,
 } from "@/search/types"
-import { ifDocumentsExist, insert } from "@/search/vespa"
+import { ifDocumentsExist, ifMailDocumentsExist, insert } from "@/search/vespa"
 import {
   MessageTypes,
   Subsystem,
@@ -177,15 +177,10 @@ export const handleGmailIngestion = async (
       let insertedPdfAttachmentsInBatch = 0 // Counter for successful PDFs in this batch
 
       const messageIds = messageBatch.map((msg) => msg.id!)
-      const existenceMap = await ifDocumentsExist(messageIds)
 
       let batchRequests = messageBatch.map((message) =>
         limit(async () => {
           const messageId = message.id!
-          if (existenceMap[messageId]) {
-            insertedMessagesInBatch++ // Count as "processed" since it exists
-            return
-          }
           let msgResp
           try {
             msgResp = await retryWithBackoff(
@@ -201,17 +196,20 @@ export const handleGmailIngestion = async (
               client,
             )
             // Call modified parseMail to get data and PDF count
-            const { mailData, insertedPdfCount } = await parseMail(
+            const { mailData, insertedPdfCount, exist } = await parseMail(
               msgResp.data,
               gmail,
               client,
-              email
+              email,
             )
-            await insert(mailData, mailSchema)
-            // Increment counters only on success
-            insertedMessagesInBatch++
-            insertedPdfAttachmentsInBatch += insertedPdfCount
-            totalIngestedMails.inc({mail_id:message.id??"", mail_title:message.payload?.filename??"", mime_type:message.payload?.mimeType??"GOOGLE_MAIL", status:"GMAIL_INGEST_SUCCESS", email: email, account_type:"SERVICE_ACCOUNT"}, 1)
+
+            if (!exist) {
+              await insert(mailData, mailSchema)
+              // Increment counters only on success
+              insertedMessagesInBatch++
+              insertedPdfAttachmentsInBatch += insertedPdfCount
+              totalIngestedMails.inc({mail_id:message.id??"", mail_title:message.payload?.filename??"", mime_type:message.payload?.mimeType??"GOOGLE_MAIL", status:"GMAIL_INGEST_SUCCESS", email: email, account_type:"SERVICE_ACCOUNT"}, 1)
+            }
           } catch (error) {
             Logger.error(
               error,
@@ -292,8 +290,8 @@ export const parseMail = async (
   email: gmail_v1.Schema$Message,
   gmail: gmail_v1.Gmail,
   client: GoogleClient,
-  userEmail: string
-): Promise<{ mailData: Mail; insertedPdfCount: number }> => {
+  userEmail: string,
+): Promise<{ mailData: Mail; insertedPdfCount: number; exist: boolean }> => {
   const messageId = email.id
   const threadId = email.threadId
   let insertedPdfCount = 0
@@ -325,8 +323,14 @@ export const parseMail = async (
   const cc = extractEmailAddresses(getHeader("Cc") ?? "")
   const bcc = extractEmailAddresses(getHeader("Bcc") ?? "")
   const subject = getHeader("Subject") || ""
-
+  const mailId =
+    getHeader("Message-Id")?.replace(/<(.*?)>/, "$1") || messageId || undefined
   // Handle timestamp from Date header if available
+  let exist = false
+  const res = await ifMailDocumentsExist([mailId!])
+  if (res[mailId!].exists) {
+    exist = true
+  }
   const dateHeader = getHeader("Date")
   if (dateHeader) {
     const date = new Date(dateHeader)
@@ -357,7 +361,7 @@ export const parseMail = async (
 
   let attachments: Attachment[] = []
   let filenames: string[] = []
-  if (payload) {
+  if (payload && !exist) {
     const parsedParts = parseAttachments(payload)
     attachments = parsedParts.attachments
     filenames = parsedParts.filenames
@@ -422,6 +426,7 @@ export const parseMail = async (
   const emailData: Mail = {
     docId: messageId,
     threadId: threadId,
+    mailId: mailId,
     subject: subject,
     chunks: chunks,
     timestamp: timestamp,
@@ -438,7 +443,7 @@ export const parseMail = async (
     labels: labels ?? [],
   }
 
-  return { mailData: emailData, insertedPdfCount }
+  return { mailData: emailData, insertedPdfCount, exist }
 }
 
 const getBody = (payload: any): string => {

--- a/server/integrations/google/gmail-worker.ts
+++ b/server/integrations/google/gmail-worker.ts
@@ -323,14 +323,22 @@ export const parseMail = async (
   const cc = extractEmailAddresses(getHeader("Cc") ?? "")
   const bcc = extractEmailAddresses(getHeader("Bcc") ?? "")
   const subject = getHeader("Subject") || ""
-  const mailId =
-    getHeader("Message-Id")?.replace(/<(.*?)>/, "$1") || messageId || undefined
-  // Handle timestamp from Date header if available
+  const mailId = getHeader("Message-Id")?.replace(/^<|>$/g, "") || messageId || undefined
   let exist = false
-  const res = await ifMailDocumentsExist([mailId!])
-  if (res[mailId!].exists) {
-    exist = true
-  }
+  if (mailId) {
+    try {
+        const res = await ifMailDocumentsExist([mailId])
+        if (res[mailId]?.exists) {
+           exist = true
+          }
+        } catch (error) {
+          Logger.warn(
+            error,
+            `Failed to check mail existence for mailId: ${mailId}, proceeding with insertion`
+          )
+          exist = false
+        }
+      }
   const dateHeader = getHeader("Date")
   if (dateHeader) {
     const date = new Date(dateHeader)

--- a/server/integrations/google/gmail/index.ts
+++ b/server/integrations/google/gmail/index.ts
@@ -198,13 +198,22 @@ export const parseMail = async (
   const cc = extractEmailAddresses(getHeader("Cc") ?? "")
   const bcc = extractEmailAddresses(getHeader("Bcc") ?? "")
   const subject = getHeader("Subject") || ""
-  const mailId =
-    getHeader("Message-Id")?.replace(/<(.*?)>/, "$1") || messageId || undefined
+  const mailId = getHeader("Message-Id")?.replace(/^<|>$/g, "") || messageId || undefined
   let exist = false
-  const res = await ifMailDocumentsExist([mailId!])
-  if (res[mailId!].exists) {
-    exist = true
-  }
+  if (mailId) {
+    try {
+        const res = await ifMailDocumentsExist([mailId])
+        if (res[mailId]?.exists) {
+           exist = true
+          }
+        } catch (error) {
+          Logger.warn(
+            error,
+            `Failed to check mail existence for mailId: ${mailId}, proceeding with insertion`
+          )
+          exist = false
+        }
+      }
   // Handle timestamp from Date header if available
   const dateHeader = getHeader("Date")
   if (dateHeader) {

--- a/server/integrations/google/sync.ts
+++ b/server/integrations/google/sync.ts
@@ -22,7 +22,6 @@ import {
   UpdateDocumentPermissions,
   UpdateEventCancelledInstances,
   insertWithRetry,
-  ifMailDocumentsExist,
 } from "@/search/vespa"
 import { db } from "@/db/client"
 import {

--- a/server/search/types.ts
+++ b/server/search/types.ts
@@ -345,6 +345,7 @@ export const AttachmentSchema = z.object({
 export const MailSchema = z.object({
   docId: z.string(),
   threadId: z.string(),
+  mailId: z.string().optional(), // Optional for threads
   subject: z.string().default(""), // Default to empty string to avoid zod errors when subject is missing
   chunks: z.array(z.string()),
   timestamp: z.number(),

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -864,10 +864,10 @@ export const ifDocumentsExist = async (
 }
 
 export const ifMailDocumentsExist = async (
-  docIds: string[],
+  mailIds: string[],
 ): Promise<Record<string, { exists: boolean; updatedAt: number | null }>> => {
   try {
-    return await vespa.ifMailDocumentsExist(docIds)
+    return await vespa.ifMailDocumentsExist(mailIds)
   } catch (error) {
     throw error
   }

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -863,6 +863,16 @@ export const ifDocumentsExist = async (
   }
 }
 
+export const ifMailDocumentsExist = async (
+  docIds: string[],
+): Promise<Record<string, { exists: boolean; updatedAt: number | null }>> => {
+  try {
+    return await vespa.ifMailDocumentsExist(docIds)
+  } catch (error) {
+    throw error
+  }
+}
+
 export const ifDocumentsExistInChatContainer = async (
   docIds: string[],
 ): Promise<

--- a/server/search/vespaClient.ts
+++ b/server/search/vespaClient.ts
@@ -788,6 +788,69 @@ class VespaClient {
     }
   }
 
+  async ifMailDocumentsExist(
+    mailIds: string[],
+  ): Promise<Record<string, { exists: boolean; updatedAt: number | null }>> {
+    // Construct the YQL query
+    const yqlIds = mailIds.map((id) => `"${id}"`).join(", ")
+    const yqlQuery = `select mailId, updatedAt from sources * where mailId in (${yqlIds})`
+    const url = `${this.vespaEndpoint}/search/`
+
+    try {
+      const payload = {
+        yql: yqlQuery,
+        hits: mailIds.length,
+        maxHits: mailIds.length + 1,
+      }
+
+      const response = await this.fetchWithRetry(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      })
+
+      if (!response.ok) {
+        const errorText = response.statusText
+        throw new Error(
+          `Search query failed: ${response.status} ${response.statusText} - ${errorText}`,
+        )
+      }
+
+      const result = await response.json()
+
+      // Extract found documents with their mailId and updatedAt
+      const foundDocs =
+        result.root?.children?.map((hit: any) => ({
+          mailId: hit.fields.mailId as string,
+          updatedAt: hit.fields.updatedAt as number | undefined, // undefined if not present
+        })) || []
+
+      // Build the result map using original mailIds as keys
+      const existenceMap = mailIds.reduce(
+        (acc, id) => {
+          const cleanedId = id.replace(/<(.*?)>/, "$1")
+          const foundDoc = foundDocs.find(
+            (doc: { mailId: string }) => doc.mailId === cleanedId,
+          )
+          acc[id] = {
+            exists: !!foundDoc,
+            updatedAt: foundDoc?.updatedAt ?? null, // null if not found or no updatedAt
+          }
+          return acc
+        },
+        {} as Record<string, { exists: boolean; updatedAt: number | null }>,
+      )
+
+      return existenceMap
+    } catch (error) {
+      const errMessage = getErrorMessage(error)
+      Logger.error(error, `Error checking documents existence:  ${errMessage}`)
+      throw error
+    }
+  }
+
   async ifDocumentsExistInSchema(
     schema: string,
     docIds: string[],

--- a/server/search/vespaClient.ts
+++ b/server/search/vespaClient.ts
@@ -793,7 +793,7 @@ class VespaClient {
   ): Promise<Record<string, { exists: boolean; updatedAt: number | null }>> {
     // Construct the YQL query
     const yqlIds = mailIds.map((id) => `"${id}"`).join(", ")
-    const yqlQuery = `select mailId, updatedAt from sources * where mailId in (${yqlIds})`
+    const yqlQuery = `select mailId, updatedAt from sources mail where mailId in (${yqlIds})`
     const url = `${this.vespaEndpoint}/search/`
 
     try {

--- a/server/vespa/schemas/mail.sd
+++ b/server/vespa/schemas/mail.sd
@@ -11,6 +11,10 @@ schema mail {
       indexing: attribute | summary
       attribute: fast-search
     }
+    field mailId type string {
+      indexing: attribute | summary
+      attribute: fast-search
+    }
 
     field subject type string {
       indexing: summary | index


### PR DESCRIPTION


### Description

Added the `mailId` field in mail.sd file to determine if an email is already present using its mailId.
If the mailId is found, the email is skipped to prevent duplication.

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added checks to prevent duplicate emails from being ingested from Gmail, ensuring each email is only stored once.
  - Introduced a unique mail identifier field to emails for improved tracking and search capabilities.
  - Exposed Google Drive change handling functions for broader use.

- **Bug Fixes**
  - Resolved issues with duplicate email and attachment processing during Gmail ingestion.

- **Improvements**
  - Enhanced email ingestion logic for better reliability and error resilience.
  - Updated email schema and search infrastructure to support the new mail identifier field.

- **Documentation**
  - Updated type definitions to reflect new fields and changes to email handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->