### PR TITLE
(fix): sidebar closes on clicking outside

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -908,7 +908,7 @@ export const ChatBox = ({
       {showReferenceBox && (
         <div
           ref={referenceBoxRef}
-          className="absolute bottom-[calc(80%+8px)] bg-white rounded-md w-[400px] z-10 border border-gray-200 rounded-xl flex flex-col"
+          className="absolute bottom-[calc(80%+8px)] bg-white rounded-md w-[400px] z-10 border border-gray-200 rounded-xl flex flex-col reference-box"
           style={{
             left: activeAtMentionIndex !== -1 ? `${referenceBoxLeft}px` : "0px",
           }}
@@ -1085,7 +1085,7 @@ export const ChatBox = ({
           </div>
         </div>
       )}
-      <div className="flex flex-col w-full border rounded-[20px] bg-white">
+      <div className="flex flex-col w-full border rounded-[20px] bg-white search-container">
         <div className="relative flex items-center">
           {isPlaceholderVisible && (
             <div className="absolute left-4 top-1/2 transform -translate-y-1/2 text-[#ACBCCC] pointer-events-none">
@@ -1095,6 +1095,7 @@ export const ChatBox = ({
           <div
             ref={inputRef}
             contentEditable
+            data-at-mention="true"
             className="flex-grow resize-none bg-transparent outline-none text-[15px] font-[450] leading-[24px] text-[#1C1D1F] placeholder-[#ACBCCC] pl-[16px] pt-[14px] pb-[14px] pr-[16px] overflow-y-auto"
             onPaste={(e: React.ClipboardEvent<HTMLDivElement>) => {
               e.preventDefault()

--- a/frontend/src/components/HistoryModal.tsx
+++ b/frontend/src/components/HistoryModal.tsx
@@ -243,7 +243,7 @@ const HistoryModal = ({
   }
 
   return (
-    <div className="fixed left-[52px] top-0 min-w-[200px] w-1/6 max-w-[300px] h-full border-r-[0.5px] border-[#D7E0E9] flex flex-col select-none bg-white">
+    <div className="fixed left-[52px] top-0 min-w-[200px] w-1/6 max-w-[300px] h-full border-r-[0.5px] border-[#D7E0E9] flex flex-col select-none bg-white history-modal-container">
       <div className="flex justify-between items-center ml-[18px] mt-[14px]">
         <p className="text-[#1C1D1F] font-medium text-[16px]">Chat History</p>
         <button

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from "@tanstack/react-router"
 import { Plug, Plus, History } from "lucide-react"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import HistoryModal from "@/components/HistoryModal"
 import { UserRole } from "shared/types"
 import {
@@ -23,10 +23,32 @@ export const Sidebar = ({
   const location = useLocation()
   const [showHistory, setShowHistory] = useState<boolean>(false)
 
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+       
+      const isInteractiveElement = target.closest('button, a, [role="button"], input, .dropdown-trigger');
+      if (isInteractiveElement) return;
+      const isSidebarClick = target.closest('.sidebar-container');
+      const isHistoryModalClick = target.closest('.history-modal-container');
+      const isChatInput = target.closest('[contenteditable="true"]'); 
+      const isSearchArea = target.closest('.search-container'); 
+      const isReferenceBox = target.closest('.reference-box'); 
+      const isAtMentionArea = target.closest('[data-at-mention]'); 
+      
+      if (!isSidebarClick && !isHistoryModalClick && !isChatInput && !isSearchArea && !isReferenceBox && !isAtMentionArea && showHistory) {
+        setShowHistory(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showHistory]);
+
   return (
     <TooltipProvider>
       <div
-        className={`bg-white h-full w-[52px] border-r-[0.5px] border-[#D7E0E9] flex flex-col fixed ${className} z-20 select-none`}
+        className={`bg-white h-full w-[52px] border-r-[0.5px] border-[#D7E0E9] flex flex-col fixed ${className} z-20 select-none sidebar-container`}
       >
         {showHistory && (
           <HistoryModal


### PR DESCRIPTION
### Description

 - Clicking outside the chat history sidebar will now close it.
-  Clicking on an interactive element (e.g., buttons, inputs) does not close the sidebar.

### Testing

- tested locally


