### PR TITLE
fix:increase Gmail ingestion timeout to 60 hours

### DIFF
--- a/server/integrations/google/index.ts
+++ b/server/integrations/google/index.ts
@@ -1055,8 +1055,8 @@ const handleGmailIngestionForServiceAccount = async (
           ),
         )
       }
-    }, 300000)
-
+    }, 216000000)
+    // 60hrs timeout
     pendingRequests.set(msgId, {
       userEmail,
       jobId, // Store jobId with the pending request


### PR DESCRIPTION
### Description

Changed the Gmail ingestion timeout from 5 minutes (or previous value) to 60 hours (216,000,000 ms).
Prevents premature timeout errors for long-running jobs.
earlier for users whose mail ingestion took more than 5 minutes , their sync jobs was not created because of timeout.

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
