### PR TITLE
Fix: Highlight Parsing and Overflow Issue in Slack Source Rendering

### DIFF
--- a/frontend/src/components/Highlight.tsx
+++ b/frontend/src/components/Highlight.tsx
@@ -32,7 +32,7 @@ const cleanDocs = (text: string): string => {
   return cleanedText
 }
 
-const parseHighlight = (text: string): ReactNode[] => {
+export const parseHighlight = (text: string): ReactNode[] => {
   // Split the text on <hi> and </hi>, including the tags in the result
   const parts: string[] = text.split(/(<hi>|<\/hi>)/)
 

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -57,6 +57,7 @@ import React from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { Pill } from "@/components/Pill"
 import { Reference } from "@/types"
+import { parseHighlight } from "@/components/Highlight"
 
 export const THINKING_PLACEHOLDER = "Thinking"
 
@@ -1510,7 +1511,7 @@ const MessageCitationList = ({
               <div className="flex pl-[12px] pt-[10px] pr-[12px]">
                 <div className="flex flex-col w-full">
                   <p className="line-clamp-2 text-[13px] tracking-[0.01em] leading-[17px] text-ellipsis font-medium">
-                    {citation.title}
+                    {citation.title ? parseHighlight(citation.title) : ""}
                   </p>
                   <div className="flex flex-col mt-[9px]">
                     <div className="flex items-center pb-[12px]">
@@ -1578,7 +1579,7 @@ const CitationList = ({ citations }: { citations: Citation[] }) => {
               </a>
               <div className="flex flex-col mr-[12px]">
                 <span className="line-clamp-2 text-[13px] tracking-[0.01em] leading-[17px] text-ellipsis font-medium">
-                  {citation.title}
+                  {citation.title ? parseHighlight(citation.title) : ""}
                 </span>
                 <div className="flex items-center pb-[12px] mt-[8px]">
                   {getIcon(citation.app, citation.entity)}

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -1510,7 +1510,7 @@ const MessageCitationList = ({
             >
               <div className="flex pl-[12px] pt-[10px] pr-[12px]">
                 <div className="flex flex-col w-full">
-                  <p className="line-clamp-2 text-[13px] tracking-[0.01em] leading-[17px] text-ellipsis font-medium">
+                  <p className="line-clamp-2 text-[13px] tracking-[0.01em] leading-[17px] text-ellipsis font-medium break-all">
                     {citation.title ? parseHighlight(citation.title) : ""}
                   </p>
                   <div className="flex flex-col mt-[9px]">
@@ -1578,7 +1578,7 @@ const CitationList = ({ citations }: { citations: Citation[] }) => {
                 {index + 1}
               </a>
               <div className="flex flex-col mr-[12px]">
-                <span className="line-clamp-2 text-[13px] tracking-[0.01em] leading-[17px] text-ellipsis font-medium">
+                <span className="line-clamp-2 text-[13px] tracking-[0.01em] leading-[17px] text-ellipsis font-medium break-all">
                   {citation.title ? parseHighlight(citation.title) : ""}
                 </span>
                 <div className="flex items-center pb-[12px] mt-[8px]">


### PR DESCRIPTION
### Description

- Text in the Sources section was being rendered directly without parsing.
- Fixed the issue where highlighted text from Slack sources was not being parsed correctly in the Ask tab.
- Ensured that text in the Sources section no longer overflows or goes out of bounds when displaying Slack source content.


### Testing

- Tested Locally




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Citation titles in chat now support enhanced formatting and highlighting for improved readability, including better handling of long words.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->