### PR TITLE
fix(metrics): updated xyne metrics dashboard and tab icon fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,9 @@ dist
 # IntelliJ based IDEs
 .idea
 
+# Vim 
+Session.vim
+
 # Finder (MacOS) folder config
 .DS_Store
 

--- a/deployment/grafana/provisioning/dashboards/xyne_metrics.json
+++ b/deployment/grafana/provisioning/dashboards/xyne_metrics.json
@@ -15,7 +15,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 1,
+  "id": 7,
   "links": [
     {
       "icon": "info",
@@ -44,6 +44,81 @@
       "fieldConfig": {
         "defaults": {
           "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 10,
+        "x": 0,
+        "y": 0
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.1",
+      "targets": [
+        {
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "increase(app_response_count{app_response_status=~\"[45]..\"}[$__rate_interval])",
+          "format": "time_series",
+          "instant": false,
+          "legendFormat": "{{app_endpoint}} : {{app_response_status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "API 4XX and 5XX Status",
+      "transformations": [
+        {
+          "id": "renameByRegex",
+          "options": {
+            "regex": "Value",
+            "renamePattern": "status"
+          }
+        }
+      ],
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P442C0F3243930FD5"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
             "mode": "palette-classic"
           },
           "custom": {
@@ -55,7 +130,7 @@
             "barAlignment": 0,
             "barWidthFactor": 0.6,
             "drawStyle": "line",
-            "fillOpacity": 0,
+            "fillOpacity": 25,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -73,7 +148,7 @@
             "spanNulls": false,
             "stacking": {
               "group": "A",
-              "mode": "none"
+              "mode": "normal"
             },
             "thresholdsStyle": {
               "mode": "off"
@@ -91,22 +166,26 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
-        "y": 15
+        "h": 10,
+        "w": 14,
+        "x": 10,
+        "y": 0
       },
       "id": 23,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
+          "calcs": [
+            "max",
+            "min"
+          ],
+          "displayMode": "table",
+          "placement": "right",
           "showLegend": true
         },
         "tooltip": {
@@ -131,117 +210,13 @@
           "hide": false,
           "includeNullMetadata": true,
           "instant": false,
-          "legendFormat": "__auto",
+          "legendFormat": "{{app_endpoint}}",
           "range": true,
           "refId": "A",
           "useBackend": false
         }
       ],
       "title": "Rate of Latency per request",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "P442C0F3243930FD5"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "Response Count",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 27
-      },
-      "id": 22,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.1",
-      "targets": [
-        {
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum by(app_response_status) (max_over_time(app_response_count[$__range]))",
-          "format": "time_series",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Response by status",
-      "transformations": [
-        {
-          "id": "renameByRegex",
-          "options": {
-            "regex": "Value",
-            "renamePattern": "status"
-          }
-        }
-      ],
       "type": "timeseries"
     },
     {
@@ -307,7 +282,7 @@
         "h": 13,
         "w": 12,
         "x": 0,
-        "y": 37
+        "y": 10
       },
       "id": 21,
       "options": {
@@ -411,7 +386,7 @@
         "h": 13,
         "w": 12,
         "x": 12,
-        "y": 37
+        "y": 10
       },
       "id": 20,
       "options": {
@@ -504,7 +479,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 50
+        "y": 23
       },
       "id": 19,
       "options": {
@@ -605,7 +580,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 33
       },
       "id": 18,
       "options": {
@@ -824,7 +799,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 69
+        "y": 42
       },
       "id": 16,
       "interval": "30",
@@ -1019,7 +994,7 @@
         "h": 12,
         "w": 24,
         "x": 0,
-        "y": 79
+        "y": 52
       },
       "id": 17,
       "options": {
@@ -1203,5 +1178,5 @@
   "timezone": "browser",
   "title": "Xyne Metric Dashboard",
   "uid": "de25akpxochkwd",
-  "version": 28
+  "version": 4
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/assets/logo.svg" />
     <title>Xyne Search</title>
   </head>
   <body>


### PR DESCRIPTION
### Description
 - fix tab icon 
![Screenshot 2025-06-03 at 14 56 21](https://github.com/user-attachments/assets/e4a25d4c-ef4d-40ec-a901-23fcc3d17f4c)
- Updated Xyne Metrics Grafana Dashboard to get 5xx & 4xx errors properly 
![Screenshot 2025-06-03 at 20 14 55](https://github.com/user-attachments/assets/a3400af3-768e-432e-8b0e-9061d6420978)
- updated update-browserslist-db

### Testing
- xyne tab icons should show up 

### Additional Notes
- added Session.vim in .gitignore
- updated update-browserslist-db


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated Grafana dashboard panels for improved monitoring of API response statuses and latency rates, with reorganized layout and enhanced visualizations.
- **Style**
  - Changed the browser tab icon to a new logo.
- **Chores**
  - Updated repository settings to ignore Vim session files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->