### PR TITLE
fix(search): Added decay for slack vectors

### DIFF
--- a/server/vespa/schemas/chat_message.sd
+++ b/server/vespa/schemas/chat_message.sd
@@ -135,6 +135,10 @@ schema chat_message {
       query(alpha) double
     }
 
+    constants {
+      SLACK_VECTOR_DECAY: 0.8
+    }
+
     function vector_score() {
       expression: closeness(field, text_embeddings)
     }
@@ -178,7 +182,7 @@ schema chat_message {
     global-phase {
       expression {
         (
-          (query(alpha) * vector_score) + 
+          (query(alpha) * (SLACK_VECTOR_DECAY * vector_score)) + 
           ((1 - query(alpha)) *  combined_nativeRank)
         )
       }
@@ -205,7 +209,7 @@ schema chat_message {
     global-phase {
       expression {
         (
-          (query(alpha) * vector_score) + 
+          (query(alpha) * (SLACK_VECTOR_DECAY * vector_score)) + 
           ((1 - query(alpha)) * scale(combined_bm25))
         )
       }
@@ -225,7 +229,7 @@ schema chat_message {
   rank-profile default_ai inherits initial {
     
     first-phase {
-      expression: (query(alpha) * vector_score) + ((1 - query(alpha)) *  combined_nativeRank)
+      expression: (query(alpha) * (SLACK_VECTOR_DECAY * vector_score)) + ((1 - query(alpha)) *  combined_nativeRank)
     }
 
     global-phase {
@@ -293,7 +297,7 @@ schema chat_message {
     }
 
     function hybrid_relevance_score_gs() {
-      expression: (query(alpha) * vector_score()) + ((1 - query(alpha)) * combined_nativeRank)
+      expression: (query(alpha) * (SLACK_VECTOR_DECAY * vector_score)) + ((1 - query(alpha)) * combined_nativeRank)
     }
 
     function normalized_hybrid_relevance_gs() {


### PR DESCRIPTION
### Description
Applied 0.8 decay to Slack vectors to balance relevance with other results.
### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted ranking logic to apply a decay factor to vector-based scoring, affecting relevance calculations across several ranking profiles. This change may subtly impact the ordering of search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->