### PR TITLE
fix:slack stats table view , Added IngestionTypes to classify the Data

### DIFF
--- a/server/integrations/slack/channelIngest.ts
+++ b/server/integrations/slack/channelIngest.ts
@@ -49,7 +49,12 @@ import type { User } from "@slack/web-api/dist/types/response/UsersInfoResponse"
 import { count, eq } from "drizzle-orm"
 import { StatType, Tracker } from "@/integrations/tracker"
 import { sendWebsocketMessage } from "../metricStream"
-import { AuthType, ConnectorStatus, SyncJobStatus } from "@/shared/types"
+import {
+  AuthType,
+  ConnectorStatus,
+  SyncJobStatus,
+  IngestionType,
+} from "@/shared/types"
 import pLimit from "p-limit"
 import { IngestionState } from "../ingestionState"
 import { insertSyncJob } from "@/db/syncJob"
@@ -808,6 +813,7 @@ export const handleSlackChannelIngestion = async (
     const interval = setInterval(() => {
       sendWebsocketMessage(
         JSON.stringify({
+          IngestionType: IngestionType.partialIngestion,
           progress: tracker.getProgress(),
           userStats: tracker.getOAuthProgress().userStats,
           startTime: tracker.getStartTime(),

--- a/server/integrations/slack/index.ts
+++ b/server/integrations/slack/index.ts
@@ -49,7 +49,12 @@ import type { User } from "@slack/web-api/dist/types/response/UsersInfoResponse"
 import { count, eq } from "drizzle-orm"
 import { StatType, Tracker } from "@/integrations/tracker"
 import { sendWebsocketMessage } from "../metricStream"
-import { AuthType, ConnectorStatus, SyncJobStatus } from "@/shared/types"
+import {
+  AuthType,
+  ConnectorStatus,
+  SyncJobStatus,
+  IngestionType,
+} from "@/shared/types"
 import pLimit from "p-limit"
 import { IngestionState } from "../ingestionState"
 import { insertSyncJob } from "@/db/syncJob"
@@ -745,6 +750,7 @@ export const handleSlackIngestion = async (data: SaaSOAuthJob) => {
     const interval = setInterval(() => {
       sendWebsocketMessage(
         JSON.stringify({
+          IngestionType: IngestionType.fullIngestion,
           progress: tracker.getProgress(),
           userStats: tracker.getOAuthProgress().userStats,
           startTime: tracker.getStartTime(),

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -318,3 +318,8 @@ export enum MessageFeedback {
   Like = "like",
   Dislike = "dislike",
 }
+
+export enum IngestionType {
+  fullIngestion = "full_ingestion",
+  partialIngestion = "partial_Ingestion",
+}

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -321,5 +321,5 @@ export enum MessageFeedback {
 
 export enum IngestionType {
   fullIngestion = "full_ingestion",
-  partialIngestion = "partial_Ingestion",
+  partialIngestion = "partial_ingestion",
 }


### PR DESCRIPTION

### Description

Earlier we don't have any way to differentiate the current stat which is coming from web-socket , since in slack we provided two ways to ingest the data 
1.Ingest all Data 
2.Ingest particular Channel
So added the ingestionType enum to verify what kind of stats its for and based on that used that to display the stats

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Slack integration now displays separate ingestion statistics for full and partial ingestion types.
  - Manual ingestion stats are shown independently when data is available.

- **Improvements**
  - Ingestion status updates are more clearly categorized by ingestion type for better tracking and visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->