### PR TITLE
Time Range Based Ingestion for Slack Channels

### DIFF
--- a/frontend/src/routes/_authenticated/admin/integrations/slack.tsx
+++ b/frontend/src/routes/_authenticated/admin/integrations/slack.tsx
@@ -438,7 +438,7 @@ const SlackOAuthTab = ({
               onClick={handleRegularIngestion}
               disabled={isRegularIngestionActive}
             >
-              {isRegularIngestionActive ? "Ingesting..." : "Ingest More"}
+              {isRegularIngestionActive ? "Ingesting..." : "Start Ingestion"}
             </Button>
           )}
 
@@ -944,7 +944,7 @@ const ManualIngestionForm = ({
       />
 
       <Button type="submit" disabled={isManualIngestionActive}>
-        {isManualIngestionActive ? "Ingesting..." : "Start Ingestion"}
+        {isManualIngestionActive ? "Ingesting..." : "Ingest Channels"}
       </Button>
     </form>
   )

--- a/frontend/src/routes/_authenticated/admin/integrations/slack.tsx
+++ b/frontend/src/routes/_authenticated/admin/integrations/slack.tsx
@@ -1,4 +1,3 @@
-
 import { createFileRoute, useRouterState } from "@tanstack/react-router"
 import { useEffect, useRef, useState } from "react"
 import { useForm } from "@tanstack/react-form"
@@ -13,7 +12,12 @@ import { Apps, AuthType } from "shared/types"
 import { PublicUser, PublicWorkspace } from "shared/types"
 import { Sidebar } from "@/components/Sidebar"
 import { IntegrationsSidebar } from "@/components/IntegrationsSidebar"
-import { Square, Pause, Play, X } from "lucide-react"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion"
 
 import {
   Card,
@@ -134,6 +138,21 @@ export const SlackOAuthButton = ({
   return <Button onClick={handleOAuth}>{text}</Button>
 }
 
+enum ConnectAction {
+  Nil,
+  Pause,
+  Start,
+  Stop,
+  Remove,
+  Edit,
+}
+
+type ManualIngestionFormData = {
+  channelIds: string
+  startDate: string
+  endDate: string
+}
+
 interface SlackOAuthTabProps {
   isPending: boolean
   oauthIntegrationStatus: OAuthIntegrationStatus
@@ -143,6 +162,9 @@ interface SlackOAuthTabProps {
   connectAction: ConnectAction
   setConnectAction: (status: ConnectAction) => void
   connector: any
+  handleRegularIngestion: () => Promise<void>
+  isManualIngestionActive: boolean
+  isRegularIngestionActive: boolean
 }
 
 const submitSlackOAuth = async (
@@ -355,45 +377,10 @@ const SlackOAuthTab = ({
   connectAction,
   setConnectAction,
   connector,
+  handleRegularIngestion,
+  isManualIngestionActive,
+  isRegularIngestionActive,
 }: SlackOAuthTabProps) => {
-  const handleStatusUpdate = async (
-    connectorId: string,
-    newStatus: ConnectorStatus,
-  ) => {
-    try {
-      await updateConnectorStatus(connectorId, newStatus)
-      toast({
-        title: "Status Updated",
-        description: `Connector status changed to ${newStatus}`,
-      })
-      refetch()
-    } catch (error) {
-      toast({
-        title: "Status Update Failed",
-        description: getErrorMessage(error),
-        variant: "destructive",
-      })
-    }
-  }
-
-  const handleDelete = async (connectorId: string) => {
-    try {
-      await deleteConnector(connectorId)
-      toast({
-        title: "Connector Deleted",
-        description: "Slack connector has been removed",
-      })
-      setOAuthIntegrationStatus(OAuthIntegrationStatus.Provider)
-      refetch()
-    } catch (error) {
-      toast({
-        title: "Deletion Failed",
-        description: getErrorMessage(error),
-        variant: "destructive",
-      })
-    }
-  }
-
   return (
     <TabsContent value="oauth">
       <Card>
@@ -442,62 +429,31 @@ const SlackOAuthTab = ({
                 setIntegrationStatus={setOAuthIntegrationStatus}
               />
             </div>
-          ) : oauthIntegrationStatus ===
-              OAuthIntegrationStatus.OAuthConnecting ||
-            oauthIntegrationStatus === OAuthIntegrationStatus.OAuthPaused ? (
-            <div className="flex flex-col items-center gap-4">
-              <p className="dark:text-gray-300">Connecting to Slack...</p>
-              <div className="flex items-center gap-2"></div>
-              <div className="flex">
-                <Square
-                  onClick={() => {
-                    handleStatusUpdate(
-                      connector.id,
-                      ConnectorStatus.NotConnected,
-                    )
-                  }}
-                />
-                {oauthIntegrationStatus ===
-                OAuthIntegrationStatus.OAuthConnecting ? (
-                  <Pause
-                    onClick={() => {
-                      handleStatusUpdate(connector.id, ConnectorStatus.Paused)
-                    }}
-                  />
-                ) : (
-                  <Play onClick={() => {}} />
-                )}
+          ) : null}
 
-                <X
-                  onClick={() => {
-                    handleDelete(connector.id)
-                  }}
-                />
-              </div>
-            </div>
-          ) : (
-            <div className="flex flex-col items-center gap-4">
-              <p className="text-green-600 dark:text-green-400 font-medium">
-                Slack OAuth Connected
-              </p>
-              <Button variant="outline" onClick={() => refetch()}>
-                Refresh Status
-              </Button>
-            </div>
+          {(oauthIntegrationStatus === OAuthIntegrationStatus.OAuthConnected ||
+            oauthIntegrationStatus ===
+              OAuthIntegrationStatus.OAuthConnecting) && (
+            <Button
+              onClick={handleRegularIngestion}
+              disabled={isRegularIngestionActive}
+            >
+              {isRegularIngestionActive ? "Ingesting..." : "Ingest More"}
+            </Button>
           )}
+
+          {/* {oauthIntegrationStatus === OAuthIntegrationStatus.OAuthConnecting && (
+            <Button
+              onClick={handleRegularIngestion}
+              disabled={isRegularIngestionActive}
+            >
+              {isRegularIngestionActive ? "Ingesting..." : "Start Regular Ingestion"}
+            </Button>
+          )} */}
         </CardContent>
       </Card>
     </TabsContent>
   )
-}
-
-enum ConnectAction {
-  Nil,
-  Pause,
-  Start,
-  Stop,
-  Remove,
-  Edit,
 }
 
 export const Slack = ({
@@ -507,8 +463,7 @@ export const Slack = ({
 }: IntegrationProps) => {
   const navigate = useNavigate()
   const [slackStatus, setSlackStatus] = useState("")
-  // @ts-ignore
-  const [activeTab, setActiveTab] = useState("oauth")
+  const [, setActiveTab] = useState("oauth")
   const startTimeRef = useRef<number | null>(null)
 
   const [connectAction, setConnectAction] = useState<ConnectAction>(
@@ -521,9 +476,11 @@ export const Slack = ({
   const [slackUserStats, setSlackUserStats] = useState<{
     [email: string]: any
   }>({})
+  const [isManualIngestionActive, setIsManualIngestionActive] = useState(false)
+  const [isRegularIngestionActive, setIsRegularIngestionActive] =
+    useState(false)
 
-  // @ts-ignore
-  const { isPending, error, data, refetch } = useQuery<any[]>({
+  const { isPending, data, refetch } = useQuery<any[]>({
     queryKey: ["all-connectors"],
     queryFn: async (): Promise<any> => {
       try {
@@ -567,7 +524,6 @@ export const Slack = ({
   useEffect(() => {
     let socket: WebSocket | null = null
     if (!isPending && data && data.length > 0) {
-      // Open a websocket with the first connector id and pass app as Slack
       const slackConnector = data.find(
         (v) => v.app === Apps.Slack && v.authType === AuthType.OAuth,
       )
@@ -596,6 +552,7 @@ export const Slack = ({
         console.info("Slack WebSocket connection closed", e.reason)
         if (e.reason === "Job finished") {
           setOAuthIntegrationStatus(OAuthIntegrationStatus.OAuthConnected)
+          setIsRegularIngestionActive(false)
         }
       })
       socket?.addEventListener("error", (error) => {
@@ -605,6 +562,7 @@ export const Slack = ({
           description: "Lost connection to Slack integration service",
           variant: "destructive",
         })
+        setIsRegularIngestionActive(false)
       })
     }
     return () => {
@@ -612,50 +570,65 @@ export const Slack = ({
     }
   }, [data, isPending])
 
-  // New component: SlackUserStatsTable similar to Google
-  const SlackUserStatsTable = ({
-    userStats,
-    type,
-  }: {
-    userStats: { [email: string]: any }
-    type: AuthType
-  }) => {
-    const elapsedSeconds = startTimeRef.current
-      ? (Date.now() - startTimeRef.current) / 1000
-      : 1
-    return (
-      <Table className="ml-[20px] max-h-[400px]">
-        <TableHeader>
-          <TableRow>
-            {type !== AuthType.OAuth && <TableHead>Email</TableHead>}
-            <TableHead>Messages</TableHead>
-            <TableHead>Replies</TableHead>
-            <TableHead>Conversations</TableHead>
-            <TableHead>Users</TableHead>
-            <TableHead>msgs / s</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {Object.entries(userStats).map(([email, stats]) => (
-            <TableRow key={email}>
-              {type !== AuthType.OAuth && (
-                <TableCell className={`${stats.done ? "text-lime-600 dark:text-lime-400" : ""}`}>
-                  {email}
-                </TableCell>
-              )}
-              <TableCell>{stats.slackMessageCount}</TableCell>
-              <TableCell>{stats.slackMessageReplyCount}</TableCell>
-              <TableCell>{stats.slackConversationCount}</TableCell>
-              <TableCell>{stats.slackUserCount}</TableCell>
-              <TableCell>
-                {(stats.slackMessageCount / elapsedSeconds).toFixed(2)}
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    )
+  const handleRegularIngestion = async () => {
+    if (!slackConnector?.cId) {
+      toast({
+        title: "Slack connector not found",
+        description: "Please ensure Slack is connected.",
+        variant: "destructive",
+      })
+      return
+    }
+
+    setIsRegularIngestionActive(true)
+
+    try {
+      const response = await api.admin.slack.start_ingestion.$post({
+        json: {
+          connectorId: slackConnector.cId,
+        },
+      })
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        toast({
+          title: "Regular Ingestion Failed",
+          description: `Error: ${errorText}`,
+          variant: "destructive",
+        })
+        setIsRegularIngestionActive(false)
+        return
+      }
+
+      toast({
+        title: "Regular Ingestion Started",
+        description: "Regular ingestion process initiated successfully.",
+      })
+    } catch (error) {
+      toast({
+        title: "An error occurred",
+        description: `Error: ${getErrorMessage(error)}`,
+        variant: "destructive",
+      })
+      setIsRegularIngestionActive(false)
+    }
   }
+
+  useEffect(() => {
+    console.log("slackUserStats changed:", slackUserStats)
+  }, [slackUserStats])
+
+  useEffect(() => {
+    console.log("isRegularIngestionActive:", isRegularIngestionActive)
+  }, [isRegularIngestionActive])
+
+  useEffect(() => {
+    console.log("isManualIngestionActive:", isManualIngestionActive)
+  }, [isManualIngestionActive])
+
+  useEffect(() => {
+    console.log("slackProgress:", slackProgress)
+  }, [slackProgress])
 
   return (
     <div className="flex w-full h-full dark:bg-[#1E1E1E]">
@@ -680,12 +653,7 @@ export const Slack = ({
 
             <TabsContent value="bot">
               <Card>
-                <CardHeader>
-                  {/* <CardTitle>Slack Bot</CardTitle>
-                  <CardDescription>
-                    Add your Slack Bot Token to enable integration.
-                  </CardDescription> */}
-                </CardHeader>
+                <CardHeader></CardHeader>
                 <CardContent>
                   <SlackBotTokenForm
                     onSuccess={() => setSlackStatus("connecting")}
@@ -711,9 +679,13 @@ export const Slack = ({
               connectAction={connectAction}
               setConnectAction={setConnectAction}
               connector={slackConnector}
+              handleRegularIngestion={handleRegularIngestion}
+              isManualIngestionActive={isManualIngestionActive}
+              isRegularIngestionActive={isRegularIngestionActive}
             />
           </Tabs>
 
+          {/* Show regular ingestion stats above the accordion */}
           {Object.keys(slackUserStats).length > 0 && (
             <div className="mt-4 w-full">
               <p className="mb-2 dark:text-gray-300">
@@ -726,9 +698,91 @@ export const Slack = ({
               />
             </div>
           )}
+
+          <Accordion type="single" collapsible className="w-full mt-4">
+            <AccordionItem value="manual-ingestion">
+              <AccordionTrigger>Manual Ingestion</AccordionTrigger>
+              <AccordionContent>
+                {oauthIntegrationStatus ===
+                  OAuthIntegrationStatus.OAuthConnecting ||
+                oauthIntegrationStatus ===
+                  OAuthIntegrationStatus.OAuthConnected ? (
+                  <ManualIngestionForm
+                    connectorId={slackConnector?.cId}
+                    isManualIngestionActive={isManualIngestionActive}
+                    setIsManualIngestionActive={setIsManualIngestionActive}
+                    slackProgress={slackProgress}
+                    slackUserStats={slackUserStats}
+                  />
+                ) : (
+                  <p>Please connect Slack OAuth to enable manual ingestion.</p>
+                )}
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+
+          {/* Show manual ingestion stats below the accordion */}
+          {isManualIngestionActive &&
+            Object.keys(slackUserStats).length > 0 && (
+              <div className="mt-4 w-full">
+                <p className="mb-2">
+                  Manual Ingestion Progress: {slackProgress}%
+                </p>
+                <Progress value={slackProgress} className="w-[60%] mb-4" />
+                <SlackUserStatsTable
+                  userStats={slackUserStats}
+                  type={AuthType.OAuth}
+                />
+              </div>
+            )}
         </div>
       </div>
     </div>
+  )
+}
+
+const SlackUserStatsTable = ({
+  userStats,
+  type,
+}: {
+  userStats: { [email: string]: any }
+  type: AuthType
+}) => {
+  const startTimeRef = useRef<number | null>(null)
+  const elapsedSeconds = startTimeRef.current
+    ? (Date.now() - startTimeRef.current) / 1000
+    : 1
+  return (
+    <Table className="ml-[20px] max-h-[400px]">
+      <TableHeader>
+        <TableRow>
+          {type !== AuthType.OAuth && <TableHead>Email</TableHead>}
+          <TableHead>Messages</TableHead>
+          <TableHead>Replies</TableHead>
+          <TableHead>Conversations</TableHead>
+          <TableHead>Users</TableHead>
+          <TableHead>msgs / s</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {Object.entries(userStats).map(([email, stats]) => (
+          <TableRow key={email}>
+            {type !== AuthType.OAuth && (
+              <TableCell className={`${stats.done ? "text-lime-600" : ""}`}>
+                {email}
+              </TableCell>
+            )}
+            <TableCell>{stats.slackMessageCount}</TableCell>
+            <TableCell>{stats.slackMessageReplyCount}</TableCell>
+            <TableCell>{stats.slackConversationCount}</TableCell>
+            <TableCell>{stats.slackUserCount}</TableCell>
+            <TableCell>
+              {(stats.slackMessageCount / elapsedSeconds).toFixed(2)}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
   )
 }
 
@@ -736,15 +790,6 @@ export const Route = createFileRoute(
   "/_authenticated/admin/integrations/slack",
 )({
   beforeLoad: async ({ params, context }) => {
-    // @ts-ignore
-    const userWorkspace = context
-    // Admins should be redirected to visit /admin/integrations
-    // if (
-    //   userWorkspace?.user?.role === UserRole.SuperAdmin ||
-    //   userWorkspace?.user?.role === UserRole.Admin
-    // ) {
-    //   throw redirect({ to: '/admin/integrations/' })
-    // }
     return params
   },
   loader: async (params) => {
@@ -763,3 +808,144 @@ export const Route = createFileRoute(
     )
   },
 })
+
+interface ManualIngestionFormProps {
+  connectorId: string | undefined
+  isManualIngestionActive: boolean
+  setIsManualIngestionActive: (active: boolean) => void
+  slackProgress: number
+  slackUserStats: { [email: string]: any }
+}
+
+const ManualIngestionForm = ({
+  connectorId,
+  isManualIngestionActive,
+  setIsManualIngestionActive,
+  slackProgress,
+  slackUserStats,
+}: ManualIngestionFormProps) => {
+  const { toast } = useToast()
+  // const startTimeRef = useRef<number | null>(null)
+
+  const form = useForm<ManualIngestionFormData>({
+    defaultValues: { channelIds: "", startDate: "", endDate: "" },
+    onSubmit: async ({ value }) => {
+      if (!connectorId) {
+        toast({
+          title: "Slack connector not found",
+          description: "Please ensure Slack is connected.",
+          variant: "destructive",
+        })
+        return
+      }
+
+      setIsManualIngestionActive(true)
+
+      try {
+        const channelIdsList = value.channelIds
+          .split(",")
+          .map((id) => id.trim())
+          .filter((id) => id.length > 0)
+
+        if (channelIdsList.length === 0) {
+          toast({
+            title: "Invalid Channel IDs",
+            description: "Please provide at least one valid channel ID.",
+            variant: "destructive",
+          })
+          setIsManualIngestionActive(false)
+          return
+        }
+
+        const response = await api.admin.slack.ingest_more_channel.$post({
+          json: {
+            connectorId: connectorId,
+            channelsToIngest: channelIdsList,
+            startDate: value.startDate,
+            endDate: value.endDate,
+          },
+        })
+
+        if (!response.ok) {
+          const errorText = await response.text()
+          toast({
+            title: "Ingestion Failed",
+            description: `Error: ${errorText}`,
+            variant: "destructive",
+          })
+          setIsManualIngestionActive(false)
+          return
+        }
+
+        toast({
+          title: "Manual Ingestion Started",
+          description: "Ingestion process initiated successfully.",
+        })
+
+        form.reset()
+        setIsManualIngestionActive(false)
+      } catch (error) {
+        toast({
+          title: "An error occurred",
+          description: `Error: ${getErrorMessage(error)}`,
+          variant: "destructive",
+        })
+        setIsManualIngestionActive(false)
+      }
+    },
+  })
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        form.handleSubmit()
+      }}
+      className="grid w-full max-w-sm items-center gap-1.5"
+    >
+      <Label htmlFor="channelIds">Channel IDs (comma-separated)</Label>
+      <form.Field
+        name="channelIds"
+        children={(field) => (
+          <Input
+            id="channelIds"
+            type="text"
+            value={field.state.value}
+            onChange={(e) => field.handleChange(e.target.value)}
+            placeholder="e.g., C123,C456"
+          />
+        )}
+      />
+
+      <Label htmlFor="startDate">Start Date</Label>
+      <form.Field
+        name="startDate"
+        children={(field) => (
+          <Input
+            id="startDate"
+            type="date"
+            value={field.state.value}
+            onChange={(e) => field.handleChange(e.target.value)}
+          />
+        )}
+      />
+
+      <Label htmlFor="endDate">End Date</Label>
+      <form.Field
+        name="endDate"
+        children={(field) => (
+          <Input
+            id="endDate"
+            type="date"
+            value={field.state.value}
+            onChange={(e) => field.handleChange(e.target.value)}
+          />
+        )}
+      />
+
+      <Button type="submit" disabled={isManualIngestionActive}>
+        {isManualIngestionActive ? "Ingesting..." : "Start Ingestion"}
+      </Button>
+    </form>
+  )
+}

--- a/server/api/admin.ts
+++ b/server/api/admin.ts
@@ -9,6 +9,7 @@ import {
   insertConnector,
   updateConnector,
   deleteOauthConnector,
+  getConnector,
 } from "@/db/connector"
 import {
   ConnectorType,
@@ -36,6 +37,8 @@ import {
 import { handleGoogleServiceAccountIngestion } from "@/integrations/google"
 import { scopes } from "@/integrations/google/config"
 import { ServiceAccountIngestMoreUsers } from "@/integrations/google"
+import { handleSlackChannelIngestion } from "@/integrations/slack/channelIngest"
+import { handleSlackIngestion } from "@/integrations/slack"
 import {
   clearUserDataInVespa,
   type ClearUserDataOptions,
@@ -53,6 +56,7 @@ export const GetConnectors = async (c: Context) => {
   }
   const user = users[0]
   const connectors = await getConnectors(workspaceId, user.id)
+  console.log(connectors)
   return c.json(connectors)
 }
 
@@ -587,6 +591,87 @@ export const AdminDeleteUserData = async (c: Context) => {
     )
     throw new HTTPException(500, {
       message: `Failed to clear user data for ${emailToClear}: ${errorMessage}`,
+    })
+  }
+}
+
+export const StartSlackIngestionApi = async (c: Context) => {
+  const { sub } = c.get(JwtPayloadKey)
+  // @ts-ignore - Assuming payload is validated by zValidator
+  const payload = c.req.valid("json") as { connectorId: string }
+
+  try {
+    const userRes = await getUserByEmail(db, sub)
+    if (!userRes || !userRes.length) {
+      Logger.error({ sub }, "No user found for sub in StartSlackIngestionApi")
+      throw new NoUserFound({})
+    }
+    const [user] = userRes
+
+    const connector = await getConnector(db, parseInt(payload.connectorId))
+    if (!connector) {
+      throw new HTTPException(404, { message: "Connector not found" })
+    }
+
+    // Call the main Slack ingestion function
+    handleSlackIngestion({
+      connectorId: connector.id,
+      app: connector.app as Apps,
+      externalId: connector.externalId,
+      authType: connector.authType as AuthType,
+      email: sub,
+    }).catch((error) => {
+      Logger.error(
+        error,
+        `Background Slack ingestion failed for connector ${connector.id}: ${getErrorMessage(error)}`,
+      )
+    })
+
+    return c.json({
+      success: true,
+      message: "Regular Slack ingestion started.",
+    })
+  } catch (error: any) {
+    Logger.error(
+      error,
+      `Error starting regular Slack ingestion: ${getErrorMessage(error)}`,
+    )
+    if (error instanceof HTTPException) throw error
+    throw new HTTPException(500, {
+      message: `Failed to start regular Slack ingestion: ${getErrorMessage(error)}`,
+    })
+  }
+}
+
+export const IngestMoreChannelApi = async (c: Context) => {
+  const { sub } = c.get(JwtPayloadKey)
+  console.log(sub)
+  // @ts-ignore
+  const payload = c.req.valid("json") as {
+    connectorId: string
+    channelsToIngest: string[]
+    startDate: string
+    endDate: string
+  }
+
+  try {
+    const email = sub
+    const resp = await handleSlackChannelIngestion(
+      parseInt(payload.connectorId),
+      payload.channelsToIngest,
+      payload.startDate,
+      payload.endDate,
+      email,
+    )
+    return c.json({
+      success: true,
+      message: "Successfully ingested the channels",
+    })
+  } catch (error) {
+    Logger.info(error)
+    return c.json({
+      success: false,
+      message: error,
     })
   }
 }

--- a/server/api/oauth.ts
+++ b/server/api/oauth.ts
@@ -137,13 +137,16 @@ export const OAuthCallback = async (c: Context) => {
     } else if (app === Apps.Slack) {
       const abortController = new AbortController()
       globalAbortControllers.set(`${connector.id}`, abortController)
-      handleSlackIngestion({
-        connectorId: connector.id,
-        app,
-        externalId: connector.externalId,
-        authType: connector.authType as AuthType,
-        email: sub,
-      })
+      // we are avoiding this , we will stop the flow here
+      // either we will provide the button to start it
+      // else we will merge it with the channelthing
+      // handleSlackIngestion({
+      //   connectorId: connector.id,
+      //   app,
+      //   externalId: connector.externalId,
+      //   authType: connector.authType as AuthType,
+      //   email: sub,
+      // })
     } else {
       const SaasJobPayload: SaaSOAuthJob = {
         connectorId: connector.id,

--- a/server/db/connector.ts
+++ b/server/db/connector.ts
@@ -5,6 +5,7 @@ import {
   ingestionStateSchema,
   oauthProviders,
   selectConnectorSchema,
+  users,
   type IngestionStateUnion,
   type SelectConnector,
   type SelectOAuthProvider,
@@ -86,6 +87,7 @@ export const getConnectors = async (workspaceId: string, userId: number) => {
   const res = await db
     .select({
       id: connectors.externalId,
+      cId: connectors.id,
       app: connectors.app,
       authType: connectors.authType,
       type: connectors.type,
@@ -255,6 +257,36 @@ export const getConnectorByExternalId = async (
     )
     throw new NoConnectorsFound({
       message: `Connector not found for external ID ${connectorId} and user ID ${userId}`,
+    })
+  }
+}
+
+export const getConnectorByAppAndEmailId = async (
+  trx: TxnOrClient,
+  app: Apps,
+  authType: AuthType,
+  emailId: string,
+): Promise<SelectConnector> => {
+  const res = await trx
+    .select()
+    .from(connectors)
+    .innerJoin(users, eq(connectors.userId, users.id))
+    .where(and(eq(connectors.app, app), eq(users.email, emailId)))
+    .limit(1)
+  // console.log(res[0].connectors)
+  if (res.length) {
+    const parsedRes = selectConnectorSchema.safeParse(res[0].connectors)
+    if (!parsedRes.success) {
+      Logger.error(`Failed to parse connector data for user:${emailId} `)
+      throw new NoConnectorsFound({
+        message: `Could not parse connector data for user: ${emailId}`,
+      })
+    }
+    return parsedRes.data
+  } else {
+    Logger.error(`Connector not found for emailID ${emailId} and app  ${app}`)
+    throw new NoConnectorsFound({
+      message: `Connector not found for emailID ${emailId} and app  ${app}`,
     })
   }
 }

--- a/server/integrations/slack/channelIngest.ts
+++ b/server/integrations/slack/channelIngest.ts
@@ -1,0 +1,1042 @@
+import { getOAuthConnectorWithCredentials } from "@/db/connector"
+import {
+  connectors,
+  type SelectConnector,
+  type SlackOAuthIngestionState,
+} from "@/db/schema"
+import {
+  Apps,
+  chatContainerSchema,
+  chatMessageSchema,
+  chatTeamSchema,
+  chatUserSchema,
+  SlackEntity,
+  type VespaChatContainer,
+  type VespaChatMessage,
+} from "@/search/types"
+import {
+  ifDocumentsExist,
+  ifDocumentsExistInSchema,
+  insert,
+  insertWithRetry,
+  NAMESPACE,
+  UpdateDocument,
+  UpdateDocumentPermissions,
+} from "@/search/vespa"
+import {
+  OperationStatus,
+  Subsystem,
+  SyncCron,
+  type SaaSOAuthJob,
+} from "@/types"
+import {
+  retryPolicies,
+  WebClient,
+  type ConversationsHistoryResponse,
+  type ConversationsListResponse,
+  type ConversationsRepliesResponse,
+  type FilesListResponse,
+  type TeamInfoResponse,
+  type UsersListResponse,
+} from "@slack/web-api"
+import type { Channel } from "@slack/web-api/dist/types/response/ConversationsListResponse"
+import type PgBoss from "pg-boss"
+import { db } from "@/db/client"
+import { getLogger } from "@/logger"
+import type { Member } from "@slack/web-api/dist/types/response/UsersListResponse"
+import type { Team } from "@slack/web-api/dist/types/response/TeamInfoResponse"
+import type { User } from "@slack/web-api/dist/types/response/UsersInfoResponse"
+import { count, eq } from "drizzle-orm"
+import { StatType, Tracker } from "@/integrations/tracker"
+import { sendWebsocketMessage } from "../metricStream"
+import { AuthType, ConnectorStatus, SyncJobStatus } from "@/shared/types"
+import pLimit from "p-limit"
+import { IngestionState } from "../ingestionState"
+import { insertSyncJob } from "@/db/syncJob"
+import type { Reaction } from "@slack/web-api/dist/types/response/ChannelsHistoryResponse"
+import { time } from "console"
+import {
+  ingestedMembersErrorTotalCount,
+  ingestedMembersTotalCount,
+  ingestedTeamErrorTotalCount,
+  ingestedTeamTotalCount,
+  insertChannelMessageDuration,
+  insertChannelMessagesCount,
+  insertChannelMessagesErrorCount,
+  insertChatMessagesCount,
+  insertConversationCount,
+  insertConversationDuration,
+  insertConversationErrorCount,
+} from "@/metrics/slack/slack-metrics"
+import { start } from "repl"
+
+const Logger = getLogger(Subsystem.Integrations).child({ module: "slack" })
+
+export const getAllUsers = async (client: WebClient): Promise<Member[]> => {
+  let users: Member[] = []
+  let cursor: string | undefined = undefined
+  do {
+    const response = await client.users.list({ limit: 999, cursor })
+    if (!response.ok) {
+      throw new Error(`Error fetching users: ${response.error}`)
+    }
+    if (response.members) {
+      users = users.concat(response.members)
+    }
+    cursor = response.response_metadata?.next_cursor
+  } while (cursor)
+  return users
+}
+
+/**
+ * Retrieves team (workspace) metadata using the team.info API.
+ */
+const getTeamInfo = async (client: WebClient): Promise<Team> => {
+  const response = await client.team.info()
+  if (!response.ok) {
+    throw new Error(`Error fetching team info: ${response.error}`)
+  }
+  return response.team!
+}
+
+/**
+ * Fetches all conversations of types: public, private, IMs, and MPIMs.
+ * except archived channels
+ */
+export async function getAllConversations(
+  client: WebClient,
+  excludeArchived: boolean,
+  abortController: AbortController,
+): Promise<ConversationsListResponse["channels"]> {
+  let channels: Channel[] = []
+  let cursor: string | undefined = undefined
+  do {
+    if (abortController.signal.aborted) {
+      Logger.info("Aborted fetching conversations")
+      break
+    }
+    const response = await client.conversations.list({
+      types: "public_channel,private_channel,im,mpim",
+      exclude_archived: excludeArchived,
+      limit: 999,
+      cursor,
+    })
+    if (!response.ok) {
+      throw new Error(`Error fetching conversations: ${response.error}`)
+    }
+    if (response.channels) {
+      channels = channels.concat(response.channels)
+    }
+    cursor = response.response_metadata?.next_cursor
+  } while (cursor)
+  return channels
+}
+
+type SlackMessage = NonNullable<
+  ConversationsHistoryResponse["messages"]
+>[number]
+
+const safeConversationReplies = async (
+  client: WebClient,
+  channelId: string,
+  threadTs: string,
+  cursor: string | undefined,
+  timestamp: string = "0",
+): Promise<ConversationsRepliesResponse> => {
+  return retryOnFatal(
+    () =>
+      client.conversations.replies({
+        channel: channelId,
+        ts: threadTs,
+        limit: 999,
+        cursor,
+        oldest: timestamp,
+      }),
+    3,
+    1000,
+  )
+}
+/**
+ * Fetches all messages in a thread (given the parent message's thread_ts)
+ */
+export async function fetchThreadMessages(
+  client: WebClient,
+  channelId: string,
+  threadTs: string,
+  timestamp: string = "0",
+): Promise<SlackMessage[]> {
+  let threadMessages: SlackMessage[] = []
+  let cursor: string | undefined = undefined
+  do {
+    const response: ConversationsRepliesResponse =
+      await safeConversationReplies(
+        client,
+        channelId,
+        threadTs,
+        cursor,
+        timestamp,
+      )
+    if (!response.ok) {
+      throw new Error(
+        `Error fetching thread replies for ${threadTs}: ${response.error}`,
+      )
+    }
+    if (response.messages) {
+      threadMessages.push(...(response.messages as SlackMessage[]))
+    }
+    cursor = response.response_metadata?.next_cursor
+  } while (cursor)
+  return threadMessages
+}
+
+function replaceMentionsIfPresent(message: string, memberMap: any): string {
+  const regex = /<@([^>]+)>/g
+
+  // Check if there's at least one mention
+  if (!regex.test(message)) {
+    return message // No mentions, return original text
+  }
+
+  // Reset regex lastIndex after test() and replace mentions
+  regex.lastIndex = 0
+  return message.replace(regex, (_match, userId) => {
+    const user = memberMap[userId]
+    return user ? `@${user.name}` : `<@${userId}>` // Replace with username or keep original
+  })
+}
+
+export const safeGetTeamInfo = async (client: WebClient): Promise<Team> => {
+  return retryOnFatal(() => getTeamInfo(client), 3, 1000)
+}
+
+export const safeConversationHistory = async (
+  client: WebClient,
+  channelId: string,
+  cursor: string | undefined,
+  timestamp: string = "0",
+  startDate: string,
+  endDate: string,
+): Promise<ConversationsHistoryResponse> => {
+  // Convert date strings to Unix timestamps
+  const oldestTimestamp = startDate
+    ? Math.floor(new Date(startDate).getTime() / 1000).toString()
+    : timestamp
+  const latestTimestamp = endDate
+    ? Math.floor(new Date(endDate).getTime() / 1000).toString()
+    : undefined
+  console.log(oldestTimestamp)
+  console.log(latestTimestamp)
+  return retryOnFatal(
+    () =>
+      client.conversations.history({
+        channel: channelId,
+        limit: 999,
+        cursor,
+        oldest: oldestTimestamp,
+        latest: latestTimestamp,
+      }),
+    3,
+    1000,
+  )
+}
+
+// instead of parsing ourselves we are relying on slack to provide us the
+// user id's
+export function extractUserIdsFromBlocks(message: SlackMessage): string[] {
+  if (!message.blocks) return []
+  const userIds: string[] = []
+  for (const block of message.blocks) {
+    if (block.type === "rich_text" && block.elements) {
+      for (const section of block.elements) {
+        if (section.elements) {
+          // Check the nested elements array
+          for (const element of section.elements) {
+            // @ts-ignore
+            if (element.type === "user" && element.user_id) {
+              // @ts-ignore
+              userIds.push(element.user_id)
+            }
+          }
+        }
+      }
+    }
+  }
+  return userIds
+}
+export function formatSlackSpecialMentions(
+  text: string | undefined,
+  channelMap: Map<string, string>,
+  currentChannelId: string,
+): string {
+  if (!text) return ""
+
+  let formattedText = text
+
+  // Get current channel name
+  const currentChannelName = channelMap.get(currentChannelId) || "this"
+
+  // Replace special mentions with more descriptive text
+  formattedText = formattedText.replace(/<!channel>/gi, `@channel`)
+
+  formattedText = formattedText.replace(/<!here>/gi, `@here`)
+
+  // Handle channel mentions with empty display name: <#C12345|>
+  formattedText = formattedText.replace(
+    /<#([A-Z0-9]+)\|>/g,
+    (match, channelId) => {
+      const channelName = channelMap.get(channelId)
+      return channelName ? `#${channelName}` : `#unknown-channel`
+    },
+  )
+
+  return formattedText
+}
+/**
+ * Fetches all messages from a channel.
+ * For each message that is a thread parent, it also fetches the thread replies.
+ */
+export async function insertChannelMessages(
+  email: string,
+  client: WebClient,
+  channelId: string,
+  abortController: AbortController,
+  memberMap: Map<string, User>,
+  tracker: Tracker,
+  timestamp: string = "0",
+  channelMap: Map<string, string>,
+  startDate: string,
+  endDate: string,
+): Promise<void> {
+  let cursor: string | undefined = undefined
+
+  let replyCount = 0
+
+  const subtypes = new Set()
+  do {
+    const response: ConversationsHistoryResponse =
+      await safeConversationHistory(
+        client,
+        channelId,
+        cursor,
+        timestamp,
+        startDate,
+        endDate,
+      )
+
+    if (!response.ok) {
+      throw new Error(
+        `Error fetching messages for channel ${channelId}: ${response.error}`,
+      )
+    }
+
+    if (response.messages) {
+      for (const message of response.messages as (SlackMessage & {
+        mentions: string[]
+      })[]) {
+        // replace user id with username
+
+        const mentions = extractUserIdsFromBlocks(message)
+        let text = message.text
+        if (mentions.length) {
+          for (const m of mentions) {
+            if (!memberMap.get(m)) {
+              memberMap.set(
+                m,
+                (
+                  await client.users.info({
+                    user: m,
+                  })
+                ).user!,
+              )
+            }
+            text = text?.replace(
+              `<@${m}>`,
+              `@${memberMap.get(m)?.profile?.display_name ?? memberMap.get(m)?.name}`,
+            )
+          }
+        }
+        text = formatSlackSpecialMentions(text, channelMap, channelId)
+        message.text = text
+        // Add the top-level message
+        if (
+          message.type === "message" &&
+          !message.subtype &&
+          message.user &&
+          message.client_msg_id &&
+          message.text != ""
+          // memberMap[message.user]
+        ) {
+          // a deleted user's message could be there
+          if (!memberMap.get(message.user)) {
+            memberMap.set(
+              message.user,
+              (
+                await client.users.info({
+                  user: message.user,
+                })
+              ).user!,
+            )
+          }
+          message.mentions = mentions
+          message.team = await getTeam(client, message)
+
+          // case to avoid bot messages
+          await insertChatMessage(
+            client,
+            message,
+            channelId,
+            memberMap.get(message.user!)?.profile?.display_name!,
+            memberMap.get(message.user!)?.name!,
+            memberMap.get(message.user!)?.profile?.image_192!,
+          )
+          try {
+            insertChatMessagesCount.inc({
+              conversation_id: channelId,
+              status: OperationStatus.Success,
+              team_id: message.team,
+            })
+          } catch (error) {
+            Logger.error(error, `Error inserting chat message`)
+          }
+          tracker.updateUserStats(email, StatType.Slack_Message, 1)
+        } else {
+          subtypes.add(message.subtype)
+        }
+
+        // If the message is a thread parent (its thread_ts equals its ts) and it has replies, fetch them.
+        if (
+          message.thread_ts &&
+          message.thread_ts === message.ts &&
+          message.reply_count &&
+          message.reply_count > 0
+        ) {
+          replyCount += 1
+          // this is the part that takes the longest and uses up all the rate limit quota
+          // for slack api
+          // for each thread that exists it will count as at least 1 api call
+          // if not for this I was able to achieve 200+ messages per second ingestion
+          // but with this we will have to accept ~5-10 messages per second rate.
+          // there is no way around this, as long as we want to ingest replies.
+          const threadMessages: SlackMessage[] = await fetchThreadMessages(
+            client,
+            channelId,
+            message.thread_ts,
+          )
+          // Exclude the parent message (already added)
+          const replies: (SlackMessage & { mentions?: string[] })[] =
+            threadMessages.filter((msg) => msg.ts !== message.ts)
+          for (const reply of replies) {
+            if (
+              reply.type === "message" &&
+              !reply.subtype &&
+              reply.user &&
+              reply.client_msg_id &&
+              reply.text != ""
+              // memberMap[reply.user]
+            ) {
+              const mentions = extractUserIdsFromBlocks(reply)
+              let text = reply.text
+              if (mentions.length) {
+                for (const m of mentions) {
+                  if (!memberMap.get(m)) {
+                    memberMap.set(
+                      m,
+                      (
+                        await client.users.info({
+                          user: m,
+                        })
+                      ).user!,
+                    )
+                  }
+                  text = text?.replace(
+                    `<@${m}>`,
+                    `@${memberMap.get(m)?.profile?.display_name ?? memberMap.get(m)?.name}`,
+                  )
+                }
+              }
+              text = formatSlackSpecialMentions(text, channelMap, channelId)
+              if (!memberMap.get(reply.user)) {
+                memberMap.set(
+                  reply.user,
+                  (
+                    await client.users.info({
+                      user: reply.user,
+                    })
+                  ).user!,
+                )
+              }
+              reply.mentions = mentions
+              reply.text = text
+
+              reply.team = await getTeam(client, reply)
+
+              await insertChatMessage(
+                client,
+                reply,
+                channelId,
+                memberMap.get(reply.user!)?.profile?.display_name!,
+                memberMap.get(reply.user!)?.name!,
+                memberMap.get(reply.user!)?.profile?.image_192!,
+              )
+              try {
+                insertChatMessagesCount.inc({
+                  conversation_id: channelId,
+                  status: OperationStatus.Success,
+                  team_id: message.team,
+                })
+              } catch (error) {
+                Logger.error(error, `Error inserting chat message`)
+              }
+              tracker.updateUserStats(email, StatType.Slack_Message_Reply, 1)
+            } else {
+              subtypes.add(reply.subtype)
+            }
+          }
+        }
+      }
+    }
+
+    cursor = response.response_metadata?.next_cursor
+  } while (cursor)
+}
+
+/**
+ * Fetches all files from a channel.
+ */
+async function fetchChannelFiles(
+  client: WebClient,
+  channelId: string,
+): Promise<FilesListResponse["files"]> {
+  let files: FilesListResponse["files"] = []
+  let cursor: string | undefined = undefined
+  do {
+    const response = (await client.files.list({
+      channel: channelId,
+      // limit: 200,
+      // cursor,
+    })) as FilesListResponse
+
+    if (!response.ok) {
+      throw new Error(
+        `Error fetching files for channel ${channelId}: ${response.error}`,
+      )
+    }
+
+    if (response.files) {
+      files = files.concat(response.files)
+    }
+    cursor = response.response_metadata?.next_cursor
+  } while (cursor)
+  return files
+}
+
+const joinChannel = async (
+  client: WebClient,
+  channelId: string,
+): Promise<void> => {
+  try {
+    const response = await client.conversations.join({ channel: channelId })
+    if (!response.ok) {
+      throw new Error(`Failed to join channel: ${response.error}`)
+    }
+    console.log(`Successfully joined channel: ${channelId}`)
+  } catch (error) {
+    console.error("Error joining channel:", error)
+  }
+}
+
+export const insertConversation = async (
+  conversation: Channel & { permissions: string[] },
+): Promise<void> => {
+  const vespaChatContainer: VespaChatContainer = {
+    docId: conversation.id!,
+    name: conversation.name!,
+    channelName: (conversation as Channel).name!,
+    app: Apps.Slack,
+    creator: conversation.creator!,
+    isPrivate: conversation.is_private ?? false,
+    isGeneral: conversation.is_general ?? false,
+    isArchived: conversation.is_archived ?? false,
+    isIm: conversation.is_im ?? false,
+    isMpim: conversation.is_mpim ?? false,
+    createdAt: conversation.created ?? new Date().getTime(),
+    updatedAt: conversation.updated ?? conversation.created!,
+    lastSyncedAt: new Date().getTime(),
+    topic: conversation.topic?.value ?? "",
+    description: conversation.purpose?.value!,
+    permissions: conversation.permissions,
+    count: conversation.num_members ?? conversation.permissions.length,
+  }
+  await insertWithRetry(vespaChatContainer, chatContainerSchema)
+}
+
+const insertConversations = async (
+  conversations: ConversationsListResponse["channels"],
+  abortController: AbortController,
+): Promise<void> => {
+  for (const conversation of conversations || []) {
+    if ((conversation as Channel).is_channel) {
+      const vespaChatContainer: VespaChatContainer = {
+        docId: (conversation as Channel).id!,
+        name: (conversation as Channel).name!,
+        channelName: (conversation as Channel).name!,
+        app: Apps.Slack,
+        creator: (conversation as Channel).creator!,
+        isPrivate: (conversation as Channel).is_private!,
+        isGeneral: (conversation as Channel).is_general!,
+        isArchived: (conversation as Channel).is_archived!,
+        // @ts-ignore
+        isIm: (conversation as Channel).is_im!,
+        isMpim: (conversation as Channel).is_mpim!,
+        createdAt: (conversation as Channel).created!,
+        updatedAt: (conversation as Channel).created!,
+        lastSyncedAt: new Date().getTime(),
+        topic: (conversation as Channel).topic?.value!,
+        description: (conversation as Channel).purpose?.value!,
+        permissions: [],
+        count: (conversation as Channel).num_members!,
+      }
+      await insertWithRetry(vespaChatContainer, chatContainerSchema)
+    }
+  }
+}
+
+export async function getConversationUsers(
+  userId: string,
+  client: WebClient,
+  conversation: Channel,
+): Promise<string[]> {
+  Logger.info("fetching users from conversation")
+
+  if (conversation.is_im) {
+    if (!conversation.user) {
+      return [userId]
+    }
+    return [userId, conversation.user!]
+  }
+
+  let allMembers: string[] = []
+  let cursor: string | undefined
+
+  try {
+    do {
+      const result = await client.conversations.members({
+        channel: conversation.id!,
+        limit: 999,
+        cursor,
+      })
+
+      if (result.ok && result.members) {
+        allMembers = allMembers.concat(result.members)
+        cursor = result.response_metadata?.next_cursor
+      } else {
+        throw new Error("Failed to fetch channel members")
+      }
+    } while (cursor)
+
+    return allMembers
+  } catch (error) {
+    console.error("Error fetching channel users:", error)
+    return []
+  }
+}
+
+export const getTeam = async (
+  client: WebClient,
+  message: SlackMessage & { mentions?: string[] },
+) => {
+  if (!message.team) {
+    if (message.files) {
+      for (const file of message.files) {
+        if (file.user_team) {
+          message.team = file.user_team
+          break
+        }
+      }
+    }
+  }
+  if (!message.team) {
+    const res = await client.users.info({ user: message.user! })
+    if (res.ok) {
+      message.team = res.user?.team_id
+    }
+  }
+  return message.team
+}
+
+export const insertChatMessage = async (
+  client: WebClient,
+  message: SlackMessage & { mentions?: string[] },
+  channelId: string,
+  name: string,
+  username: string,
+  image: string,
+) => {
+  const editedTimestamp = message.edited
+    ? parseFloat(message?.edited?.ts!)
+    : message.ts!
+
+  return insertWithRetry(
+    {
+      docId: message.client_msg_id!,
+      teamId: message.team!,
+      text: message.text!,
+      attachmentIds: [],
+      app: Apps.Slack,
+      entity: SlackEntity.Message,
+      name: name || username,
+      username,
+      image,
+      teamRef: `id:${NAMESPACE}:${chatTeamSchema}::${message.team!}`,
+      chatRef: `id:${NAMESPACE}:${chatContainerSchema}::${channelId}`,
+      reactions: message.reactions?.reduce((acc, curr) => {
+        return acc + (curr as Reaction).count! || 0
+      }, 0),
+      channelId,
+      userId: message.user!,
+      replyCount: message.reply_count!,
+      replyUsersCount: message.reply_users_count!,
+      threadId: message.thread_ts!,
+      createdAt: parseFloat(message.ts!),
+      mentions: message.mentions || [],
+      updatedAt: editedTimestamp,
+      deletedAt: 0,
+      // files: [],
+      metadata: "",
+      // files: message.files,
+    } as VespaChatMessage,
+    chatMessageSchema,
+  )
+}
+
+export const insertTeam = async (team: Team, own: boolean) => {
+  return insertWithRetry(
+    {
+      docId: team.id!,
+      name: team.name!,
+      app: Apps.Slack,
+      url: team.url!,
+      icon: team.icon?.image_230!,
+      domain: team.domain!,
+      email_domain: team.email_domain!,
+      own,
+      createdAt: 0,
+      updatedAt: 0,
+      count: 0,
+    },
+    chatTeamSchema,
+  )
+}
+
+export const insertMember = async (member: Member) => {
+  return insertWithRetry(
+    {
+      docId: member.id!,
+      name: member.name!,
+      app: Apps.Slack,
+      entity: SlackEntity.User,
+      email: member.profile?.email!,
+      image: member.profile?.image_192!,
+      teamId: member.team_id!,
+      statusText: member.profile?.status_text!,
+      title: member.profile?.title!,
+      tz: member.tz!,
+      isAdmin: member.is_admin!,
+      deleted: member.deleted!,
+      updatedAt: member.updated!,
+    },
+    chatUserSchema,
+  )
+}
+
+export const handleSlackChannelIngestion = async (
+  connectorId: number,
+  channelsToIngest: string[],
+  startDate: string,
+  endDate: string,
+  email: string,
+) => {
+  try {
+    console.log(email)
+    console.log(connectorId)
+
+    const abortController = new AbortController()
+    const connector: SelectConnector = await getOAuthConnectorWithCredentials(
+      db,
+      connectorId,
+    )
+
+    const { accessToken } = connector.oauthCredentials
+    const client = new WebClient(accessToken, {
+      retryConfig: retryPolicies.rapidRetryPolicy,
+    })
+    const tracker = new Tracker(Apps.Slack, AuthType.OAuth)
+    const team = await safeGetTeamInfo(client)
+    const channelMap = new Map<string, string>()
+    const interval = setInterval(() => {
+      sendWebsocketMessage(
+        JSON.stringify({
+          progress: tracker.getProgress(),
+          userStats: tracker.getOAuthProgress().userStats,
+          startTime: tracker.getStartTime(),
+        }),
+        connector?.externalId,
+      )
+    }, 4000)
+
+    const conversations: Channel[] = []
+    for (const channel in channelsToIngest) {
+      const channelId = channelsToIngest[channel] // Get the channel ID string using the index from the for...in loop
+      try {
+        const response = await client.conversations.info({ channel: channelId })
+        console.log(response.channel)
+        if (response.ok && response.channel) {
+          conversations.push(response.channel as Channel)
+        } else {
+          Logger.warn(
+            `Failed to retrieve information for channel ${channelId}: ${response.error}`,
+          )
+        }
+      } catch (error) {
+        Logger.error(
+          `Exception while fetching info for channel ${channelId}:`,
+          error,
+        )
+      }
+    }
+    for (const conv of conversations) {
+      if (conv.id && conv.name) channelMap.set(conv.id!, conv.name!)
+    }
+    // only insert conversations that are not yet inserted already
+    const existenceMap = await ifDocumentsExistInSchema(
+      chatContainerSchema,
+      conversations.map((c) => c.id!),
+    )
+    const conversationsToInsert = conversations
+    // .filter(
+    //   (conversation) =>
+    //     (existenceMap[conversation.id!] &&
+    //       !existenceMap[conversation.id!].exists) ||
+    //     !existenceMap[conversation.id!],
+    // )
+    Logger.info(
+      `conversations to insert ${conversationsToInsert.length} and skipping ${conversations.length - conversationsToInsert.length}`,
+    )
+    const user = await getAuthenticatedUserId(client)
+    const teamMap = new Map<string, Team>()
+    teamMap.set(team.id!, team)
+    const memberMap = new Map<string, User>()
+    tracker.setCurrent(0)
+    tracker.setTotal(conversationsToInsert.length)
+    let conversationIndex = 0
+    // can be done concurrently, but can cause issues with ratelimits
+    for (const conversation of conversationsToInsert) {
+      const memberIds = await getConversationUsers(user, client, conversation)
+      const membersToFetch = memberIds.filter((m: string) => !memberMap.get(m))
+      const concurrencyLimit = pLimit(5)
+      const memberPromises = membersToFetch.map((memberId: string) =>
+        concurrencyLimit(() => client.users.info({ user: memberId })),
+      )
+      const members: User[] = (await Promise.all(memberPromises))
+        .map((userResp) => {
+          if (userResp.user) {
+            memberMap.set(userResp.user.id!, userResp.user)
+            return userResp.user as User
+          }
+        })
+        .filter((user) => !!user)
+      // check if already exists
+      for (const member of members) {
+        // team first time encountering
+        if (!teamMap.get(member.team_id!)) {
+          const teamResp: TeamInfoResponse = await client.team.info({
+            team: member.team_id!,
+          })
+          teamMap.set(teamResp.team?.id!, teamResp.team!)
+          try {
+            await insertTeam(teamResp.team!, false)
+            ingestedTeamTotalCount.inc({
+              email_domain: teamResp.team!.email_domain,
+              enterprise_id: teamResp.team!.enterprise_id,
+              domain: teamResp.team!.domain,
+              status: OperationStatus.Success,
+            })
+          } catch (error) {
+            Logger.error(error, `Error inserting member`)
+            ingestedTeamErrorTotalCount.inc({
+              email_domain: teamResp.team!.email_domain,
+              enterprise_id: teamResp.team!.enterprise_id,
+              domain: teamResp.team!.domain,
+              status: OperationStatus.Failure,
+            })
+          }
+        }
+        try {
+          await insertMember(member)
+          ingestedMembersTotalCount.inc({
+            team_id: team.id,
+            status: OperationStatus.Success,
+          })
+        } catch (error) {
+          Logger.error(`Error inserting member ${member.id}: ${error}`)
+          ingestedMembersErrorTotalCount.inc({
+            team_id: team.id,
+            status: OperationStatus.Failure,
+          })
+        }
+      }
+
+      let permissions: string[] = memberIds
+        .map((m: string) => {
+          const user: User | undefined = memberMap.get(m)
+          return user?.profile?.email
+        })
+        .filter((email): email is string => !!email)
+      // this case shouldn't even be there
+      if (!permissions.length || permissions.indexOf(email) == -1) {
+        permissions = permissions.concat(email)
+      }
+      const conversationWithPermission: Channel & { permissions: string[] } = {
+        ...conversation,
+        permissions,
+      }
+
+      const channelMessageInsertionDuration =
+        insertChannelMessageDuration.startTimer({
+          conversation_id: conversation.id,
+          team_id: team.id,
+          status: OperationStatus.Success,
+        })
+      try {
+        await insertChannelMessages(
+          email,
+          client,
+          conversation.id!,
+          abortController,
+          memberMap,
+          tracker,
+          "0",
+          channelMap,
+          startDate,
+          endDate,
+        )
+        channelMessageInsertionDuration()
+        insertChannelMessagesCount.inc({
+          conversation_id: conversation.id ?? "",
+          team_id: team.id ?? "",
+          status: OperationStatus.Success,
+        })
+        tracker.updateUserStats(email, StatType.Slack_Conversation, 1)
+      } catch (error) {
+        Logger.error("Error inserting Channel Messages")
+        insertChannelMessagesErrorCount.inc({
+          conversation_id: conversation.id ?? "",
+          team_id: team.id ?? "",
+          status: OperationStatus.Failure,
+        })
+      }
+      try {
+        const conversationInsertionDuration =
+          insertConversationDuration.startTimer({
+            conversation_id: conversation.id,
+            team_id: team.id,
+            status: OperationStatus.Success,
+          })
+        await insertConversation(conversationWithPermission)
+        conversationInsertionDuration()
+        insertConversationCount.inc({
+          conversation_id: conversationWithPermission.id ?? "",
+          team_id: conversationWithPermission.context_team_id ?? "",
+          status: OperationStatus.Success,
+        })
+        conversationIndex++
+        tracker.setCurrent(conversationIndex)
+      } catch (error) {
+        Logger.error(`Error inserting Conversation`)
+        insertConversationErrorCount.inc({
+          conversation_id: conversationWithPermission.id ?? "",
+          team_id: conversationWithPermission.context_team_id ?? "",
+          status: OperationStatus.Failure,
+        })
+      }
+    }
+    setTimeout(() => {
+      clearInterval(interval)
+    }, 8000)
+
+    db.transaction(async (trx) => {
+      await trx
+        .update(connectors)
+        .set({
+          status: ConnectorStatus.Connected,
+          state: JSON.stringify({}),
+        })
+        .where(eq(connectors.id, connector.id))
+    })
+  } catch (error) {
+    Logger.error(error)
+  }
+}
+
+/**
+ * Determines if an error is considered fatal.
+ * Modify this logic to distinguish between retryable fatal errors and those
+ * that should immediately bubble up.
+ *
+ * @param error The error thrown by a Slack API call.
+ * @returns True if the error is fatal, false otherwise.
+ */
+function isFatalError(error: any): boolean {
+  // For example, if your error has a code or property indicating it’s fatal,
+  // you can check for that. Here, we assume every error is fatal.
+  // Modify this as needed.
+  return true
+}
+
+/**
+ * Retries a given async function if a fatal error occurs.
+ * The function will be attempted up to maxAttempts times.
+ * If the error is not considered fatal, it will immediately throw.
+ *
+ * @param fn The async function to retry.
+ * @param maxAttempts Maximum number of attempts.
+ * @param delayMs Optional delay between attempts in milliseconds.
+ * @returns The result of the async function.
+ * @throws The last fatal error encountered if all attempts fail.
+ */
+async function retryOnFatal<T>(
+  fn: () => Promise<T>,
+  maxAttempts: number,
+  delayMs = 0,
+): Promise<T> {
+  let lastError: any
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn()
+    } catch (error) {
+      if (isFatalError(error)) {
+        lastError = error
+        console.error(
+          `Fatal error on attempt ${attempt}: ${(error as Error).message}. Retrying...`,
+        )
+        if (attempt < maxAttempts && delayMs > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delayMs))
+        }
+      } else {
+        // If error is not fatal, rethrow immediately.
+        throw error
+      }
+    }
+  }
+  throw lastError
+}
+
+async function getAuthenticatedUserId(client: WebClient): Promise<string> {
+  const authResponse = await client.auth.test()
+  if (!authResponse.ok || !authResponse.user_id) {
+    throw new Error(
+      `Failed to fetch authenticated user ID: ${authResponse.error}`,
+    )
+  }
+  return authResponse.user_id
+}

--- a/server/server.ts
+++ b/server/server.ts
@@ -26,6 +26,8 @@ import {
   updateConnectorStatusSchema,
   serviceAccountIngestMoreSchema,
   deleteUserDataSchema,
+  ingestMoreChannelSchema,
+  startSlackIngestionSchema,
 } from "@/types"
 import {
   AddApiKeyConnector,
@@ -38,6 +40,8 @@ import {
   UpdateConnectorStatus,
   ServiceAccountIngestMoreUsersApi,
   AdminDeleteUserData,
+  IngestMoreChannelApi,
+  StartSlackIngestionApi,
 } from "@/api/admin"
 import { ProxyUrl } from "@/api/proxy"
 import { init as initQueue } from "@/queue"
@@ -257,6 +261,20 @@ export const AppRoutes = app
     "/oauth/create",
     zValidator("form", createOAuthProvider),
     CreateOAuthProvider,
+  )
+  .post(
+    "/slack/ingest_more_channel",
+    async (c, next) => {
+      console.log("i am ")
+      await next()
+    },
+    zValidator("json", ingestMoreChannelSchema),
+    IngestMoreChannelApi,
+  )
+  .post(
+    "/slack/start_ingestion",
+    zValidator("json", startSlackIngestionSchema),
+    StartSlackIngestionApi,
   )
   .post(
     "/apikey/create",

--- a/server/types.ts
+++ b/server/types.ts
@@ -367,3 +367,14 @@ export enum metricAccountType {
   slackUser = "slackUser",
   admin = "admin",
 }
+
+export const ingestMoreChannelSchema = z.object({
+  connectorId: z.number(),
+  channelsToIngest: z.array(z.string()),
+  startDate: z.string(),
+  endDate: z.string(),
+})
+
+export const startSlackIngestionSchema = z.object({
+  connectorId: z.number(),
+})


### PR DESCRIPTION
### Description

Added  time-based filtering functionality for Slack channel ingestion, allowing users to specify custom date ranges when ingesting channel data.
Earlier we were using the sync_jobs to verify that user has ingested slack or not and also to show the slack messages in chat and search, now we are using the connector status (connecting,connected) to show the slack message in chat and search

### Testing
Tested Locally
<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
