### PR TITLE
Remove UploadedBy check for chat access.Now All agents will be visible

### DIFF
--- a/server/api/agent.ts
+++ b/server/api/agent.ts
@@ -8,6 +8,7 @@ import {
   updateAgentByExternalId,
   getAgentByExternalId,
   deleteAgentByExternalId,
+  getAllAgents,
 } from "@/db/agent"
 import { getUserAndWorkspaceByEmail } from "@/db/user"
 import { getLogger } from "@/logger"
@@ -245,10 +246,8 @@ export const ListAgentsApi = async (c: Context) => {
       return c.json({ message: "User or workspace not found" }, 404)
     }
 
-    const agents = await getAgentsByUserId(
+    const agents = await getAllAgents(
       db,
-      userAndWorkspace.user.id,
-      userAndWorkspace.workspace.id,
       limit,
       offset,
     )

--- a/server/api/chat.ts
+++ b/server/api/chat.ts
@@ -2261,6 +2261,18 @@ async function* generateMetadataQueryAnswer(
         items = searchResults!.root.children || []
       }
     }
+    else{
+      searchResults = await getItems({
+        email,
+        schema,
+        app: app ?? null,
+        entity: entity ?? null,
+        timestampRange,
+        limit: userSpecifiedCountLimit,
+        asc: sortDirection === "asc",
+      })
+      items = searchResults!.root.children || []
+    }
 
     span?.setAttribute(`retrieved documents length`, items.length)
     span?.setAttribute(

--- a/server/db/agent.ts
+++ b/server/db/agent.ts
@@ -48,7 +48,6 @@ export const getAgentByExternalId = async (
     .where(
       and(
         eq(agents.externalId, agentExternalId),
-        eq(agents.workspaceId, workspaceId),
         isNull(agents.deletedAt),
       ),
     )
@@ -72,6 +71,28 @@ export const getAgentsByUserId = async (
       and(
         eq(agents.userId, userId),
         eq(agents.workspaceId, workspaceId),
+        isNull(agents.deletedAt),
+      ),
+    )
+    .orderBy(desc(agents.updatedAt))
+    .limit(limit)
+    .offset(offset)
+  return z.array(selectPublicAgentSchema).parse(agentsArr)
+}
+
+// to list all the agent which are there is respective of who has created it
+export const getAllAgents = async (
+  trx: TxnOrClient,
+  // userId: number,
+  // workspaceId: number,
+  limit: number = 50,
+  offset: number = 0,
+): Promise<SelectPublicAgent[]> => {
+  const agentsArr = await trx
+    .select()
+    .from(agents)
+    .where(
+      and(
         isNull(agents.deletedAt),
       ),
     )

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -650,8 +650,7 @@ export const HybridDefaultProfileForAgent = (
           ({targetHits:${hits}}userInput(@query))
           or
           ({targetHits:${hits}}nearestNeighbor(chunk_embeddings, e))
-        )
-        and uploadedBy contains @email 
+        ) 
         and ${dataSourceIdConditions}
         ${appOrEntityFilter} 
       )`
@@ -1679,7 +1678,7 @@ export const getItems = async (
   }
 
   // Permissions or owner condition based on schema
-  if(schema === datasourceFileSchema){
+  if (schema === datasourceFileSchema) {
     // Temporal fix for datasoure selection
   } else if (schema !== userSchema) {
     conditions.push(`permissions contains @email`)


### PR DESCRIPTION

### Description
Earlier we list Agent to users to which he has access too , but now we will list all the Agents 
Also removed the UploadedBy check , Agent using the Data source id to which he has access, get the correct datasource
Added the getItems else case which will run in case of when normal flow
### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve all agents with pagination, regardless of user or workspace.

- **Bug Fixes**
  - Ensured that items are fetched even when no agent prompt is provided in metadata queries.

- **Refactor**
  - Updated agent retrieval and search logic to remove unnecessary user and workspace filters.
  - Adjusted permissions filtering in search queries for data source files.

- **Style**
  - Improved code formatting for consistency (no user-facing impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->