### PR TITLE
fix(chats): Fix missing bullet points and numbering in markdown lists

### DIFF
--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -1813,6 +1813,34 @@ export const ChatMessage = ({
                     h6: ({ node, ...props }) => (
                       <h1 style={{ fontSize: "0.68em" }} {...props} />
                     ),
+                    ul: ({ node, ...props }) => (
+                      <ul
+                        style={{
+                          listStyleType: "disc",
+                          paddingLeft: "1.5rem",
+                          marginBottom: "1rem",
+                        }}
+                        {...props}
+                      />
+                    ),
+                    ol: ({ node, ...props }) => (
+                      <ol
+                        style={{
+                          listStyleType: "decimal",
+                          paddingLeft: "1.5rem",
+                          marginBottom: "1rem",
+                        }}
+                        {...props}
+                      />
+                    ),
+                    li: ({ node, ...props }) => (
+                      <li
+                        style={{
+                          marginBottom: "0.25rem",
+                        }}
+                        {...props}
+                      />
+                    ),
                   }}
                 />
               ) : null}


### PR DESCRIPTION
### Description
- Fixed an issue where unordered (`ul`) and ordered (`ol`) lists in chat messages were not rendering bullet points or numbers correctly.

### Testing
Tested locally
<img width="702" alt="image" src="https://github.com/user-attachments/assets/ec94b0de-d694-421f-88dd-72bda05c0dd4" />

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved markdown rendering in chat messages by adding custom styles for unordered and ordered lists, as well as list items, ensuring consistent and visually enhanced display of lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->