### PR TITLE
Fix flickering

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -69,6 +69,7 @@ interface ChatBoxProps {
   setQuery: (query: string) => void
   handleSend: (messageToSend: string, selectedSources?: string[]) => void
   isStreaming?: boolean
+  retryIsStreaming?: boolean
   handleStop?: () => void
   chatId?: string | null
   allCitations: Map<string, Citation>
@@ -188,6 +189,7 @@ export const ChatBox = ({
   setQuery,
   handleSend,
   isStreaming = false,
+  retryIsStreaming = false,
   allCitations,
   handleStop,
   chatId,
@@ -1526,7 +1528,7 @@ export const ChatBox = ({
             {/* Use prop for styling */}
             <span>Reasoning</span>
           </button>
-          {isStreaming && chatId ? (
+          {(isStreaming || retryIsStreaming) && chatId ? (
             <button
               onClick={handleStop}
               style={{ marginLeft: "auto" }}
@@ -1536,7 +1538,7 @@ export const ChatBox = ({
             </button>
           ) : (
             <button
-              disabled={isStreaming}
+              disabled={isStreaming || retryIsStreaming}
               onClick={() => handleSendMessage()}
               style={{ marginLeft: "auto" }}
               className="flex mr-6 bg-[#464B53] text-white hover:bg-[#5a5f66] rounded-full w-[32px] h-[32px] items-center justify-center disabled:opacity-50"

--- a/frontend/src/hooks/useChatHistory.ts
+++ b/frontend/src/hooks/useChatHistory.ts
@@ -1,0 +1,117 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { api } from "@/api"
+import { SelectPublicMessage } from "shared/types"
+
+interface ChatHistoryData {
+  messages: SelectPublicMessage[]
+  chat?: {
+    title: string | null
+    isBookmarked: boolean
+  }
+}
+
+export const useChatHistory = (chatId: string | null) => {
+  const queryClient = useQueryClient()
+
+  const query = useQuery<ChatHistoryData>({
+    queryKey: ["chatHistory", chatId],
+    queryFn: async () => {
+      console.log(`[useChatHistory] Fetching data for chatId: ${chatId}`)
+      
+      if (!chatId) {
+        console.log(`[useChatHistory] No chatId provided, returning empty messages`)
+        return { messages: [] }
+      }
+
+      try {
+        const response = await api.chat.$post({
+          json: { chatId }
+        })
+        
+        if (!response.ok) {
+          throw new Error("Failed to fetch chat history")
+        }
+        
+        const data = await response.json()
+        console.log(`[useChatHistory] Fetched ${data.messages?.length || 0} messages for chatId: ${chatId}`)
+        return data as ChatHistoryData
+      } catch (error) {
+        console.error("Error fetching chat history:", error)
+        throw error
+      }
+    },
+    enabled: !!chatId, // Only fetch when we have a chatId
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    refetchOnWindowFocus: false,
+  })
+
+  // Helper function to add a message optimistically
+  const addMessageOptimistically = (message: SelectPublicMessage) => {
+    console.log(`[useChatHistory] Adding message optimistically to chatId: ${chatId}`)
+    
+    queryClient.setQueryData<ChatHistoryData>(
+      ["chatHistory", chatId],
+      (oldData) => {
+        if (!oldData) {
+          console.log(`[useChatHistory] Creating new chat history with first message`)
+          return { messages: [message] }
+        }
+        console.log(`[useChatHistory] Adding message to existing ${oldData.messages.length} messages`)
+        return {
+          ...oldData,
+          messages: [...oldData.messages, message],
+        }
+      }
+    )
+  }
+
+  // Helper function to update the last message
+  const updateLastMessage = (updater: (msg: SelectPublicMessage) => SelectPublicMessage) => {
+    if (!chatId) return
+
+    queryClient.setQueryData<ChatHistoryData>(
+      ["chatHistory", chatId],
+      (oldData) => {
+        if (!oldData || oldData.messages.length === 0) return oldData
+        
+        const messages = [...oldData.messages]
+        const lastIndex = messages.length - 1
+        messages[lastIndex] = updater(messages[lastIndex])
+        
+        return {
+          ...oldData,
+          messages,
+        }
+      }
+    )
+  }
+
+  // Helper function to update chat metadata
+  const updateChatMetadata = (updates: Partial<{ title: string | null; isBookmarked: boolean }>) => {
+    if (!chatId) return
+
+    queryClient.setQueryData<ChatHistoryData>(
+      ["chatHistory", chatId],
+      (oldData) => {
+        if (!oldData) return oldData
+        
+        return {
+          ...oldData,
+          chat: {
+            ...oldData.chat,
+            title: oldData.chat?.title || null,
+            isBookmarked: oldData.chat?.isBookmarked || false,
+            ...updates,
+          }
+        }
+      }
+    )
+  }
+
+  return {
+    ...query,
+    addMessageOptimistically,
+    updateLastMessage,
+    updateChatMetadata,
+  }
+} 

--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -1,0 +1,613 @@
+import { useRef, useState, useEffect, useCallback } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { useRouter } from "@tanstack/react-router"
+import { api } from "@/api"
+import { ChatSSEvents, Citation } from "shared/types"
+import { toast } from "@/hooks/use-toast"
+
+// Module-level storage for persistent EventSource connections
+interface StreamState {
+  es: EventSource
+  partial: string
+  thinking: string
+  sources: Citation[]
+  citationMap: Record<number, number>
+  messageId?: string
+  chatId?: string
+  isStreaming: boolean
+  subscribers: Set<() => void>
+}
+
+interface StreamInfo {
+  partial: string
+  thinking: string
+  sources: Citation[]
+  citationMap: Record<number, number>
+  messageId?: string
+  chatId?: string
+  isStreaming: boolean
+}
+
+// Global map to store active streams - persists across component unmounts
+const activeStreams = new Map<string, StreamState>()
+
+// Map real chatId to frontend-generated UUID to avoid component remounting
+const chatIdToUUIDMap = new Map<string, string>()
+
+// Helper function to parse HTML message input
+const parseMessageInput = (htmlString: string) => {
+  const container = document.createElement("div")
+  container.innerHTML = htmlString
+  const parts: Array<any> = []
+
+  const walk = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      if (node.textContent) {
+        parts.push({ type: "text", value: node.textContent })
+      }
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const el = node as HTMLElement
+      if (
+        el.tagName.toLowerCase() === "a" &&
+        el.classList.contains("reference-pill") &&
+        (el.dataset.docId || el.dataset.referenceId)
+      ) {
+        const entity = el.dataset.entity
+        const isContactPill =
+          entity === "OtherContacts" || entity === "Contacts"
+        let imgSrc: string | null = null
+        const imgElement = el.querySelector("img")
+        if (imgElement) {
+          imgSrc = imgElement.getAttribute("src")
+        }
+        parts.push({
+          type: "pill",
+          value: {
+            docId: el.dataset.docId || el.dataset.referenceId!,
+            url: isContactPill ? null : el.getAttribute("href"),
+            title: el.getAttribute("title"),
+            app: el.dataset.app,
+            entity: entity,
+            imgSrc: imgSrc,
+          },
+        })
+      } else if (el.tagName.toLowerCase() === "a" && el.getAttribute("href")) {
+        if (
+          !(
+            el.classList.contains("reference-pill") &&
+            (el.dataset.docId || el.dataset.referenceId)
+          )
+        ) {
+          parts.push({
+            type: "link",
+            value: el.getAttribute("href") || "",
+          })
+        } else {
+          Array.from(el.childNodes).forEach(walk)
+        }
+      }
+    }
+  }
+
+  Array.from(container.childNodes).forEach(walk)
+  return parts
+}
+
+// Notify all subscribers of a stream state change
+const notifySubscribers = (streamId: string) => {
+  const resolvedKey = chatIdToUUIDMap.get(streamId) || streamId
+  const stream = activeStreams.get(resolvedKey)
+  if (stream) {
+    stream.subscribers.forEach(callback => callback())
+  }
+}
+
+// Start a new stream or continue existing one
+export const startStream = async (
+  streamKey: string,
+  messageToSend: string,
+  selectedSources: string[] = [],
+  isReasoningActive: boolean = true,
+  queryClient?: any,
+  router?: any,
+  onTitleUpdate?: (title: string) => void
+): Promise<void> => {
+  if (!messageToSend) {
+    console.log("[SSEManager] Cannot start stream: no message provided")
+    return
+  }
+
+  let initialKey = chatIdToUUIDMap.get(streamKey) ?? streamKey
+  
+  // Check if stream already exists and is active
+  if (activeStreams.has(initialKey) && activeStreams.get(initialKey)?.isStreaming) {
+    console.log(`[SSEManager] Stream ${initialKey} already active, skipping`)
+    return
+  }
+
+  console.log(`[SSEManager] Starting stream for ${initialKey}`)
+
+  // Parse message content
+  const parsedMessageParts = parseMessageInput(messageToSend)
+  const hasRichContent = parsedMessageParts.some(
+    (part) => part.type === "pill" || part.type === "link"
+  )
+
+  let finalMessagePayload: string
+  if (hasRichContent) {
+    finalMessagePayload = JSON.stringify(parsedMessageParts)
+  } else {
+    finalMessagePayload = parsedMessageParts
+      .filter((part) => part.type === "text")
+      .map((part) => part.value)
+      .join("")
+  }
+
+  // Determine if this is a new chat (streamKey is a UUID) or existing chat
+  const isNewChat = !streamKey.match(/^[a-z0-9]+$/) // Real chatIds are typically shorter alphanumeric
+  const chatId = isNewChat ? null : streamKey
+
+  // Construct URL
+  const url = new URL(`/api/v1/message/create`, window.location.origin)
+  if (chatId) {
+    url.searchParams.append("chatId", chatId)
+    console.log(`[SSEManager] Using existing chatId: ${chatId}`)
+  } else {
+    console.log(`[SSEManager] Starting new chat with temporary key: ${initialKey}`)
+  }
+  url.searchParams.append("modelId", "gpt-4o-mini")
+  url.searchParams.append("message", finalMessagePayload)
+  if (isReasoningActive) {
+    url.searchParams.append("isReasoningEnabled", "true")
+  }
+
+  console.log(`[SSEManager] SSE URL: ${url.toString()}`)
+
+  // Create EventSource
+  const eventSource = new EventSource(url.toString(), {
+    withCredentials: true,
+  })
+
+  // Initialize stream state
+  const streamState: StreamState = {
+    es: eventSource,
+    partial: "",
+    thinking: "",
+    sources: [],
+    citationMap: {},
+    messageId: undefined,
+    chatId: chatId || undefined,
+    isStreaming: true,
+    subscribers: new Set(),
+  }
+
+  activeStreams.set(initialKey, streamState)
+  console.log(`[SSEManager] Created stream state for ${initialKey}`)
+
+  // Immediately notify subscribers so UI shows streaming state right away
+  notifySubscribers(initialKey)
+
+  // Setup event listeners
+  eventSource.addEventListener('open', () => {
+    console.log(`[SSEManager] EventSource connection opened for ${initialKey}`)
+  })
+
+  eventSource.addEventListener(ChatSSEvents.Start, () => {
+    console.log(`[SSEManager] Stream started for ${initialKey}`)
+  })
+
+  eventSource.addEventListener(ChatSSEvents.ResponseUpdate, (event) => {
+    console.log(`[SSEManager] Response update for ${initialKey}: ${event.data.slice(0, 50)}...`)
+    streamState.partial += event.data
+    
+    // Notify subscribers using current key (might have migrated)
+    const currentKey = streamState.chatId || initialKey
+    notifySubscribers(currentKey)
+  })
+
+  eventSource.addEventListener(ChatSSEvents.Reasoning, (event) => {
+    console.log(`[SSEManager] Reasoning for ${initialKey}: ${event.data.slice(0, 50)}...`)
+    streamState.thinking += event.data
+    
+    // Notify subscribers using current key (might have migrated)
+    const currentKey = streamState.chatId || initialKey
+    notifySubscribers(currentKey)
+  })
+
+  eventSource.addEventListener(ChatSSEvents.CitationsUpdate, (event) => {
+    console.log(`[SSEManager] Citations update for ${initialKey}`)
+    const { contextChunks, citationMap } = JSON.parse(event.data)
+    streamState.sources = contextChunks
+    streamState.citationMap = citationMap
+    
+    // Notify subscribers using current key (might have migrated)
+    const currentKey = streamState.chatId || initialKey
+    notifySubscribers(currentKey)
+  })
+
+  eventSource.addEventListener(ChatSSEvents.ResponseMetadata, (event) => {
+    const { chatId: realId, messageId } = JSON.parse(event.data)
+    console.log(`[SSEManager] ResponseMetadata for ${initialKey} - chatId: ${realId}, messageId: ${messageId}`)
+    
+    streamState.messageId = messageId
+
+    // Instead of migrating streams, just map the chatId to UUID to avoid component remounting
+    if (realId && initialKey !== realId) {
+      console.log(`[SSEManager] Mapping chatId ${realId} to UUID ${initialKey}`)
+      
+      // Set up the mapping from real chatId to UUID
+      chatIdToUUIDMap.set(realId, initialKey)
+      streamState.chatId = realId
+      
+      // Handle navigation for new chats
+      if (router && router.state.location.pathname === "/chat") {
+        console.log(`[SSEManager] New chat created, navigating to: /chat/${realId}`)
+        const isGlobalDebugMode = import.meta.env.VITE_SHOW_DEBUG_INFO === "true"
+        // setTimeout(() => {
+          router.navigate({
+            to: "/chat/$chatId",
+            params: { chatId: realId },
+            search: !isGlobalDebugMode ? {} : {},
+            replace: true,
+          })
+        // }, 1000)
+      }
+
+      // Update React Query cache for new chats
+      if (queryClient) {
+        console.log(`[SSEManager] Transferring cache from ${initialKey} to ${realId}`)
+        const oldData = queryClient.getQueryData(["chatHistory", null])
+        if (oldData) {
+          queryClient.setQueryData(["chatHistory", realId], oldData)
+          queryClient.removeQueries({ queryKey: ["chatHistory", null] })
+        }
+      }
+      
+      // Notify subscribers using the UUID key (no remounting)
+      notifySubscribers(initialKey)
+    } else {
+      // No mapping needed, just update existing stream
+      streamState.chatId = realId
+      notifySubscribers(initialKey)
+    }
+  })
+
+  eventSource.addEventListener(ChatSSEvents.ChatTitleUpdate, (event) => {
+    console.log(`[SSEManager] Title update for ${initialKey}: ${event.data}`)
+    if (onTitleUpdate) {
+      onTitleUpdate(event.data)
+    }
+  })
+
+  eventSource.addEventListener(ChatSSEvents.End, () => {
+    console.log(`[SSEManager] Stream ended for ${initialKey}`)
+    streamState.isStreaming = false
+    
+    // Invalidate and refetch chat history using the final chatId
+    const finalChatId = streamState.chatId
+    if (finalChatId && queryClient) {
+      console.log(`[SSEManager] Invalidating cache for chatId: ${finalChatId}`)
+      queryClient.invalidateQueries({ queryKey: ["chatHistory", finalChatId] })
+    }
+    
+    // Notify subscribers using current key (might have migrated)
+    const currentKey = streamState.chatId || initialKey
+    notifySubscribers(currentKey)
+    
+    // Don't remove the stream here - keep it for potential reconnection
+    // Only clean up the EventSource
+    eventSource.close()
+  })
+
+  eventSource.addEventListener(ChatSSEvents.Error, (event) => {
+    console.error(`[SSEManager] Stream error for ${initialKey}:`, event.data)
+    streamState.isStreaming = false
+    eventSource.close()
+    
+    toast({
+      title: "Error",
+      description: event.data,
+      variant: "destructive",
+    })
+    
+    // Notify subscribers using current key (might have migrated)
+    const currentKey = streamState.chatId || initialKey
+    notifySubscribers(currentKey)
+  })
+
+  eventSource.onerror = (error) => {
+    console.error(`[SSEManager] EventSource error for ${initialKey}:`, error)
+    streamState.isStreaming = false
+    
+    toast({
+      title: "Error",
+      description: "Connection error. Please try again.",
+      variant: "destructive",
+    })
+    
+    // Notify subscribers using current key (might have migrated)
+    const currentKey = streamState.chatId || initialKey
+    notifySubscribers(currentKey)
+    eventSource.close()
+  }
+}
+
+// Stop a specific stream
+export const stopStream = async (streamKey: string, queryClient?: any): Promise<void> => {
+  const resolvedKey = chatIdToUUIDMap.get(streamKey) || streamKey
+  const stream = activeStreams.get(resolvedKey)
+  
+  if (!stream) {
+    console.log(`[SSEManager] No stream found for ${streamKey}`)
+    return
+  }
+
+  console.log(`[SSEManager] Stopping stream for ${streamKey}`)
+  
+  stream.isStreaming = false
+  stream.es.close()
+  
+  // Send stop request to backend using the real chatId if available
+  const currentChatId = stream.chatId
+  if (currentChatId) {
+    console.log(`[SSEManager] Sending stop request for chatId: ${currentChatId}`)
+    try {
+      await api.chat.stop.$post({
+        json: { chatId: currentChatId },
+      })
+      
+      // Invalidate and refetch chat history just like natural stream end
+      if (queryClient) {
+        console.log(`[SSEManager] Invalidating cache for stopped stream chatId: ${currentChatId}`)
+        queryClient.invalidateQueries({ queryKey: ["chatHistory", currentChatId] })
+        // Force immediate refetch to ensure the stopped message appears as saved
+        console.log(`[SSEManager] Force refetching chat history for persistence`)
+        await queryClient.refetchQueries({ queryKey: ["chatHistory", currentChatId] })
+        
+        // Add a small delay to ensure backend has processed the stop request
+        await new Promise(resolve => setTimeout(resolve, 500))
+        
+        // Final refetch to ensure complete persistence
+        await queryClient.refetchQueries({ queryKey: ["chatHistory", currentChatId] })
+      }
+    } catch (error) {
+      console.error("Failed to send stop request:", error)
+      toast({
+        title: "Error",
+        description: "Could not stop streaming.",
+        variant: "destructive",
+        duration: 1000,
+      })
+    }
+  }
+  notifySubscribers(resolvedKey)
+}
+
+// Get current stream state (for hook consumers)
+export const getStreamState = (streamKey: string): StreamInfo => {
+  const resolvedKey = chatIdToUUIDMap.get(streamKey) || streamKey
+  const stream = activeStreams.get(resolvedKey)
+  
+  if (!stream) {
+    return {
+      partial: "",
+      thinking: "",
+      sources: [],
+      citationMap: {},
+      messageId: undefined,
+      chatId: undefined,
+      isStreaming: false,
+    }
+  }
+  
+  return {
+    partial: stream.partial,
+    thinking: stream.thinking,
+    sources: stream.sources,
+    citationMap: stream.citationMap,
+    messageId: stream.messageId,
+    chatId: stream.chatId,
+    isStreaming: stream.isStreaming,
+  }
+}
+
+// React hook that subscribes to stream updates
+export const useChatStream = (
+  chatId: string | null,
+  onTitleUpdate?: (title: string) => void
+) => {
+  const queryClient = useQueryClient()
+  const router = useRouter()
+  
+  // Generate a consistent stream key for this hook instance
+  const streamKeyRef = useRef<string | null>(null)
+  if (!streamKeyRef.current) {
+    streamKeyRef.current = chatId ?? crypto.randomUUID()
+  }
+  
+  // Update stream key if chatId changes (e.g., after migration)
+  const currentStreamKey = chatId ?? streamKeyRef.current
+  
+  const [streamInfo, setStreamInfo] = useState<StreamInfo>(() => getStreamState(currentStreamKey))
+  const subscriberRef = useRef<(() => void) | null>(null)
+
+  // Subscribe to stream updates
+  useEffect(() => {
+    const streamKey = currentStreamKey
+    console.log(`[useChatStream] Subscribing to stream ${streamKey}`)
+    
+    // Create subscriber function
+    const subscriber = () => {
+      console.log(`[useChatStream] Stream update received for ${streamKey}`)
+      setStreamInfo(getStreamState(streamKey))
+    }
+    
+    subscriberRef.current = subscriber
+    
+    // Add subscriber to the stream if it exists
+    const resolvedKey = chatIdToUUIDMap.get(streamKey) || streamKey
+    const stream = activeStreams.get(resolvedKey)
+    if (stream) {
+      stream.subscribers.add(subscriber)
+      // Immediately call subscriber to get current state
+      subscriber()
+    } else {
+      // Update initial state even if no stream exists yet
+      setStreamInfo(getStreamState(streamKey))
+    }
+    
+    // Cleanup subscription on unmount or chatId change
+    return () => {
+      console.log(`[useChatStream] Unsubscribing from stream ${streamKey}`)
+      const resolvedKey = chatIdToUUIDMap.get(streamKey) || streamKey
+      const stream = activeStreams.get(resolvedKey)
+      if (stream && subscriberRef.current) {
+        stream.subscribers.delete(subscriberRef.current)
+      }
+    }
+  }, [currentStreamKey])
+
+  // Wrapped functions that include necessary context
+  const wrappedStartStream = useCallback(async (
+    messageToSend: string,
+    selectedSources: string[] = [],
+    isReasoningActive: boolean = true
+  ) => {
+    let streamKey = chatId ?? crypto.randomUUID()
+    console.log(`[useChatStream] Starting stream with key: ${streamKey}`)
+    
+    await startStream(
+      streamKey,
+      messageToSend,
+      selectedSources,
+      isReasoningActive,
+      queryClient,
+      router,
+      onTitleUpdate
+    )
+
+    streamKey = chatIdToUUIDMap.get(streamKey) ?? streamKey
+    
+    // Force immediate update of local state after starting stream
+    setStreamInfo(getStreamState(streamKey))
+    
+    // Ensure our subscriber is registered for hot streams (e.g. UUID-based new chats)
+    const resolvedStreamKey = chatIdToUUIDMap.get(streamKey) || streamKey
+    const stream = activeStreams.get(resolvedStreamKey)
+    if (stream && subscriberRef.current) {
+      stream.subscribers.add(subscriberRef.current)
+      // Immediately push the current buffer into React state
+      subscriberRef.current()
+    }
+    
+    // Update our stream key reference for future operations
+    streamKeyRef.current = streamKey
+  }, [chatId, queryClient, router, onTitleUpdate])
+
+  const wrappedStopStream = useCallback(async () => {
+    await stopStream(currentStreamKey, queryClient)
+  }, [currentStreamKey, queryClient])
+
+  const retryMessage = useCallback(async (
+    messageId: string,
+    isReasoningActive: boolean = true
+  ) => {
+    if (!messageId || streamInfo.isStreaming) return
+
+    console.log(`[useChatStream] Retrying message: ${messageId}`)
+
+    const url = new URL(`/api/v1/message/retry`, window.location.origin)
+    url.searchParams.append("messageId", encodeURIComponent(messageId))
+    url.searchParams.append("isReasoningEnabled", `${isReasoningActive}`)
+
+    // For retry, we'll use a simpler approach since it's less common
+    // and doesn't need the full persistent stream management
+    const eventSource = new EventSource(url.toString(), {
+      withCredentials: true,
+    })
+
+    const streamKey = currentStreamKey
+    
+    // Create temporary stream state for retry
+    const streamState: StreamState = {
+      es: eventSource,
+      partial: "",
+      thinking: "",
+      sources: [],
+      citationMap: {},
+      messageId: undefined,
+      chatId: chatId || undefined,
+      isStreaming: true,
+      subscribers: new Set(),
+    }
+
+    const resolvedRetryKey = chatIdToUUIDMap.get(streamKey) || streamKey
+    activeStreams.set(resolvedRetryKey, streamState)
+
+    // Subscribe UI updates for retry stream
+    if (subscriberRef.current) {
+      streamState.subscribers.add(subscriberRef.current)
+      subscriberRef.current()
+    }
+
+    // Setup event listeners for retry
+    eventSource.addEventListener(ChatSSEvents.ResponseUpdate, (event) => {
+      streamState.partial += event.data
+      notifySubscribers(streamKey)
+    })
+
+    eventSource.addEventListener(ChatSSEvents.Reasoning, (event) => {
+      streamState.thinking += event.data
+      notifySubscribers(streamKey)
+    })
+
+    eventSource.addEventListener(ChatSSEvents.CitationsUpdate, (event) => {
+      const { contextChunks, citationMap } = JSON.parse(event.data)
+      streamState.sources = contextChunks
+      streamState.citationMap = citationMap
+      notifySubscribers(streamKey)
+    })
+
+    eventSource.addEventListener(ChatSSEvents.ResponseMetadata, (event) => {
+      const { messageId: newMessageId } = JSON.parse(event.data)
+      streamState.messageId = newMessageId
+      notifySubscribers(streamKey)
+    })
+
+    eventSource.addEventListener(ChatSSEvents.End, () => {
+      streamState.isStreaming = false
+      if (chatId) {
+        queryClient.invalidateQueries({ queryKey: ["chatHistory", chatId] })
+      }
+      notifySubscribers(streamKey)
+      eventSource.close()
+    })
+
+    eventSource.addEventListener(ChatSSEvents.Error, (event) => {
+      console.error("Retry stream error:", event.data)
+      streamState.isStreaming = false
+      toast({
+        title: "Error",
+        description: event.data,
+        variant: "destructive",
+      })
+      notifySubscribers(streamKey)
+      eventSource.close()
+    })
+
+    eventSource.onerror = () => {
+      streamState.isStreaming = false
+      console.error("Retry EventSource error")
+      notifySubscribers(streamKey)
+      eventSource.close()
+    }
+  }, [currentStreamKey, streamInfo.isStreaming, queryClient, chatId])
+
+  return {
+    ...streamInfo,
+    startStream: wrappedStartStream,
+    stopStream: wrappedStopStream,
+    retryMessage,
+    onTitleUpdate,
+  }
+} 

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -11,7 +11,6 @@ import {
 import { Bookmark, Copy, Ellipsis, Pencil, X, ChevronDown, ThumbsUp, ThumbsDown } from "lucide-react"
 import { useEffect, useRef, useState, Fragment } from "react"
 import {
-  ChatSSEvents,
   SelectPublicMessage,
   Citation,
   MessageFeedback,
@@ -48,17 +47,10 @@ import React from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { Pill } from "@/components/Pill"
 import { Reference } from "@/types"
+import { useChatStream } from "@/hooks/useChatStream"
+import { useChatHistory } from "@/hooks/useChatHistory"
 
 export const THINKING_PLACEHOLDER = "Thinking";
-
-type CurrentResp = {
-  resp: string
-  chatId?: string
-  messageId?: string
-  sources?: Citation[]
-  citationMap?: Record<number, number>
-  thinking?: string
-}
 
 // Mapping from source ID to app/entity object
 // const sourceIdToAppEntityMap: Record<string, { app: string; entity?: string }> =
@@ -93,67 +85,6 @@ type ParsedMessagePart =
       }
     }
   | { type: "link"; value: string }
-
-// Helper function to parse HTML message input
-const parseMessageInput = (htmlString: string): Array<ParsedMessagePart> => {
-  const container = document.createElement("div")
-  container.innerHTML = htmlString
-  const parts: Array<ParsedMessagePart> = []
-
-  const walk = (node: Node) => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      if (node.textContent) {
-        parts.push({ type: "text", value: node.textContent })
-      }
-    } else if (node.nodeType === Node.ELEMENT_NODE) {
-      const el = node as HTMLElement
-      if (
-        el.tagName.toLowerCase() === "a" &&
-        el.classList.contains("reference-pill") &&
-        (el.dataset.docId || el.dataset.referenceId)
-      ) {
-        const entity = el.dataset.entity
-        const isContactPill =
-          entity === "OtherContacts" || entity === "Contacts"
-        let imgSrc: string | null = null
-        const imgElement = el.querySelector("img")
-        if (imgElement) {
-          imgSrc = imgElement.getAttribute("src")
-        }
-        parts.push({
-          type: "pill",
-          value: {
-            docId: el.dataset.docId || el.dataset.referenceId!,
-            url: isContactPill ? null : el.getAttribute("href"),
-            title: el.getAttribute("title"),
-            app: el.dataset.app,
-            entity: entity,
-            imgSrc: imgSrc,
-          },
-        })
-      } else if (el.tagName.toLowerCase() === "a" && el.getAttribute("href")) {
-        // Ensure this link is not also a reference pill that we've already processed
-        if (
-          !(
-            el.classList.contains("reference-pill") &&
-            (el.dataset.docId || el.dataset.referenceId)
-          )
-        ) {
-          parts.push({
-            type: "link",
-            value: el.getAttribute("href") || "",
-          })
-        }
-        // Do not walk children of a link we've already processed as a "link" part
-      } else {
-        Array.from(el.childNodes).forEach(walk)
-      }
-    }
-  }
-
-  Array.from(container.childNodes).forEach(walk)
-  return parts
-}
 
 // Helper function to convert JSON message parts back to HTML using Pill component
 const jsonToHtmlMessage = (jsonString: string): string => {
@@ -233,6 +164,7 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
       : "/_authenticated/chat",
   })
   const queryClient = useQueryClient()
+  
   if (chatParams.q && isWithChatId) {
     router.navigate({
       to: "/chat/$chatId",
@@ -243,23 +175,41 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
   const hasHandledQueryParam = useRef(false)
 
   const [query, setQuery] = useState("")
-  const [messages, setMessages] = useState<SelectPublicMessage[]>(
-    isWithChatId ? data?.messages || [] : [],
-  )
-  const [chatId, setChatId] = useState<string | null>(
-    (params as any).chatId || null,
-  )
+  const chatId = (params as any).chatId || null
+  
+  // Use custom hooks for streaming and history
+  const { data: historyData, isLoading: historyLoading } = useChatHistory(chatId)
+  const {
+    partial,
+    thinking,
+    sources,
+    citationMap,
+    messageId: streamingMessageId,
+    isStreaming,
+    startStream,
+    stopStream,
+    retryMessage,
+  } = useChatStream(chatId, (title: string) => setChatTitle(title))
+  
+  // Use history data if available, otherwise fall back to loader data
+  const messages = historyData?.messages || (isWithChatId ? data?.messages || [] : [])
+  
   const [chatTitle, setChatTitle] = useState<string | null>(
     isWithChatId && data ? data?.chat?.title || null : null,
   )
-  const [currentResp, setCurrentResp] = useState<CurrentResp | null>(null)
-  const [showRagTrace, setShowRagTrace] = useState(false) // Added state
-  const [stopMsg, setStopMsg] = useState<boolean>(false)
-  const [selectedMessageId, setSelectedMessageId] = useState<string | null>(
-    null,
-  ) // Added state
+  
+  // Create a current streaming response for compatibility with existing UI
+  const currentResp = isStreaming ? {
+    resp: partial,
+    thinking,
+    sources,
+    citationMap,
+    messageId: streamingMessageId,
+    chatId: chatId,
+  } : null
 
-  const currentRespRef = useRef<CurrentResp | null>(null)
+  const [showRagTrace, setShowRagTrace] = useState(false)
+  const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null)
   const [bookmark, setBookmark] = useState<boolean>(
     isWithChatId ? !!data?.chat?.isBookmarked || false : false,
   )
@@ -267,36 +217,18 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
   const messagesContainerRef = useRef<HTMLDivElement>(null)
   const [userHasScrolled, setUserHasScrolled] = useState(false)
   const [dots, setDots] = useState("")
-  const [isStreaming, setIsStreaming] = useState(false)
   const [showSources, setShowSources] = useState(false)
   const [currentCitations, setCurrentCitations] = useState<Citation[]>([])
   const [currentMessageId, setCurrentMessageId] = useState<string | null>(null)
   const [isEditing, setIsEditing] = useState<boolean>(false)
   const [editedTitle, setEditedTitle] = useState<string | null>(chatTitle)
   const titleRef = useRef<HTMLInputElement | null>(null)
-  const [allCitations, setAllCitations] = useState<Map<string, Citation>>(
-    new Map(),
-  ) // State for all citations
-  const eventSourceRef = useRef<EventSource | null>(null) // Added ref for EventSource
-  const [userStopped, setUserStopped] = useState<boolean>(false) // Add state for user stop
+  const [allCitations, setAllCitations] = useState<Map<string, Citation>>(new Map())
   const [feedbackMap, setFeedbackMap] = useState<Record<string, MessageFeedback | null>>({});
-
   const [isReasoningActive, setIsReasoningActive] = useState(() => {
     const storedValue = localStorage.getItem(REASONING_STATE_KEY)
     return storedValue ? JSON.parse(storedValue) : true
   })
-
-  useEffect(() => {
-    return () => {
-      if (isStreaming && eventSourceRef.current) {
-        eventSourceRef.current.close()
-        eventSourceRef.current = null
-        setIsStreaming(false)
-        setCurrentResp(null)
-        currentRespRef.current = null
-      }
-    }
-  }, [router.state.location.pathname])
 
   useEffect(() => {
     localStorage.setItem(REASONING_STATE_KEY, JSON.stringify(isReasoningActive))
@@ -356,7 +288,7 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
   useEffect(() => {
     const newCitations = new Map(allCitations)
     let changed = false
-    messages.forEach((msg) => {
+    messages.forEach((msg: SelectPublicMessage) => {
       if (msg.messageRole === "assistant" && msg.sources) {
         // Add explicit type for citation
         msg.sources.forEach((citation: Citation) => {
@@ -430,11 +362,12 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
     }
   }, [isStreaming])
 
+  // Handle initial data loading and feedbackMap initialization
   useEffect(() => {
     if (!hasHandledQueryParam.current || isWithChatId) {
-      setMessages(isWithChatId ? data?.messages || [] : [])
+      // Data will be loaded via useChatHistory hook
     }
-    setChatId((params as any).chatId || null)
+    
     setChatTitle(isWithChatId ? data?.chat?.title || null : null)
     setBookmark(isWithChatId ? !!data?.chat?.isBookmarked || false : false)
 
@@ -442,17 +375,13 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
     if (data?.messages) {
       const initialFeedbackMap: Record<string, MessageFeedback | null> = {};
       data.messages.forEach((msg: SelectPublicMessage) => {
-        if (msg.externalId && msg.feedback !== undefined) { // msg.feedback can be null
+        if (msg.externalId && msg.feedback !== undefined) {
           initialFeedbackMap[msg.externalId] = msg.feedback as MessageFeedback | null;
         }
       });
       setFeedbackMap(initialFeedbackMap);
     }
 
-    if (!isStreaming && !hasHandledQueryParam.current) {
-      setCurrentResp(null)
-      currentRespRef.current = null
-    }
     inputRef.current?.focus()
     setShowSources(false)
     setCurrentCitations([])
@@ -460,7 +389,7 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
   }, [
     data?.chat?.isBookmarked,
     data?.chat?.title,
-    data?.messages, // This will re-run when messages data changes
+    data?.messages,
     isWithChatId,
     params,
   ])
@@ -470,7 +399,6 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
       const messageToSend = decodeURIComponent(chatParams.q)
 
       let sourcesArray: string[] = []
-      // Process chatParams.sources safely
       const _sources = chatParams.sources as string | string[] | undefined
 
       if (Array.isArray(_sources)) {
@@ -482,12 +410,10 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
           .filter((s) => s.length > 0)
       }
 
-      // Set reasoning state from URL param if present
       if (typeof chatParams.reasoning === "boolean") {
         setIsReasoningActive(chatParams.reasoning)
       }
 
-      // Call handleSend without referencesForHandleSend, as it's no longer a parameter
       handleSend(messageToSend, sourcesArray)
       hasHandledQueryParam.current = true
       router.navigate({
@@ -503,256 +429,39 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
     }
   }, [chatParams.q, chatParams.reasoning, chatParams.sources, router])
 
-  const locationKeyRef = useRef<string | null>(null);
   const handleSend = async (
     messageToSend: string,
     selectedSources: string[] = [],
   ) => {
     if (!messageToSend || isStreaming) return
 
-    locationKeyRef.current = router.state.location.pathname;
-    // Reset userHasScrolled to false when a new message is sent.
-    // This ensures that the view will scroll down automatically as the new message streams in,
-    // unless the user manually scrolls up during the streaming.
+    console.log(`[ChatPage] handleSend called with chatId: ${chatId}, message: ${messageToSend.slice(0, 50)}...`)
+    
     setUserHasScrolled(false)
     setQuery("")
-    setMessages((prevMessages) => [
-      ...prevMessages,
-      { messageRole: "user", message: messageToSend },
-    ])
-
-    setIsStreaming(true)
-    setCurrentResp({ resp: "", thinking: "" })
-    currentRespRef.current = { resp: "", sources: [], thinking: "" }
-
-    // const appEntities = selectedSources
-    //   .map((sourceId) => sourceIdToAppEntityMap[sourceId])
-    //   .filter((item) => item !== undefined)
-
-    // Always parse the message input to a structured format
-    const parsedMessageParts = parseMessageInput(messageToSend)
-
-    // Determine if the message contains any pills or links
-    const hasRichContent = parsedMessageParts.some(
-      (part) => part.type === "pill" || part.type === "link",
-    )
-
-    let finalMessagePayload: string
-    if (hasRichContent) {
-      finalMessagePayload = JSON.stringify(parsedMessageParts)
-    } else {
-      // If only text parts, send the original plain text message
-      // We extract the text content from parsedMessageParts to ensure it's just the text
-      // and not potentially an empty array string if messageToSend was empty.
-      finalMessagePayload = parsedMessageParts
-        .filter((part) => part.type === "text")
-        .map((part) => part.value)
-        .join("")
-    }
-
-    const url = new URL(`/api/v1/message/create`, window.location.origin)
-    if (chatId) {
-      url.searchParams.append("chatId", chatId)
-    }
-    url.searchParams.append("modelId", "gpt-4o-mini")
-    url.searchParams.append("message", finalMessagePayload)
-
-    // if (appEntities.length > 0) {
-    //   url.searchParams.append(
-    //     "stringifiedAppEntity",
-    //     JSON.stringify(appEntities),
-    //   )
-    // }
-    if (isReasoningActive) {
-      url.searchParams.append("isReasoningEnabled", "true")
-    }
-
-    eventSourceRef.current = new EventSource(url.toString(), {
-      // Store EventSource
-      withCredentials: true,
-    })
-
-    // ... (rest of the eventSource listeners remain the same) ...
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.CitationsUpdate,
-      (event) => {
-        // Use ref
-        const { contextChunks, citationMap } = JSON.parse(event.data)
-        if (currentRespRef.current) {
-          currentRespRef.current.sources = contextChunks
-          currentRespRef.current.citationMap = citationMap
-          // Add explicit type for prevResp
-          setCurrentResp((prevResp: CurrentResp | null) => ({
-            ...(prevResp || { resp: "", thinking: "" }), // Ensure proper default structure
-            resp: prevResp?.resp || "",
-            sources: contextChunks,
-            citationMap,
-          }))
+    
+    // Add user message optimistically to React Query cache
+    const queryKey = chatId
+    console.log(`[ChatPage] Adding optimistic message to cache with key: ${queryKey}`)
+    
+    queryClient.setQueryData<any>(
+      ["chatHistory", queryKey],
+      (oldData: any) => {
+        console.log(`[ChatPage] Current cache data:`, oldData)
+        if (!oldData) {
+          console.log(`[ChatPage] Creating new cache entry`)
+          return { messages: [{ messageRole: "user", message: messageToSend }] }
         }
-      },
-    )
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.Reasoning, (event) => {
-      setCurrentResp((prevResp: CurrentResp | null) => ({
-        ...(prevResp || { resp: "", thinking: event.data || "" }),
-        thinking: (prevResp?.thinking || "") + event.data,
-      }))
-    })
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.Start, (event) => {})
-
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.ResponseUpdate,
-      (event) => {
-        setCurrentResp((prevResp: CurrentResp | null) => {
-          const updatedResp = prevResp
-            ? { ...prevResp, resp: prevResp.resp + event.data }
-            : { resp: event.data, thinking: "", sources: [], citationMap: {} }
-          currentRespRef.current = updatedResp
-          return updatedResp
-        })
-      },
-    )
-
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.ResponseMetadata,
-      (event) => {
-        // Use ref
-        const { chatId, messageId } = JSON.parse(event.data)
-        setChatId(chatId)
-        if (chatId && router.state.location.pathname === locationKeyRef.current) {
-          setTimeout(() => {
-            router.navigate({
-              to: "/chat/$chatId",
-              params: { chatId },
-              search: !isGlobalDebugMode ? { debug: isDebugMode } : {},
-            })
-          }, 1000)
-
-          if (!stopMsg) {
-            setStopMsg(true)
-          }
+        console.log(`[ChatPage] Adding to existing ${oldData.messages?.length || 0} messages`)
+        return {
+          ...oldData,
+          messages: [...(oldData.messages || []), { messageRole: "user", message: messageToSend }],
         }
-        if (messageId) {
-          if (currentRespRef.current) {
-            setCurrentResp((resp: CurrentResp | null) => {
-              const updatedResp = resp || { resp: "", thinking: "" }
-              updatedResp.chatId = chatId
-              updatedResp.messageId = messageId
-              currentRespRef.current = updatedResp
-              return updatedResp
-            })
-          } else {
-            setMessages((prevMessages) => {
-              const lastMessage = prevMessages[prevMessages.length - 1]
-              if (lastMessage.messageRole === "assistant") {
-                return [
-                  ...prevMessages.slice(0, -1),
-                  { ...lastMessage, externalId: messageId },
-                ]
-              }
-              return prevMessages
-            })
-          }
-        }
-      },
+      }
     )
 
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.ChatTitleUpdate,
-      (event) => {
-        // Use ref
-        setChatTitle(event.data)
-      },
-    )
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.End, (event) => {
-      // Use ref
-      const currentResp = currentRespRef.current
-      if (currentResp) {
-        setMessages((prevMessages) => [
-          ...prevMessages,
-          {
-            messageRole: "assistant",
-            message: currentResp.resp,
-            externalId: currentResp.messageId,
-            sources: currentResp.sources,
-            citationMap: currentResp.citationMap,
-            thinking: currentResp.thinking,
-          },
-        ])
-      }
-      setCurrentResp(null)
-      currentRespRef.current = null
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setStopMsg(false)
-      setIsStreaming(false)
-    })
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.Error, (event) => {
-      // Use ref
-      console.error("Error with SSE:", event.data)
-      const currentResp = currentRespRef.current
-      if (currentResp) {
-        setMessages((prevMessages) => [
-          ...prevMessages,
-          {
-            messageRole: "assistant",
-            message: `${event.data}`,
-            externalId: currentResp.messageId,
-            sources: currentResp.sources,
-            citationMap: currentResp.citationMap,
-            thinking: currentResp.thinking,
-          },
-        ])
-      }
-      setCurrentResp(null)
-      currentRespRef.current = null
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setStopMsg(false)
-      setIsStreaming(false)
-    })
-
-    eventSourceRef.current.onerror = (error) => {
-      // Use ref
-      // Check if the stop was intentional
-      if (userStopped) {
-        setUserStopped(false) // Reset the flag
-        // Clean up state, similar to handleStop or End event
-        setCurrentResp(null)
-        currentRespRef.current = null
-        setStopMsg(false)
-        setIsStreaming(false)
-        // Close again just in case, and clear ref
-        eventSourceRef.current?.close()
-        eventSourceRef.current = null
-        // Do NOT add an error message in this case
-        return
-      }
-
-      // If it wasn't a user stop, proceed with error handling as before
-      console.error("Error with SSE:", error)
-      const currentResp = currentRespRef.current
-      if (currentResp) {
-        setMessages((prevMessages) => [
-          ...prevMessages,
-          {
-            messageRole: "assistant",
-            message: `Error occurred: please try again`,
-          },
-        ])
-      }
-      setCurrentResp(null)
-      currentRespRef.current = null
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setStopMsg(false)
-      setIsStreaming(false)
-    }
-
-    setQuery("")
+    console.log(`[ChatPage] Starting persistent stream with reasoning: ${isReasoningActive}`)
+    await startStream(messageToSend, selectedSources, isReasoningActive)
   }
 
   const handleFeedback = async (messageId: string, feedback: MessageFeedback) => {
@@ -762,7 +471,7 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
       const currentFeedback = prev[messageId];
       return {
         ...prev,
-        [messageId]: currentFeedback === feedback ? null : feedback, // Toggle if same, else set new
+        [messageId]: currentFeedback === feedback ? null : feedback,
       };
     });
 
@@ -775,7 +484,6 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
     } catch (error) {
       console.error("Failed to submit feedback", error);
       setFeedbackMap(prev => {
-        // Get the current state after optimistic update
         const currentState = prev[messageId];
         const originalFeedback = currentState === null ? feedback : (currentState === feedback ? feedbackMap[messageId] : null);
         return { ...prev, [messageId]: originalFeedback };
@@ -788,356 +496,9 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
     }
   };
 
-  const handleStop = async () => {
-    setUserStopped(true) // Indicate intentional stop before closing
-
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close()
-      eventSourceRef.current = null // Clear the ref
-    }
-
-    setIsStreaming(false)
-
-    // 4. Attempt to send stop request to backend if IDs are available
-    if (chatId && isStreaming) {
-      // This `isStreaming` check might be redundant now, but let's keep it for safety
-      try {
-        await api.chat.stop.$post({
-          json: {
-            chatId: chatId,
-          },
-        })
-      } catch (error) {
-        console.error("Failed to send stop request to backend:", error)
-        toast({
-          title: "Error",
-          description: "Could not stop streaming.",
-          variant: "destructive",
-          duration: 1000,
-        })
-        // Backend stop failed, but client-side is already stopped
-      }
-    }
-
-    // 5. Add partial response to messages if available
-    if (currentRespRef.current && currentRespRef.current.resp) {
-      // Use currentRespRef.current directly
-      setMessages((prevMessages) => [
-        ...prevMessages,
-        {
-          messageRole: "assistant",
-          message: currentRespRef.current?.resp || " ", // Use currentRespRef.current
-          externalId: currentRespRef.current?.messageId, // Use currentRespRef.current
-          sources: currentRespRef.current?.sources, // Use currentRespRef.current
-          citationMap: currentRespRef.current?.citationMap, // Use currentRespRef.current
-          thinking: currentRespRef.current?.thinking, // Use currentRespRef.current
-        },
-      ])
-    }
-
-    // 6. Clear streaming-related state *after* backend request and message handling
-    setCurrentResp(null)
-    currentRespRef.current = null
-    setStopMsg(false)
-    // 7. Invalidate router state after a short delay to refetch loader data
-    setTimeout(() => {
-      router.invalidate()
-    }, 1000) // Delay for 500ms
-  }
-
   const handleRetry = async (messageId: string) => {
     if (!messageId || isStreaming) return
-
-    setIsStreaming(true)
-    const userMsgWithErr = messages.find(
-      (msg) =>
-        msg.externalId === messageId &&
-        msg.messageRole === "user" &&
-        msg.errorMessage,
-    )
-    setMessages((prevMessages) => {
-      if (userMsgWithErr) {
-        const updatedMessages = [...prevMessages]
-        const index = updatedMessages.findIndex(
-          (msg) => msg.externalId === messageId && msg.messageRole === "user",
-        )
-
-        if (index !== -1) {
-          updatedMessages[index] = {
-            ...updatedMessages[index],
-            errorMessage: "",
-          }
-          updatedMessages.splice(index + 1, 0, {
-            messageRole: "assistant",
-            message: "",
-            isRetrying: true,
-            thinking: "",
-            sources: [],
-          })
-        }
-
-        return updatedMessages
-      } else {
-        return prevMessages.map((msg) => {
-          if (msg.externalId === messageId && msg.messageRole === "assistant") {
-            return {
-              ...msg,
-              message: "",
-              isRetrying: true,
-              sources: [],
-              thinking: "",
-            }
-          }
-          return msg
-        })
-      }
-    })
-
-    const url = new URL(`/api/v1/message/retry`, window.location.origin)
-    url.searchParams.append("messageId", encodeURIComponent(messageId))
-    url.searchParams.append("isReasoningEnabled", `${isReasoningActive}`)
-    setStopMsg(true) // Ensure stop message can be sent for retries
-    eventSourceRef.current = new EventSource(url.toString(), {
-      // Store EventSource
-      withCredentials: true,
-    })
-
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.ResponseUpdate,
-      (event) => {
-        // Use ref
-        if (userMsgWithErr) {
-          setMessages((prevMessages) => {
-            const index = prevMessages.findIndex(
-              (msg) => msg.externalId === messageId,
-            )
-
-            if (index === -1 || index + 1 >= prevMessages.length) {
-              return prevMessages
-            }
-
-            const newMessages = [...prevMessages]
-            newMessages[index + 1] = {
-              ...newMessages[index + 1],
-              message: newMessages[index + 1].message + event.data,
-            }
-
-            return newMessages
-          })
-        } else {
-          setMessages((prevMessages) =>
-            prevMessages.map((msg) =>
-              msg.externalId === messageId && msg.isRetrying
-                ? { ...msg, message: msg.message + event.data }
-                : msg,
-            ),
-          )
-        }
-      },
-    )
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.Reasoning, (event) => {
-      // Use ref
-      if (userMsgWithErr) {
-        setMessages((prevMessages) => {
-          const index = prevMessages.findIndex(
-            (msg) => msg.externalId === messageId,
-          )
-
-          if (index === -1 || index + 1 >= prevMessages.length) {
-            return prevMessages
-          }
-
-          const newMessages = [...prevMessages]
-          newMessages[index + 1] = {
-            ...newMessages[index + 1],
-            thinking: (newMessages[index + 1].thinking || "") + event.data,
-          }
-
-          return newMessages
-        })
-      } else {
-        setMessages((prevMessages) =>
-          prevMessages.map((msg) =>
-            msg.externalId === messageId && msg.isRetrying
-              ? { ...msg, thinking: (msg.thinking || "") + event.data }
-              : msg,
-          ),
-        )
-      }
-    })
-
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.ResponseMetadata,
-      (event) => {
-        // Use ref
-        const userMessage = messages.find(
-          (msg) => msg.externalId === messageId && msg.messageRole === "user",
-        )
-        if (userMessage) {
-          const { messageId: newMessageId } = JSON.parse(event.data)
-
-          if (newMessageId) {
-            setMessages((prevMessages) => {
-              const index = prevMessages.findIndex(
-                (msg) => msg.externalId === messageId,
-              )
-
-              if (index === -1 || index + 1 >= prevMessages.length) {
-                return prevMessages
-              }
-
-              const newMessages = [...prevMessages]
-              newMessages[index + 1] = {
-                ...newMessages[index + 1],
-                externalId: newMessageId,
-              }
-              return newMessages
-            })
-          }
-        }
-      },
-    )
-
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.CitationsUpdate,
-      (event) => {
-        // Use ref
-        const { contextChunks, citationMap } = JSON.parse(event.data)
-        setMessages((prevMessages) => {
-          if (userMsgWithErr) {
-            const index = prevMessages.findIndex(
-              (msg) => msg.externalId === messageId,
-            )
-
-            if (index === -1 || index + 1 >= prevMessages.length) {
-              return prevMessages
-            }
-
-            const newMessages = [...prevMessages]
-
-            if (newMessages[index + 1].isRetrying) {
-              newMessages[index + 1] = {
-                ...newMessages[index + 1],
-                sources: contextChunks,
-                citationMap,
-              }
-            }
-
-            return newMessages
-          } else {
-            return prevMessages.map((msg) =>
-              msg.externalId === messageId && msg.isRetrying
-                ? { ...msg, sources: contextChunks, citationMap }
-                : msg,
-            )
-          }
-        })
-      },
-    )
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.End, (event) => {
-      // Use ref
-      setMessages((prevMessages) => {
-        if (userMsgWithErr) {
-          const index = prevMessages.findIndex(
-            (msg) => msg.externalId === messageId,
-          )
-
-          if (index === -1 || index + 1 >= prevMessages.length) {
-            return prevMessages
-          }
-
-          const newMessages = [...prevMessages]
-
-          if (newMessages[index + 1].isRetrying) {
-            newMessages[index + 1] = {
-              ...newMessages[index + 1],
-              isRetrying: false,
-            }
-          }
-
-          return newMessages
-        } else {
-          return prevMessages.map((msg) =>
-            msg.externalId === messageId && msg.isRetrying
-              ? { ...msg, isRetrying: false }
-              : msg,
-          )
-        }
-      })
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setIsStreaming(false)
-    })
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.Error, (event) => {
-      // Use ref
-      console.error("Retry Error with SSE:", event.data)
-      setMessages((prevMessages) => {
-        if (userMsgWithErr) {
-          const index = prevMessages.findIndex(
-            (msg) => msg.externalId === messageId,
-          )
-
-          if (index === -1 || index + 1 >= prevMessages.length) {
-            return prevMessages
-          }
-
-          const newMessages = [...prevMessages]
-
-          if (newMessages[index + 1].isRetrying)
-            newMessages[index + 1] = {
-              ...newMessages[index + 1],
-              isRetrying: false,
-              message: event.data,
-            }
-
-          return newMessages
-        } else {
-          return prevMessages.map((msg) =>
-            msg.externalId === messageId && msg.isRetrying
-              ? { ...msg, isRetrying: false, message: event.data }
-              : msg,
-          )
-        }
-      })
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setIsStreaming(false)
-    })
-
-    eventSourceRef.current.onerror = (error) => {
-      // Use ref
-      console.error("Retry SSE Error:", error)
-      setMessages((prevMessages) => {
-        if (userMsgWithErr) {
-          const index = prevMessages.findIndex(
-            (msg) => msg.externalId === messageId,
-          )
-
-          if (index === -1 || index + 1 >= prevMessages.length) {
-            return prevMessages
-          }
-
-          const newMessages = [...prevMessages]
-
-          newMessages[index + 1] = {
-            ...newMessages[index + 1],
-            isRetrying: false,
-          }
-
-          return newMessages
-        } else {
-          return prevMessages.map((msg) =>
-            msg.isRetrying ? { ...msg, isRetrying: false } : msg,
-          )
-        }
-      })
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setIsStreaming(false)
-    }
+    await retryMessage(messageId, isReasoningActive)
   }
 
   const handleBookmark = async () => {
@@ -1165,26 +526,23 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
 
   const handleScroll = () => {
     const isAtBottom = isScrolledToBottom()
-    // Set userHasScrolled to true if the user scrolls up from the bottom.
-    // This will prevent the automatic scrolling behavior while the user is manually scrolling.
     setUserHasScrolled(!isAtBottom)
   }
 
   useEffect(() => {
     const container = messagesContainerRef.current
-    // Only scroll to the bottom if the container exists and the user has not manually scrolled up.
-    // This prevents the view from jumping to the bottom if the user is trying to read previous messages
-    // while a new message is streaming in.
     if (!container || userHasScrolled) return
 
     container.scrollTop = container.scrollHeight
-  }, [messages, currentResp?.resp])
+  }, [messages, partial])
 
-  if (data?.error) {
+  if (data?.error || historyLoading) {
     return (
       <div className="h-full w-full flex flex-col bg-white">
         <Sidebar />
-        <div className="ml-[120px]">Error: Could not get data</div>
+        <div className="ml-[120px]">
+          {historyLoading ? "Loading..." : "Error: Could not get data"}
+        </div>
       </div>
     )
   }
@@ -1276,8 +634,6 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
           </div>
         </div>
 
-        {/* The onScroll event handler is attached to this div because it's the scrollable container for messages. */}
-        {/* This ensures that scroll events are captured correctly to manage the auto-scroll behavior. */}
         <div
           className={`h-full w-full flex items-end overflow-y-auto justify-center transition-all duration-250 ${showSources ? "pr-[18%]" : ""}`}
           ref={messagesContainerRef}
@@ -1285,7 +641,7 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
         >
           <div className={`w-full h-full flex flex-col items-center`}>
             <div className="flex flex-col w-full  max-w-3xl flex-grow mb-[60px] mt-[56px]">
-              {messages.map((message, index) => {
+              {messages.map((message: SelectPublicMessage, index: number) => {
                 const isSourcesVisible =
                   showSources && currentMessageId === message.externalId
                 const userMessageWithErr =
@@ -1394,7 +750,6 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
                   isStreaming={isStreaming}
                   isDebugMode={isDebugMode}
                   onShowRagTrace={handleShowRagTrace}
-                  // Feedback not applicable for streaming response, but props are needed
                   feedbackStatus={null} 
                   onFeedback={handleFeedback}
                 />
@@ -1416,8 +771,8 @@ export const ChatPage = ({ user, workspace }: ChatPageProps) => {
             <ChatBox
               query={query}
               setQuery={setQuery}
-              handleSend={handleSend} // handleSend function is passed here
-              handleStop={handleStop}
+              handleSend={handleSend}
+              handleStop={stopStream}
               isStreaming={isStreaming}
               allCitations={allCitations}
               chatId={chatId}
@@ -1858,7 +1213,7 @@ const chatParams = z.object({
     .optional()
     .default("false"),
   reasoning: z.boolean().optional(),
-  refs: z // Changed from docId to refs, expects a JSON string array
+  refs: z
     .string()
     .optional()
     .transform((val) => {
@@ -1870,10 +1225,10 @@ const chatParams = z.object({
           ? parsed
           : undefined
       } catch (e) {
-        return undefined // Invalid JSON
+        return undefined
       }
     }),
-  sources: z // Changed from sourceIds to sources, expects comma-separated string
+  sources: z
     .string()
     .optional()
     .transform((val) => (val ? val.split(",") : undefined)),
@@ -1891,7 +1246,9 @@ export const Route = createFileRoute("/_authenticated/chat")({
   component: () => {
     const matches = useRouterState({ select: (s) => s.matches })
     const { user, workspace } = matches[matches.length - 1].context
-    return <ChatPage user={user} workspace={workspace} />
+    const params = matches[matches.length - 1].params as { chatId?: string }
+    const chatId = params?.chatId
+    return <ChatPage key={chatId} user={user} workspace={workspace} />
   },
   errorComponent: errorComponent,
 })


### PR DESCRIPTION
### Description

Previously, when a user entered a query and navigated to a different chat (either before or after the chat ID was generated), the streaming response from the active query would continue to render across other chats. This caused the UI to behave inconsistently and display content unrelated to the current chat context.

This PR resolves that issue by ensuring that streaming responses are isolated to their respective chats. Now, when a user navigates away mid-response, the ongoing stream is properly scoped and no longer affects other chat views.

### Testing
	1.	Start a new query in one chat.
	2.	While the response is streaming, navigate to a different chat from the history list:
	•	Before the chat ID is generated.
	•	After the chat ID is generated.
	3.	Confirm that:
	•	The response stream does not interfere with the newly opened chat.
	•	Upon returning to the original chat, the stream continues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced real-time chat streaming, enabling messages to appear incrementally as they are received.
  - Added support for retrying message streams with improved control over streaming and retry states.
  - Chat history now loads dynamically and updates optimistically for a smoother user experience.

- **Refactor**
  - Streamlined chat page logic by centralizing streaming and message state management into reusable hooks, improving performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->