### PR TITLE
fixes chat rename and delete button

### DIFF
--- a/frontend/src/components/HistoryModal.tsx
+++ b/frontend/src/components/HistoryModal.tsx
@@ -307,6 +307,7 @@ const HistoryModal = ({
                     <DropdownMenuContent>
                       <DropdownMenuItem
                         key={"rename"}
+                        role="button"
                         className="flex text-[14px] py-[8px] px-[10px] hover:bg-[#EBEFF2] items-center"
                         onClick={() => {
                           setEditedTitle(item.title) // Set the current title for editing
@@ -324,6 +325,7 @@ const HistoryModal = ({
                       </DropdownMenuItem>
                       <DropdownMenuItem
                         key={"delete"}
+                        role="button"
                         className="flex text-[14px] py-[8px] px-[10px] hover:bg-[#EBEFF2] items-center"
                         onClick={() => {
                           mutation.mutate(item?.externalId)


### PR DESCRIPTION
### Description

chat rename and chat delete button not working in chat history sidebar #501
fixes chat delete and rename button by adding role=button

### Testing

tested locally



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved accessibility by adding button roles to the "Rename" and "Delete" actions in the chat history dropdown menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->