### PR TITLE
fixed multi chat parallel streaming

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -97,6 +97,7 @@ interface ChatBoxProps {
     toolExternalIds?: string[],
   ) => void // Expects agentId string
   isStreaming?: boolean
+  retryIsStreaming?: boolean
   handleStop?: () => void
   chatId?: string | null // Current chat ID
   agentIdFromChatData?: string | null // New prop for agentId from chat data
@@ -218,6 +219,7 @@ export const ChatBox = ({
   setQuery,
   handleSend,
   isStreaming = false,
+  retryIsStreaming = false,
   allCitations,
   handleStop,
   chatId,
@@ -2312,7 +2314,7 @@ export const ChatBox = ({
               Agent
             </span>
           </div>
-          {isStreaming && chatId ? (
+          {(isStreaming || retryIsStreaming) && chatId ? (
             <button
               onClick={handleStop}
               style={{ marginLeft: "auto" }}
@@ -2322,7 +2324,7 @@ export const ChatBox = ({
             </button>
           ) : (
             <button
-              disabled={isStreaming}
+              disabled={isStreaming || retryIsStreaming}
               onClick={() => handleSendMessage()}
               style={{ marginLeft: "auto" }}
               className="flex mr-6 bg-[#464B53] dark:bg-slate-700 text-white dark:text-slate-200 hover:bg-[#5a5f66] dark:hover:bg-slate-600 rounded-full w-[32px] h-[32px] items-center justify-center disabled:opacity-50"

--- a/frontend/src/hooks/useChatHistory.ts
+++ b/frontend/src/hooks/useChatHistory.ts
@@ -1,0 +1,117 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { api } from "@/api"
+import { SelectPublicMessage } from "shared/types"
+
+interface ChatHistoryData {
+  messages: SelectPublicMessage[]
+  chat?: {
+    title: string | null
+    isBookmarked: boolean
+  }
+}
+
+export const useChatHistory = (chatId: string | null) => {
+  const queryClient = useQueryClient()
+
+  const query = useQuery<ChatHistoryData>({
+    queryKey: ["chatHistory", chatId],
+    queryFn: async () => {
+      console.log(`[useChatHistory] Fetching data for chatId: ${chatId}`)
+      
+      if (!chatId) {
+        console.log(`[useChatHistory] No chatId provided, returning empty messages`)
+        return { messages: [] }
+      }
+
+      try {
+        const response = await api.chat.$post({
+          json: { chatId }
+        })
+        
+        if (!response.ok) {
+          throw new Error("Failed to fetch chat history")
+        }
+        
+        const data = await response.json()
+        console.log(`[useChatHistory] Fetched ${data.messages?.length || 0} messages for chatId: ${chatId}`)
+        return data as ChatHistoryData
+      } catch (error) {
+        console.error("Error fetching chat history:", error)
+        throw error
+      }
+    },
+    enabled: !!chatId, // Only fetch when we have a chatId
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    refetchOnWindowFocus: false,
+  })
+
+  // Helper function to add a message optimistically
+  const addMessageOptimistically = (message: SelectPublicMessage) => {
+    console.log(`[useChatHistory] Adding message optimistically to chatId: ${chatId}`)
+    
+    queryClient.setQueryData<ChatHistoryData>(
+      ["chatHistory", chatId],
+      (oldData) => {
+        if (!oldData) {
+          console.log(`[useChatHistory] Creating new chat history with first message`)
+          return { messages: [message] }
+        }
+        console.log(`[useChatHistory] Adding message to existing ${oldData.messages.length} messages`)
+        return {
+          ...oldData,
+          messages: [...oldData.messages, message],
+        }
+      }
+    )
+  }
+
+  // Helper function to update the last message
+  const updateLastMessage = (updater: (msg: SelectPublicMessage) => SelectPublicMessage) => {
+    if (!chatId) return
+
+    queryClient.setQueryData<ChatHistoryData>(
+      ["chatHistory", chatId],
+      (oldData) => {
+        if (!oldData || oldData.messages.length === 0) return oldData
+        
+        const messages = [...oldData.messages]
+        const lastIndex = messages.length - 1
+        messages[lastIndex] = updater(messages[lastIndex])
+        
+        return {
+          ...oldData,
+          messages,
+        }
+      }
+    )
+  }
+
+  // Helper function to update chat metadata
+  const updateChatMetadata = (updates: Partial<{ title: string | null; isBookmarked: boolean }>) => {
+    if (!chatId) return
+
+    queryClient.setQueryData<ChatHistoryData>(
+      ["chatHistory", chatId],
+      (oldData) => {
+        if (!oldData) return oldData
+        
+        return {
+          ...oldData,
+          chat: {
+            ...oldData.chat,
+            title: oldData.chat?.title || null,
+            isBookmarked: oldData.chat?.isBookmarked || false,
+            ...updates,
+          }
+        }
+      }
+    )
+  }
+
+  return {
+    ...query,
+    addMessageOptimistically,
+    updateLastMessage,
+    updateChatMetadata,
+  }
+} 

--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -1,0 +1,704 @@
+import { useRef, useState, useEffect, useCallback } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { useRouter } from "@tanstack/react-router"
+import { api } from "@/api"
+import { ChatSSEvents, Citation } from "shared/types"
+import { toast } from "@/hooks/use-toast"
+
+// Module-level storage for persistent EventSource connections
+interface StreamState {
+  es: EventSource
+  partial: string
+  thinking: string
+  sources: Citation[]
+  citationMap: Record<number, number>
+  messageId?: string
+  chatId?: string
+  isStreaming: boolean
+  isRetrying?: boolean
+  subscribers: Set<() => void>
+}
+
+interface StreamInfo {
+  partial: string
+  thinking: string
+  sources: Citation[]
+  citationMap: Record<number, number>
+  messageId?: string
+  chatId?: string
+  isStreaming: boolean
+  isRetrying?: boolean
+}
+
+// Global map to store active streams - persists across component unmounts
+const activeStreams = new Map<string, StreamState>()
+
+// Helper function to parse HTML message input
+const parseMessageInput = (htmlString: string) => {
+  const container = document.createElement("div")
+  container.innerHTML = htmlString
+  const parts: Array<{ type: "text" | "pill" | "link"; value: any }> = []
+
+  const walk = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      if (node.textContent) {
+        parts.push({ type: "text", value: node.textContent })
+      }
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const el = node as HTMLElement
+      if (
+        el.tagName.toLowerCase() === "a" &&
+        el.classList.contains("reference-pill") &&
+        (el.dataset.docId || el.dataset.referenceId)
+      ) {
+        const entity = el.dataset.entity
+        const isContactPill =
+          entity === "OtherContacts" || entity === "Contacts"
+        let imgSrc: string | null = null
+        const imgElement = el.querySelector("img")
+        if (imgElement) {
+          imgSrc = imgElement.getAttribute("src")
+        }
+        parts.push({
+          type: "pill",
+          value: {
+            docId: el.dataset.docId || el.dataset.referenceId!,
+            url: isContactPill ? null : el.getAttribute("href"),
+            title: el.getAttribute("title"),
+            app: el.dataset.app,
+            entity: entity,
+            imgSrc: imgSrc,
+          },
+        })
+      } else if (el.tagName.toLowerCase() === "a" && el.getAttribute("href")) {
+        if (
+          !(
+            el.classList.contains("reference-pill") &&
+            (el.dataset.docId || el.dataset.referenceId)
+          )
+        ) {
+          parts.push({
+            type: "link",
+            value: el.getAttribute("href") || "",
+          })
+        } else {
+          Array.from(el.childNodes).forEach(walk)
+        }
+      }
+    }
+  }
+
+  Array.from(container.childNodes).forEach(walk)
+  return parts
+}
+
+// Notify all subscribers of a stream state change
+const notifySubscribers = (streamId: string) => {
+  const stream = activeStreams.get(streamId)
+  if (stream) {
+    stream.subscribers.forEach(callback => callback())
+  }
+}
+
+// Start a new stream or continue existing one
+export const startStream = async (
+  streamKey: string,
+  messageToSend: string,
+  selectedSources: string[] = [],
+  isReasoningActive: boolean = true,
+  isAgenticMode: boolean = false,
+  toolExternalIds: string[] = [],
+  queryClient?: any,
+  router?: any,
+  onTitleUpdate?: (title: string) => void,
+  agentIdFromChatParams?: string | null
+): Promise<void> => {
+  if (!messageToSend) return
+  
+  // Check if stream already exists and is active
+  if (activeStreams.has(streamKey) && activeStreams.get(streamKey)?.isStreaming) {
+    return
+  }
+
+  // Parse message content
+  const parsedMessageParts = parseMessageInput(messageToSend)
+  const hasRichContent = parsedMessageParts.some(
+    (part) => part.type === "pill" || part.type === "link"
+  )
+
+  let finalMessagePayload: string
+  if (hasRichContent) {
+    finalMessagePayload = JSON.stringify(parsedMessageParts)
+  } else {
+    finalMessagePayload = parsedMessageParts
+      .filter((part) => part.type === "text")
+      .map((part) => part.value)
+      .join("")
+  }
+
+  const isNewChat = streamKey.length === 36 && streamKey.includes('-')
+  const chatId = isNewChat ? null : streamKey
+
+  const url = new URL(`/api/v1/message/create`, window.location.origin)
+  if (chatId) {
+    url.searchParams.append("chatId", chatId)
+  }
+  if (isAgenticMode) {
+    url.searchParams.append("agentic", "true")
+  }
+  url.searchParams.append("modelId", "gpt-4o-mini")
+  url.searchParams.append("message", finalMessagePayload)
+
+  if (isReasoningActive) {
+    url.searchParams.append("isReasoningEnabled", "true")
+  }
+  if (toolExternalIds && toolExternalIds.length > 0) {
+    toolExternalIds.forEach((toolId) => {
+      url.searchParams.append("toolExternalIds", toolId)
+    })
+  }
+
+  const agentIdToUse = agentIdFromChatParams;
+  if (agentIdToUse) {
+    url.searchParams.append("agentId", agentIdToUse);
+  }
+
+  const eventSource = new EventSource(url.toString(), {
+    withCredentials: true,
+  })
+
+  const streamState: StreamState = {
+    es: eventSource,
+    partial: "",
+    thinking: "",
+    sources: [],
+    citationMap: {},
+    messageId: undefined,
+    chatId: chatId || undefined,
+    isStreaming: true,
+    isRetrying: false,
+    subscribers: new Set(),
+  }
+
+  activeStreams.set(streamKey, streamState)
+
+  streamState.es.addEventListener(ChatSSEvents.ResponseUpdate, (event) => {
+    streamState.partial += event.data
+    notifySubscribers(streamKey)
+  })
+
+  streamState.es.addEventListener(ChatSSEvents.Reasoning, (event) => {
+    streamState.thinking += event.data
+    notifySubscribers(streamKey)
+  })
+
+  streamState.es.addEventListener(ChatSSEvents.CitationsUpdate, (event) => {
+    const { contextChunks, citationMap } = JSON.parse(event.data)
+    streamState.sources = contextChunks
+    streamState.citationMap = citationMap
+    notifySubscribers(streamKey)
+  })
+
+  streamState.es.addEventListener(ChatSSEvents.ResponseMetadata, (event) => {
+    const { chatId: realId, messageId } = JSON.parse(event.data)
+    streamState.messageId = messageId
+    streamState.chatId = realId
+      
+    if (realId && streamKey !== realId && !streamKey.match(/^[a-z0-9]+$/)) {
+      activeStreams.delete(streamKey)
+      activeStreams.set(realId, streamState)
+      
+      if (router && router.state.location.pathname === "/chat") {
+        const isGlobalDebugMode = import.meta.env.VITE_SHOW_DEBUG_INFO === "true"
+        router.navigate({
+          to: "/chat/$chatId",
+          params: { chatId: realId },
+          search: isGlobalDebugMode ? { debug: true } : {},
+          replace: true,
+        })
+      }
+
+      if (queryClient) {
+        const oldData = queryClient.getQueryData(["chatHistory", null])
+        if (oldData) {
+          queryClient.setQueryData(["chatHistory", realId], oldData)
+          queryClient.removeQueries({ queryKey: ["chatHistory", null] })
+        }
+      }
+      streamKey = realId
+    }
+    notifySubscribers(streamKey)
+  })
+
+  streamState.es.addEventListener(ChatSSEvents.ChatTitleUpdate, (event) => {
+    if (onTitleUpdate) {
+      onTitleUpdate(event.data)
+    }
+  })
+
+  streamState.es.addEventListener(ChatSSEvents.End, () => {
+    streamState.isStreaming = false
+    streamState.es.close()
+    
+    if (streamKey && queryClient) {
+      queryClient.invalidateQueries({ queryKey: ["chatHistory", streamKey] })
+    }
+    notifySubscribers(streamKey)
+  })
+
+  streamState.es.addEventListener(ChatSSEvents.Error, (event) => {
+    console.error(`Stream error:`, event.data)
+    streamState.isStreaming = false
+    streamState.es.close()
+    
+    toast({
+      title: "Error",
+      description: event.data,
+      variant: "destructive",
+    })
+    notifySubscribers(streamKey)
+  })
+
+  streamState.es.onerror = (error) => {
+    console.error(`EventSource error:`, error)
+    streamState.isStreaming = false
+    streamState.es.close()
+    
+    toast({
+      title: "Error",
+      description: "Connection error. Please try again.",
+      variant: "destructive",
+    })
+    notifySubscribers(streamKey)
+  }
+}
+
+// Stop a specific stream
+export const stopStream = async (streamKey: string, queryClient?: any, setRetryIsStreaming?: (isRetrying: boolean) => void): Promise<void> => {
+  const stream = activeStreams.get(streamKey)
+  
+  if (!stream) return
+
+  if (setRetryIsStreaming) {
+    setRetryIsStreaming(false)
+    stream.isRetrying = false
+  }
+  
+  stream.isStreaming = false
+  stream.es.close()
+  
+  const currentChatId = stream.chatId || streamKey
+  if (currentChatId) {
+    try {
+      await api.chat.stop.$post({
+        json: { chatId: currentChatId },
+      })
+      
+      if (queryClient) {
+        await new Promise(resolve => setTimeout(resolve, 500))
+        await queryClient.refetchQueries({ queryKey: ["chatHistory", currentChatId] })
+      }
+    } catch (error) {
+      console.error("Failed to send stop request:", error)
+      toast({
+        title: "Error",
+        description: "Could not stop streaming.",
+        variant: "destructive",
+        duration: 1000,
+      })
+    }
+  }
+  notifySubscribers(currentChatId)
+  activeStreams.delete(streamKey)
+}
+
+// Get current stream state (for hook consumers)
+export const getStreamState = (streamKey: string): StreamInfo => {
+  const stream = activeStreams.get(streamKey)
+  
+  if (!stream) {
+    return {
+      partial: "",
+      thinking: "",
+      sources: [],
+      citationMap: {},
+      messageId: undefined,
+      chatId: undefined,
+      isStreaming: false,
+    }
+  }
+  
+  return {
+    partial: stream.partial,
+    thinking: stream.thinking,
+    sources: stream.sources,
+    citationMap: stream.citationMap,
+    messageId: stream.messageId,
+    chatId: stream.chatId,
+    isStreaming: stream.isStreaming,
+  }
+}
+
+// Periodic check for dead streams:
+const cleanupInterval = setInterval(() => {
+  activeStreams.forEach((stream, key) => {
+    if (stream.es.readyState === EventSource.CLOSED) {
+      activeStreams.delete(key);
+    }
+  });
+}, 30000);
+
+export const cleanupStreams = () => {
+  clearInterval(cleanupInterval)
+}
+
+// React hook that subscribes to stream updates
+export const useChatStream = (
+  chatId: string | null,
+  onTitleUpdate?: (title: string) => void,
+  setRetryIsStreaming?: (isRetrying: boolean) => void
+) => {
+  const queryClient = useQueryClient()
+  const router = useRouter()
+  
+  const streamKeyRef = useRef<string | null>(null)
+  const lastChatIdRef = useRef<string | null>(null)
+  
+  if (chatId !== lastChatIdRef.current) {
+    streamKeyRef.current = chatId ?? crypto.randomUUID()
+    lastChatIdRef.current = chatId
+  }
+  
+  if (!streamKeyRef.current) {
+    streamKeyRef.current = chatId ?? crypto.randomUUID()
+  }
+  
+  const currentStreamKey = chatId ?? streamKeyRef.current
+  
+  const [streamInfo, setStreamInfo] = useState<StreamInfo>(() => getStreamState(currentStreamKey))
+  const subscriberRef = useRef<(() => void) | null>(null)
+  const currentStreamKeyRef = useRef<string>(currentStreamKey)
+
+  useEffect(() => {
+    currentStreamKeyRef.current = currentStreamKey
+  }, [currentStreamKey])
+
+  useEffect(() => {
+    const stream = activeStreams.get(router.state.location.pathname.split("/").pop() || "")
+    if(setRetryIsStreaming) {
+      setRetryIsStreaming(stream?.isRetrying|| false)
+    }
+  }, [router.state.location.pathname])
+
+  useEffect(() => {
+    const streamKey = currentStreamKey
+    
+    if (subscriberRef.current) {
+      activeStreams.forEach((stream, key) => {
+        if (subscriberRef.current) {
+          stream.subscribers.delete(subscriberRef.current)
+        }
+      })
+    }
+    
+    const subscriber = () => {
+      if (currentStreamKeyRef.current === streamKey) {
+        setStreamInfo(getStreamState(streamKey))
+      }
+    }
+    
+    subscriberRef.current = subscriber
+    
+    const stream = activeStreams.get(streamKey)
+    if (stream) {
+      stream.subscribers.add(subscriber)
+      subscriber()
+    } else {
+      setStreamInfo(getStreamState(streamKey))
+    }
+    
+    return () => {
+      const stream = activeStreams.get(streamKey)
+      if (stream && subscriberRef.current) {
+        stream.subscribers.delete(subscriberRef.current)
+      }
+    }
+  }, [currentStreamKey])
+
+  const wrappedStartStream = useCallback(async (
+    messageToSend: string,
+    selectedSources: string[] = [],
+    isReasoningActive: boolean = true,
+    isAgenticMode: boolean = false,
+    toolExternalIds: string[] = [],
+    agentIdFromChatParams?: string | null
+  ) => {
+    const streamKey = currentStreamKey
+    
+    await startStream(
+      streamKey,
+      messageToSend,
+      selectedSources,
+      isReasoningActive,
+      isAgenticMode,
+      toolExternalIds,
+      queryClient,
+      router,
+      onTitleUpdate,
+      agentIdFromChatParams
+    )
+    
+    setStreamInfo(getStreamState(streamKey))
+    
+    const stream = activeStreams.get(streamKey)
+    if (stream && subscriberRef.current) {
+      stream.subscribers.add(subscriberRef.current)
+      subscriberRef.current()
+    }
+    
+    streamKeyRef.current = streamKey
+  }, [currentStreamKey, queryClient, router, onTitleUpdate])
+
+  const wrappedStopStream = useCallback(async () => {
+    await stopStream(currentStreamKey, queryClient, setRetryIsStreaming)
+  }, [currentStreamKey, queryClient, setRetryIsStreaming])
+
+  const retryMessage = useCallback(async (
+    messageId: string,
+    isReasoningActive: boolean = false,
+    isAgenticMode: boolean = false,
+  ) => {
+    if (!messageId) return
+
+    let isError = false
+    let targetMessageId : string | null = null
+    
+    if (chatId) {
+      try {
+        await queryClient.fetchQuery({
+          queryKey: ["chatHistory", chatId],
+        })
+      } catch (err) {
+        console.error("Failed to fetch latest chat history before retry:", err)
+      }
+    }
+    
+    if (chatId) {
+      queryClient.setQueryData(["chatHistory", chatId], (old: any) => {
+        if (!old?.messages) return old
+        return {
+          ...old,
+          messages: old.messages.map((m: any) =>
+            (m.externalId === messageId && m.messageRole === "assistant") ? { ...m, isRetrying: true, message: "", thinking: "" } : m,
+          ),
+        }
+      })
+
+      const chatData = queryClient.getQueryData<any>(["chatHistory", chatId])
+      if (chatData && chatData.messages) {
+        const matched = chatData.messages.find((msg: any) => msg.externalId === messageId)
+
+        if (matched && matched.errorMessage && matched.errorMessage !== "") {
+          isError = true
+          const matchedIndex = chatData.messages.findIndex(
+            (msg: any) => msg.externalId === messageId
+          )
+          
+          targetMessageId = crypto.randomUUID()
+          const assistantMessage = {
+            ...JSON.parse(JSON.stringify(matched)),
+            chatExternalId: chatId,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            externalId: targetMessageId,
+            messageRole: "assistant",
+            message: "",
+            isRetrying: true,
+            sources: [],
+            thinking: "",
+            errorMessage: "",
+          }
+          
+          queryClient.setQueryData(["chatHistory", chatId], (old: any) => {
+            if (!old?.messages) return old
+            const insertIndex = matchedIndex + 1
+            const updatedMessages = [
+              ...old.messages.slice(0, insertIndex),
+              assistantMessage,
+              ...old.messages.slice(insertIndex),
+            ]
+
+            return {
+              ...old,
+              messages: updatedMessages,
+            }
+          })
+
+          queryClient.setQueryData(["chatHistory", chatId], (old: any) => {
+            if (!old?.messages) return old
+            return {
+              ...old,
+              messages: old.messages.map((m: any) => {
+                if (m.externalId === messageId && m.messageRole === "user") {
+                  return { 
+                    ...m, 
+                    errorMessage: ""
+                  }
+                }
+                return m
+              }),
+            }
+          })
+        }
+      }
+    }
+
+    const url = new URL(`/api/v1/message/retry`, window.location.origin)
+    url.searchParams.append("messageId", encodeURIComponent(messageId))
+    if (isReasoningActive) {
+      url.searchParams.append("isReasoningEnabled", "true")
+    }
+    if (isAgenticMode) {
+      url.searchParams.append("agentic", "true")
+    }
+
+    const eventSource = new EventSource(url.toString(), {
+      withCredentials: true,
+    })
+
+    if (setRetryIsStreaming) {
+      setRetryIsStreaming(true)
+    }
+
+    const retryStreamKey = chatId || currentStreamKey
+    
+    const streamState: StreamState = {
+      es: eventSource,
+      partial: "",
+      thinking: "",
+      sources: [],
+      citationMap: {},
+      messageId: undefined,
+      chatId: chatId || undefined,
+      isStreaming: false,
+      isRetrying: true,
+      subscribers: new Set(),
+    }
+
+    activeStreams.set(retryStreamKey, streamState)
+
+    if (subscriberRef.current && retryStreamKey === currentStreamKeyRef.current) {
+      streamState.subscribers.add(subscriberRef.current)
+      subscriberRef.current()
+    }
+    notifySubscribers(retryStreamKey)
+
+    const patchResponseContent = (delta: string, isFinal = false) => {
+      if (!chatId) return
+      queryClient.setQueryData(["chatHistory", chatId], (old: any) => {
+        if (!old?.messages) return old
+        return {
+          ...old,
+          messages: old.messages.map((m: any) =>
+            (isError ? m.externalId === targetMessageId : m.externalId === messageId && m.messageRole === "assistant")
+              ? {
+                  ...m,
+                  message: isFinal ? delta : (m.message || "") + delta,
+                  isRetrying: !isFinal,
+                }
+              : m,
+          ),
+        }
+      })
+    }
+
+    const patchReasoningContent = (delta: string) => {
+      if (!chatId) return
+      queryClient.setQueryData(["chatHistory", chatId], (old: any) => {
+        if (!old?.messages) return old
+        return {
+          ...old,
+          messages: old.messages.map((m: any) =>
+            (isError ? m.externalId === targetMessageId : m.externalId === messageId && m.messageRole === "assistant")
+              ? {
+                  ...m,
+                  thinking: (m.thinking || "") + delta,
+                }
+              : m,
+          ),
+        }
+      })
+    }
+
+    eventSource.addEventListener(ChatSSEvents.ResponseUpdate, (event) => {
+      streamState.partial += event.data
+      patchResponseContent(event.data)
+    })
+
+    eventSource.addEventListener(ChatSSEvents.Reasoning, (event) => {
+      streamState.thinking += event.data
+      patchReasoningContent(event.data)
+    })
+
+    eventSource.addEventListener(ChatSSEvents.CitationsUpdate, (event) => {
+      const { contextChunks, citationMap } = JSON.parse(event.data)
+      streamState.sources = contextChunks
+      streamState.citationMap = citationMap
+    })
+
+    eventSource.addEventListener(ChatSSEvents.ResponseMetadata, (event) => {
+      const { messageId: newMessageId } = JSON.parse(event.data)
+      streamState.messageId = newMessageId
+    })
+
+    eventSource.addEventListener(ChatSSEvents.End, () => {
+      patchResponseContent(streamState.partial)
+      if (chatId) {
+        queryClient.invalidateQueries({ queryKey: ["chatHistory", chatId] })
+      }
+      if (setRetryIsStreaming) {
+        setRetryIsStreaming(false)
+      }
+      streamState.isRetrying = false
+      notifySubscribers(retryStreamKey)
+      activeStreams.delete(retryStreamKey)
+      eventSource.close()
+    })
+
+    eventSource.addEventListener(ChatSSEvents.Error, (event) => {
+      console.error("Retry stream error:", event.data)
+      toast({
+        title: "Error",
+        description: event.data,
+        variant: "destructive",
+      })
+      if (setRetryIsStreaming) {
+        setRetryIsStreaming(false)
+      }
+      streamState.isRetrying = false
+      notifySubscribers(retryStreamKey)
+      activeStreams.delete(retryStreamKey)
+      eventSource.close()
+    })
+
+    eventSource.onerror = () => {
+      console.error("Retry EventSource error")
+      if (setRetryIsStreaming) {
+        setRetryIsStreaming(false)
+      }
+      streamState.isRetrying = false
+      notifySubscribers(retryStreamKey)
+      activeStreams.delete(retryStreamKey)
+      eventSource.close()
+    }
+
+  }, [currentStreamKey, queryClient, chatId, setRetryIsStreaming])
+
+  return {
+    ...streamInfo,
+    startStream: wrappedStartStream,
+    stopStream: wrappedStopStream,
+    retryMessage,
+    onTitleUpdate,
+  }
+}

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -21,7 +21,6 @@ import {
 import { useEffect, useRef, useState, Fragment } from "react"
 import { useTheme } from "@/components/ThemeContext"
 import {
-  ChatSSEvents,
   SelectPublicMessage,
   Citation,
   MessageFeedback,
@@ -58,18 +57,11 @@ import React from "react"
 import { renderToStaticMarkup } from "react-dom/server"
 import { Pill } from "@/components/Pill"
 import { Reference } from "@/types"
+import { useChatStream } from "@/hooks/useChatStream"
+import { useChatHistory } from "@/hooks/useChatHistory"
 import { parseHighlight } from "@/components/Highlight"
 
 export const THINKING_PLACEHOLDER = "Thinking"
-
-type CurrentResp = {
-  resp: string
-  chatId?: string
-  messageId?: string
-  sources?: Citation[]
-  citationMap?: Record<number, number>
-  thinking?: string
-}
 
 // Mapping from source ID to app/entity object
 // const sourceIdToAppEntityMap: Record<string, { app: string; entity?: string }> =
@@ -105,67 +97,6 @@ type ParsedMessagePart =
       }
     }
   | { type: "link"; value: string }
-
-// Helper function to parse HTML message input
-const parseMessageInput = (htmlString: string): Array<ParsedMessagePart> => {
-  const container = document.createElement("div")
-  container.innerHTML = htmlString
-  const parts: Array<ParsedMessagePart> = []
-
-  const walk = (node: Node) => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      if (node.textContent) {
-        parts.push({ type: "text", value: node.textContent })
-      }
-    } else if (node.nodeType === Node.ELEMENT_NODE) {
-      const el = node as HTMLElement
-      if (
-        el.tagName.toLowerCase() === "a" &&
-        el.classList.contains("reference-pill") &&
-        (el.dataset.docId || el.dataset.referenceId)
-      ) {
-        const entity = el.dataset.entity
-        const isContactPill =
-          entity === "OtherContacts" || entity === "Contacts"
-        let imgSrc: string | null = null
-        const imgElement = el.querySelector("img")
-        if (imgElement) {
-          imgSrc = imgElement.getAttribute("src")
-        }
-        parts.push({
-          type: "pill",
-          value: {
-            docId: el.dataset.docId || el.dataset.referenceId!,
-            url: isContactPill ? null : el.getAttribute("href"),
-            title: el.getAttribute("title"),
-            app: el.dataset.app,
-            entity: entity,
-            imgSrc: imgSrc,
-          },
-        })
-      } else if (el.tagName.toLowerCase() === "a" && el.getAttribute("href")) {
-        // Ensure this link is not also a reference pill that we've already processed
-        if (
-          !(
-            el.classList.contains("reference-pill") &&
-            (el.dataset.docId || el.dataset.referenceId)
-          )
-        ) {
-          parts.push({
-            type: "link",
-            value: el.getAttribute("href") || "",
-          })
-        }
-        // Do not walk children of a link we've already processed as a "link" part
-      } else {
-        Array.from(el.childNodes).forEach(walk)
-      }
-    }
-  }
-
-  Array.from(container.childNodes).forEach(walk)
-  return parts
-}
 
 // Helper function to convert JSON message parts back to HTML using Pill component
 const jsonToHtmlMessage = (jsonString: string): string => {
@@ -252,6 +183,7 @@ export const ChatPage = ({
       : "/_authenticated/chat",
   })
   const queryClient = useQueryClient()
+  
   if (chatParams.q && isWithChatId) {
     router.navigate({
       to: "/chat/$chatId",
@@ -265,23 +197,47 @@ export const ChatPage = ({
   const hasHandledQueryParam = useRef(false)
 
   const [query, setQuery] = useState("")
-  const [messages, setMessages] = useState<SelectPublicMessage[]>(
-    isWithChatId ? data?.messages || [] : [],
-  )
-  const [chatId, setChatId] = useState<string | null>(
-    (params as any).chatId || null,
-  )
+  const chatId = (params as any).chatId || null
+  
+  // Add retryIsStreaming state
+  const [retryIsStreaming, setRetryIsStreaming] = useState(false)
+  
+  // Use custom hooks for streaming and history
+  const { data: historyData, isLoading: historyLoading } = useChatHistory(chatId)
+  const {
+    partial,
+    thinking,
+    sources,
+    citationMap,
+    isStreaming,
+    messageId: streamInfoMessageId,
+    startStream,
+    stopStream,
+    retryMessage,
+  } = useChatStream(chatId, (title: string) => setChatTitle(title), setRetryIsStreaming)
+  
+  // Use history data if available, otherwise fall back to loader data
+  const messages = historyData?.messages || (isWithChatId ? data?.messages || [] : [])
+  
   const [chatTitle, setChatTitle] = useState<string | null>(
     isWithChatId && data ? data?.chat?.title || null : null,
   )
-  const [currentResp, setCurrentResp] = useState<CurrentResp | null>(null)
-  const [showRagTrace, setShowRagTrace] = useState(false) // Added state
-  const [stopMsg, setStopMsg] = useState<boolean>(false)
-  const [selectedMessageId, setSelectedMessageId] = useState<string | null>(
-    null,
-  ) // Added state
+  
+  // Create a current streaming response for compatibility with existing UI,
+  // merging the real stream IDs once available
+  const currentResp = isStreaming
+    ? {
+        resp: partial,
+        thinking,
+        sources,
+        citationMap,
+        messageId: streamInfoMessageId,
+        chatId,
+      }
+    : null
 
-  const currentRespRef = useRef<CurrentResp | null>(null)
+  const [showRagTrace, setShowRagTrace] = useState(false)
+  const [selectedMessageId, setSelectedMessageId] = useState<string | null>(null)
   const [bookmark, setBookmark] = useState<boolean>(
     isWithChatId ? !!data?.chat?.isBookmarked || false : false,
   )
@@ -289,7 +245,6 @@ export const ChatPage = ({
   const messagesContainerRef = useRef<HTMLDivElement>(null)
   const [userHasScrolled, setUserHasScrolled] = useState(false)
   const [dots, setDots] = useState("")
-  const [isStreaming, setIsStreaming] = useState(false)
   const [showSources, setShowSources] = useState(false)
   const [currentCitations, setCurrentCitations] = useState<Citation[]>([])
   const [currentMessageId, setCurrentMessageId] = useState<string | null>(null)
@@ -299,8 +254,8 @@ export const ChatPage = ({
   const [allCitations, setAllCitations] = useState<Map<string, Citation>>(
     new Map(),
   ) // State for all citations
-  const eventSourceRef = useRef<EventSource | null>(null) // Added ref for EventSource
-  const [userStopped, setUserStopped] = useState<boolean>(false) // Add state for user stop
+  // const eventSourceRef = useRef<EventSource | null>(null) // Added ref for EventSource
+  // const [userStopped, setUserStopped] = useState<boolean>(false) // Add state for user stop
   const [feedbackMap, setFeedbackMap] = useState<
     Record<string, MessageFeedback | null>
   >({})
@@ -309,6 +264,9 @@ export const ChatPage = ({
     const storedValue = localStorage.getItem(REASONING_STATE_KEY)
     return storedValue ? JSON.parse(storedValue) : true
   })
+
+  // Compute disableRetry flag for retry buttons
+  const disableRetry = isStreaming || retryIsStreaming
 
   useEffect(() => {
     localStorage.setItem(REASONING_STATE_KEY, JSON.stringify(isReasoningActive))
@@ -370,7 +328,7 @@ export const ChatPage = ({
   useEffect(() => {
     const newCitations = new Map(allCitations)
     let changed = false
-    messages.forEach((msg) => {
+    messages.forEach((msg: SelectPublicMessage) => {
       if (msg.messageRole === "assistant" && msg.sources) {
         // Add explicit type for citation
         msg.sources.forEach((citation: Citation) => {
@@ -427,7 +385,7 @@ export const ChatPage = ({
   }, [currentChat?.title, isEditing, chatTitle])
 
   useEffect(() => {
-    if (isStreaming) {
+    if (isStreaming || retryIsStreaming) {
       const interval = setInterval(() => {
         setDots((prev) => {
           if (prev.length >= 3) {
@@ -442,13 +400,14 @@ export const ChatPage = ({
     } else {
       setDots("")
     }
-  }, [isStreaming])
+  }, [isStreaming, retryIsStreaming])
 
+  // Handle initial data loading and feedbackMap initialization
   useEffect(() => {
     if (!hasHandledQueryParam.current || isWithChatId) {
-      setMessages(isWithChatId ? data?.messages || [] : [])
+      // Data will be loaded via useChatHistory hook
     }
-    setChatId((params as any).chatId || null)
+    
     setChatTitle(isWithChatId ? data?.chat?.title || null : null)
     setBookmark(isWithChatId ? !!data?.chat?.isBookmarked || false : false)
 
@@ -465,10 +424,6 @@ export const ChatPage = ({
       setFeedbackMap(initialFeedbackMap)
     }
 
-    if (!isStreaming && !hasHandledQueryParam.current) {
-      setCurrentResp(null)
-      currentRespRef.current = null
-    }
     inputRef.current?.focus()
     setShowSources(false)
     setCurrentCitations([])
@@ -476,7 +431,7 @@ export const ChatPage = ({
   }, [
     data?.chat?.isBookmarked,
     data?.chat?.title,
-    data?.messages, // This will re-run when messages data changes
+    data?.messages,
     isWithChatId,
     params,
   ])
@@ -486,7 +441,6 @@ export const ChatPage = ({
       const messageToSend = decodeURIComponent(chatParams.q)
 
       let sourcesArray: string[] = []
-      // Process chatParams.sources safely
       const _sources = chatParams.sources as string | string[] | undefined
 
       if (Array.isArray(_sources)) {
@@ -498,7 +452,6 @@ export const ChatPage = ({
           .filter((s) => s.length > 0)
       }
 
-      // Set reasoning state from URL param if present
       if (typeof chatParams.reasoning === "boolean") {
         setIsReasoningActive(chatParams.reasoning)
       }
@@ -536,267 +489,33 @@ export const ChatPage = ({
   const handleSend = async (
     messageToSend: string,
     selectedSources: string[] = [],
-    agentIdFromChatBox?: string | null, // Added agentIdFromChatBox
+    agentIdFromChatBox?: string | null,
     toolExternalIds?: string[],
   ) => {
     if (!messageToSend || isStreaming) return
-
-    // Reset userHasScrolled to false when a new message is sent.
-    // This ensures that the view will scroll down automatically as the new message streams in,
-    // unless the user manually scrolls up during the streaming.
+    
     setUserHasScrolled(false)
     setQuery("")
-    setMessages((prevMessages) => [
-      ...prevMessages,
-      { messageRole: "user", message: messageToSend },
-    ])
-
-    setIsStreaming(true)
-    setCurrentResp({ resp: "", thinking: "" })
-    currentRespRef.current = { resp: "", sources: [], thinking: "" }
-
-    // const appEntities = selectedSources
-    //   .map((sourceId) => sourceIdToAppEntityMap[sourceId])
-    //   .filter((item) => item !== undefined)
-
-    // Always parse the message input to a structured format
-    const parsedMessageParts = parseMessageInput(messageToSend)
-
-    // Determine if the message contains any pills or links
-    const hasRichContent = parsedMessageParts.some(
-      (part) => part.type === "pill" || part.type === "link",
+    
+    // Add user message optimistically to React Query cache
+    const queryKey = chatId
+    
+    queryClient.setQueryData<any>(
+      ["chatHistory", queryKey],
+      (oldData: any) => {
+        if (!oldData) {
+          return { messages: [{ messageRole: "user", message: messageToSend }] }
+        }
+        return {
+          ...oldData,
+          messages: [...(oldData.messages || []), { messageRole: "user", message: messageToSend }],
+        }
+      }
     )
-
-    let finalMessagePayload: string
-    if (hasRichContent) {
-      finalMessagePayload = JSON.stringify(parsedMessageParts)
-    } else {
-      // If only text parts, send the original plain text message
-      // We extract the text content from parsedMessageParts to ensure it's just the text
-      // and not potentially an empty array string if messageToSend was empty.
-      finalMessagePayload = parsedMessageParts
-        .filter((part) => part.type === "text")
-        .map((part) => part.value)
-        .join("")
-    }
-
-    const url = new URL(`/api/v1/message/create`, window.location.origin) // TODO: call only if any mcp clients are enable.
-    if (chatId) {
-      url.searchParams.append("chatId", chatId)
-    }
-    if (isAgenticMode) {
-      url.searchParams.append("agentic", "true")
-    }
-    url.searchParams.append("modelId", "gpt-4o-mini")
-    url.searchParams.append("message", finalMessagePayload)
-
-    // if (appEntities.length > 0) {
-    //   url.searchParams.append(
-    //     "stringifiedAppEntity",
-    //     JSON.stringify(appEntities),
-    //   )
-    // }
-    if (isReasoningActive) {
-      url.searchParams.append("isReasoningEnabled", "true")
-    }
-    if (toolExternalIds && toolExternalIds.length > 0) {
-      toolExternalIds.forEach((toolId) => {
-        url.searchParams.append("toolExternalIds", toolId)
-      })
-    }
 
     // Use agentIdFromChatBox if provided, otherwise fallback to chatParams.agentId (for initial load)
     const agentIdToUse = agentIdFromChatBox || chatParams.agentId
-    if (agentIdToUse) {
-      url.searchParams.append("agentId", agentIdToUse)
-    }
-
-    eventSourceRef.current = new EventSource(url.toString(), {
-      // Store EventSource
-      withCredentials: true,
-    })
-
-    // ... (rest of the eventSource listeners remain the same) ...
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.CitationsUpdate,
-      (event) => {
-        // Use ref
-        const { contextChunks, citationMap } = JSON.parse(event.data)
-        if (currentRespRef.current) {
-          currentRespRef.current.sources = contextChunks
-          currentRespRef.current.citationMap = citationMap
-          // Add explicit type for prevResp
-          setCurrentResp((prevResp: CurrentResp | null) => ({
-            ...(prevResp || { resp: "", thinking: "" }), // Ensure proper default structure
-            resp: prevResp?.resp || "",
-            sources: contextChunks,
-            citationMap,
-          }))
-        }
-      },
-    )
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.Reasoning, (event) => {
-      setCurrentResp((prevResp: CurrentResp | null) => ({
-        ...(prevResp || { resp: "", thinking: event.data || "" }),
-        thinking: (prevResp?.thinking || "") + event.data,
-      }))
-    })
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.Start, (event) => {})
-
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.ResponseUpdate,
-      (event) => {
-        setCurrentResp((prevResp: CurrentResp | null) => {
-          const updatedResp = prevResp
-            ? { ...prevResp, resp: prevResp.resp + event.data }
-            : { resp: event.data, thinking: "", sources: [], citationMap: {} }
-          currentRespRef.current = updatedResp
-          return updatedResp
-        })
-      },
-    )
-
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.ResponseMetadata,
-      (event) => {
-        // Use ref
-        const { chatId, messageId } = JSON.parse(event.data)
-        setChatId(chatId)
-        if (chatId) {
-          setTimeout(() => {
-            router.navigate({
-              to: "/chat/$chatId",
-              params: { chatId },
-              search: !isGlobalDebugMode ? { debug: isDebugMode } : {},
-            })
-          }, 1000)
-
-          if (!stopMsg) {
-            setStopMsg(true)
-          }
-        }
-        if (messageId) {
-          if (currentRespRef.current) {
-            setCurrentResp((resp: CurrentResp | null) => {
-              const updatedResp = resp || { resp: "", thinking: "" }
-              updatedResp.chatId = chatId
-              updatedResp.messageId = messageId
-              currentRespRef.current = updatedResp
-              return updatedResp
-            })
-          } else {
-            setMessages((prevMessages) => {
-              const lastMessage = prevMessages[prevMessages.length - 1]
-              if (lastMessage.messageRole === "assistant") {
-                return [
-                  ...prevMessages.slice(0, -1),
-                  { ...lastMessage, externalId: messageId },
-                ]
-              }
-              return prevMessages
-            })
-          }
-        }
-      },
-    )
-
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.ChatTitleUpdate,
-      (event) => {
-        // Use ref
-        setChatTitle(event.data)
-      },
-    )
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.End, (event) => {
-      // Use ref
-      const currentResp = currentRespRef.current
-      if (currentResp) {
-        setMessages((prevMessages) => [
-          ...prevMessages,
-          {
-            messageRole: "assistant",
-            message: currentResp.resp,
-            externalId: currentResp.messageId,
-            sources: currentResp.sources,
-            citationMap: currentResp.citationMap,
-            thinking: currentResp.thinking,
-          },
-        ])
-      }
-      setCurrentResp(null)
-      currentRespRef.current = null
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setStopMsg(false)
-      setIsStreaming(false)
-    })
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.Error, (event) => {
-      // Use ref
-      console.error("Error with SSE:", event.data)
-      const currentResp = currentRespRef.current
-      if (currentResp) {
-        setMessages((prevMessages) => [
-          ...prevMessages,
-          {
-            messageRole: "assistant",
-            message: `${event.data}`,
-            externalId: currentResp.messageId,
-            sources: currentResp.sources,
-            citationMap: currentResp.citationMap,
-            thinking: currentResp.thinking,
-          },
-        ])
-      }
-      setCurrentResp(null)
-      currentRespRef.current = null
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setStopMsg(false)
-      setIsStreaming(false)
-    })
-
-    eventSourceRef.current.onerror = (error) => {
-      // Use ref
-      // Check if the stop was intentional
-      if (userStopped) {
-        setUserStopped(false) // Reset the flag
-        // Clean up state, similar to handleStop or End event
-        setCurrentResp(null)
-        currentRespRef.current = null
-        setStopMsg(false)
-        setIsStreaming(false)
-        // Close again just in case, and clear ref
-        eventSourceRef.current?.close()
-        eventSourceRef.current = null
-        // Do NOT add an error message in this case
-        return
-      }
-
-      // If it wasn't a user stop, proceed with error handling as before
-      console.error("Error with SSE:", error)
-      const currentResp = currentRespRef.current
-      if (currentResp) {
-        setMessages((prevMessages) => [
-          ...prevMessages,
-          {
-            messageRole: "assistant",
-            message: `Error occurred: please try again`,
-          },
-        ])
-      }
-      setCurrentResp(null)
-      currentRespRef.current = null
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setStopMsg(false)
-      setIsStreaming(false)
-    }
-
-    setQuery("")
+    await startStream(messageToSend, selectedSources, isReasoningActive, isAgenticMode, toolExternalIds || [], agentIdToUse)
   }
 
   const handleFeedback = async (
@@ -843,360 +562,9 @@ export const ChatPage = ({
     }
   }
 
-  const handleStop = async () => {
-    setUserStopped(true) // Indicate intentional stop before closing
-
-    if (eventSourceRef.current) {
-      eventSourceRef.current.close()
-      eventSourceRef.current = null // Clear the ref
-    }
-
-    setIsStreaming(false)
-
-    // 4. Attempt to send stop request to backend if IDs are available
-    if (chatId && isStreaming) {
-      // This `isStreaming` check might be redundant now, but let's keep it for safety
-      try {
-        await api.chat.stop.$post({
-          json: {
-            chatId: chatId,
-          },
-        })
-      } catch (error) {
-        console.error("Failed to send stop request to backend:", error)
-        toast({
-          title: "Error",
-          description: "Could not stop streaming.",
-          variant: "destructive",
-          duration: 1000,
-        })
-        // Backend stop failed, but client-side is already stopped
-      }
-    }
-
-    // 5. Add partial response to messages if available
-    if (currentRespRef.current && currentRespRef.current.resp) {
-      // Use currentRespRef.current directly
-      setMessages((prevMessages) => [
-        ...prevMessages,
-        {
-          messageRole: "assistant",
-          message: currentRespRef.current?.resp || " ", // Use currentRespRef.current
-          externalId: currentRespRef.current?.messageId, // Use currentRespRef.current
-          sources: currentRespRef.current?.sources, // Use currentRespRef.current
-          citationMap: currentRespRef.current?.citationMap, // Use currentRespRef.current
-          thinking: currentRespRef.current?.thinking, // Use currentRespRef.current
-        },
-      ])
-    }
-
-    // 6. Clear streaming-related state *after* backend request and message handling
-    setCurrentResp(null)
-    currentRespRef.current = null
-    setStopMsg(false)
-    // 7. Invalidate router state after a short delay to refetch loader data
-    setTimeout(() => {
-      router.invalidate()
-    }, 1000) // Delay for 500ms
-  }
-
   const handleRetry = async (messageId: string) => {
     if (!messageId || isStreaming) return
-
-    setIsStreaming(true)
-    const userMsgWithErr = messages.find(
-      (msg) =>
-        msg.externalId === messageId &&
-        msg.messageRole === "user" &&
-        msg.errorMessage,
-    )
-    setMessages((prevMessages) => {
-      if (userMsgWithErr) {
-        const updatedMessages = [...prevMessages]
-        const index = updatedMessages.findIndex(
-          (msg) => msg.externalId === messageId && msg.messageRole === "user",
-        )
-
-        if (index !== -1) {
-          updatedMessages[index] = {
-            ...updatedMessages[index],
-            errorMessage: "",
-          }
-          updatedMessages.splice(index + 1, 0, {
-            messageRole: "assistant",
-            message: "",
-            isRetrying: true,
-            thinking: "",
-            sources: [],
-          })
-        }
-
-        return updatedMessages
-      } else {
-        return prevMessages.map((msg) => {
-          if (msg.externalId === messageId && msg.messageRole === "assistant") {
-            return {
-              ...msg,
-              message: "",
-              isRetrying: true,
-              sources: [],
-              thinking: "",
-            }
-          }
-          return msg
-        })
-      }
-    })
-
-    const url = new URL(`/api/v1/message/retry`, window.location.origin)
-    url.searchParams.append("messageId", encodeURIComponent(messageId))
-    url.searchParams.append("isReasoningEnabled", `${isReasoningActive}`)
-    setStopMsg(true) // Ensure stop message can be sent for retries
-    eventSourceRef.current = new EventSource(url.toString(), {
-      // Store EventSource
-      withCredentials: true,
-    })
-
-    if (isAgenticMode) {
-      url.searchParams.append("agentic", "true")
-    }
-
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.ResponseUpdate,
-      (event) => {
-        // Use ref
-        if (userMsgWithErr) {
-          setMessages((prevMessages) => {
-            const index = prevMessages.findIndex(
-              (msg) => msg.externalId === messageId,
-            )
-
-            if (index === -1 || index + 1 >= prevMessages.length) {
-              return prevMessages
-            }
-
-            const newMessages = [...prevMessages]
-            newMessages[index + 1] = {
-              ...newMessages[index + 1],
-              message: newMessages[index + 1].message + event.data,
-            }
-
-            return newMessages
-          })
-        } else {
-          setMessages((prevMessages) =>
-            prevMessages.map((msg) =>
-              msg.externalId === messageId && msg.isRetrying
-                ? { ...msg, message: msg.message + event.data }
-                : msg,
-            ),
-          )
-        }
-      },
-    )
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.Reasoning, (event) => {
-      // Use ref
-      if (userMsgWithErr) {
-        setMessages((prevMessages) => {
-          const index = prevMessages.findIndex(
-            (msg) => msg.externalId === messageId,
-          )
-
-          if (index === -1 || index + 1 >= prevMessages.length) {
-            return prevMessages
-          }
-
-          const newMessages = [...prevMessages]
-          newMessages[index + 1] = {
-            ...newMessages[index + 1],
-            thinking: (newMessages[index + 1].thinking || "") + event.data,
-          }
-
-          return newMessages
-        })
-      } else {
-        setMessages((prevMessages) =>
-          prevMessages.map((msg) =>
-            msg.externalId === messageId && msg.isRetrying
-              ? { ...msg, thinking: (msg.thinking || "") + event.data }
-              : msg,
-          ),
-        )
-      }
-    })
-
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.ResponseMetadata,
-      (event) => {
-        // Use ref
-        const userMessage = messages.find(
-          (msg) => msg.externalId === messageId && msg.messageRole === "user",
-        )
-        if (userMessage) {
-          const { messageId: newMessageId } = JSON.parse(event.data)
-
-          if (newMessageId) {
-            setMessages((prevMessages) => {
-              const index = prevMessages.findIndex(
-                (msg) => msg.externalId === messageId,
-              )
-
-              if (index === -1 || index + 1 >= prevMessages.length) {
-                return prevMessages
-              }
-
-              const newMessages = [...prevMessages]
-              newMessages[index + 1] = {
-                ...newMessages[index + 1],
-                externalId: newMessageId,
-              }
-              return newMessages
-            })
-          }
-        }
-      },
-    )
-
-    eventSourceRef.current.addEventListener(
-      ChatSSEvents.CitationsUpdate,
-      (event) => {
-        // Use ref
-        const { contextChunks, citationMap } = JSON.parse(event.data)
-        setMessages((prevMessages) => {
-          if (userMsgWithErr) {
-            const index = prevMessages.findIndex(
-              (msg) => msg.externalId === messageId,
-            )
-
-            if (index === -1 || index + 1 >= prevMessages.length) {
-              return prevMessages
-            }
-
-            const newMessages = [...prevMessages]
-
-            if (newMessages[index + 1].isRetrying) {
-              newMessages[index + 1] = {
-                ...newMessages[index + 1],
-                sources: contextChunks,
-                citationMap,
-              }
-            }
-
-            return newMessages
-          } else {
-            return prevMessages.map((msg) =>
-              msg.externalId === messageId && msg.isRetrying
-                ? { ...msg, sources: contextChunks, citationMap }
-                : msg,
-            )
-          }
-        })
-      },
-    )
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.End, (event) => {
-      // Use ref
-      setMessages((prevMessages) => {
-        if (userMsgWithErr) {
-          const index = prevMessages.findIndex(
-            (msg) => msg.externalId === messageId,
-          )
-
-          if (index === -1 || index + 1 >= prevMessages.length) {
-            return prevMessages
-          }
-
-          const newMessages = [...prevMessages]
-
-          if (newMessages[index + 1].isRetrying) {
-            newMessages[index + 1] = {
-              ...newMessages[index + 1],
-              isRetrying: false,
-            }
-          }
-
-          return newMessages
-        } else {
-          return prevMessages.map((msg) =>
-            msg.externalId === messageId && msg.isRetrying
-              ? { ...msg, isRetrying: false }
-              : msg,
-          )
-        }
-      })
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setIsStreaming(false)
-    })
-
-    eventSourceRef.current.addEventListener(ChatSSEvents.Error, (event) => {
-      // Use ref
-      console.error("Retry Error with SSE:", event.data)
-      setMessages((prevMessages) => {
-        if (userMsgWithErr) {
-          const index = prevMessages.findIndex(
-            (msg) => msg.externalId === messageId,
-          )
-
-          if (index === -1 || index + 1 >= prevMessages.length) {
-            return prevMessages
-          }
-
-          const newMessages = [...prevMessages]
-
-          if (newMessages[index + 1].isRetrying)
-            newMessages[index + 1] = {
-              ...newMessages[index + 1],
-              isRetrying: false,
-              message: event.data,
-            }
-
-          return newMessages
-        } else {
-          return prevMessages.map((msg) =>
-            msg.externalId === messageId && msg.isRetrying
-              ? { ...msg, isRetrying: false, message: event.data }
-              : msg,
-          )
-        }
-      })
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setIsStreaming(false)
-    })
-
-    eventSourceRef.current.onerror = (error) => {
-      // Use ref
-      console.error("Retry SSE Error:", error)
-      setMessages((prevMessages) => {
-        if (userMsgWithErr) {
-          const index = prevMessages.findIndex(
-            (msg) => msg.externalId === messageId,
-          )
-
-          if (index === -1 || index + 1 >= prevMessages.length) {
-            return prevMessages
-          }
-
-          const newMessages = [...prevMessages]
-
-          newMessages[index + 1] = {
-            ...newMessages[index + 1],
-            isRetrying: false,
-          }
-
-          return newMessages
-        } else {
-          return prevMessages.map((msg) =>
-            msg.isRetrying ? { ...msg, isRetrying: false } : msg,
-          )
-        }
-      })
-      eventSourceRef.current?.close() // Use ref
-      eventSourceRef.current = null // Clear ref
-      setIsStreaming(false)
-    }
+    await retryMessage(messageId, isReasoningActive, isAgenticMode)
   }
 
   const handleBookmark = async () => {
@@ -1224,22 +592,17 @@ export const ChatPage = ({
 
   const handleScroll = () => {
     const isAtBottom = isScrolledToBottom()
-    // Set userHasScrolled to true if the user scrolls up from the bottom.
-    // This will prevent the automatic scrolling behavior while the user is manually scrolling.
     setUserHasScrolled(!isAtBottom)
   }
 
   useEffect(() => {
     const container = messagesContainerRef.current
-    // Only scroll to the bottom if the container exists and the user has not manually scrolled up.
-    // This prevents the view from jumping to the bottom if the user is trying to read previous messages
-    // while a new message is streaming in.
     if (!container || userHasScrolled) return
 
     container.scrollTop = container.scrollHeight
-  }, [messages, currentResp?.resp])
+  }, [messages, partial])
 
-  if (data?.error) {
+  if (data?.error || historyLoading) {
     return (
       <div className="h-full w-full flex flex-col bg-white">
         <Sidebar isAgentMode={agentWhiteList} />
@@ -1347,8 +710,6 @@ export const ChatPage = ({
           </div>
         </div>
 
-        {/* The onScroll event handler is attached to this div because it's the scrollable container for messages. */}
-        {/* This ensures that scroll events are captured correctly to manage the auto-scroll behavior. */}
         <div
           className={`h-full w-full flex items-end overflow-y-auto justify-center transition-all duration-250 ${showSources ? "pr-[18%]" : ""}`}
           ref={messagesContainerRef}
@@ -1356,7 +717,7 @@ export const ChatPage = ({
         >
           <div className={`w-full h-full flex flex-col items-center`}>
             <div className="flex flex-col w-full  max-w-3xl flex-grow mb-[60px] mt-[56px]">
-              {messages.map((message, index) => {
+              {messages.map((message: SelectPublicMessage, index: number) => {
                 const isSourcesVisible =
                   showSources && currentMessageId === message.externalId
                 const userMessageWithErr =
@@ -1400,6 +761,7 @@ export const ChatPage = ({
                       onShowRagTrace={handleShowRagTrace}
                       feedbackStatus={feedbackMap[message.externalId!] || null}
                       onFeedback={handleFeedback}
+                      disableRetry={disableRetry}
                     />
                     {userMessageWithErr && (
                       <ChatMessage
@@ -1440,6 +802,7 @@ export const ChatPage = ({
                           feedbackMap[message.externalId!] || null
                         }
                         onFeedback={handleFeedback}
+                        disableRetry={disableRetry}
                       />
                     )}
                   </Fragment>
@@ -1479,6 +842,7 @@ export const ChatPage = ({
                   // Feedback not applicable for streaming response, but props are needed
                   feedbackStatus={null}
                   onFeedback={handleFeedback}
+                  disableRetry={disableRetry}
                 />
               )}
               <div className="absolute bottom-0 left-0 w-full h-[80px] bg-white dark:bg-[#1E1E1E]"></div>
@@ -1499,9 +863,10 @@ export const ChatPage = ({
               role={user?.role}
               query={query}
               setQuery={setQuery}
-              handleSend={handleSend} // handleSend function is passed here
-              handleStop={handleStop}
+              handleSend={handleSend}
+              handleStop={stopStream}
               isStreaming={isStreaming}
+              retryIsStreaming={retryIsStreaming}
               allCitations={allCitations}
               setIsAgenticMode={setIsAgenticMode}
               isAgenticMode={isAgenticMode}
@@ -1699,6 +1064,7 @@ export const ChatMessage = ({
   onShowRagTrace,
   feedbackStatus,
   onFeedback,
+  disableRetry = false,
 }: {
   message: string
   thinking: string
@@ -1715,8 +1081,9 @@ export const ChatMessage = ({
   isStreaming?: boolean
   isDebugMode: boolean
   onShowRagTrace: (messageId: string) => void
-  feedbackStatus?: MessageFeedback | null
-  onFeedback?: (messageId: string, feedback: MessageFeedback) => void
+  feedbackStatus?: MessageFeedback | null;
+  onFeedback?: (messageId: string, feedback: MessageFeedback) => void;
+  disableRetry?: boolean;
 }) => {
   const { theme } = useTheme()
   const [isCopied, setIsCopied] = useState(false)
@@ -1921,11 +1288,9 @@ export const ChatMessage = ({
                   }
                 />
                 <img
-                  className={`ml-[18px] ${isStreaming || !messageId ? "opacity-50" : "cursor-pointer"}`}
+                  className={`ml-[18px] ${disableRetry || !messageId ? "opacity-50" : "cursor-pointer"}`}
                   src={Retry}
-                  onClick={() =>
-                    messageId && !isStreaming && handleRetry(messageId)
-                  }
+                  onClick={() => messageId && !disableRetry && handleRetry(messageId)}
                   title="Retry"
                 />
                 {messageId && onFeedback && (
@@ -2016,10 +1381,10 @@ const chatParams = z.object({
           ? parsed
           : undefined
       } catch (e) {
-        return undefined // Invalid JSON
+        return undefined
       }
     }),
-  sources: z // Changed from sourceIds to sources, expects comma-separated string
+  sources: z
     .string()
     .optional()
     .transform((val) => (val ? val.split(",") : undefined)),


### PR DESCRIPTION
### Description

Previously, when a user entered a query and navigated to a different chat (either before or after the chat ID was generated), the streaming response from the active query would continue to render across other chats. This caused the UI to behave inconsistently and display content unrelated to the current chat context.

This PR resolves that issue by ensuring that streaming responses are isolated to their respective chats. Now, when a user navigates away mid-response, the ongoing stream is properly scoped and no longer affects other chat views.

### Testing
	1.	Start a new query in one chat.
	2.	While the response is streaming, navigate to a different chat from the history list:
	•	Before the chat ID is generated.
	•	After the chat ID is generated.
	3.	Confirm that:
	•	The response stream does not interfere with the newly opened chat.
	•	Upon returning to the original chat, the stream continues
