### PR TITLE
fix(chats-metadata): fix schema determination based on app/entity

### DIFF
--- a/server/search/mappers.ts
+++ b/server/search/mappers.ts
@@ -449,7 +449,7 @@ export const appToSchemaMapper = (appName?: string): VespaSchema | null => {
     [Apps.GoogleDrive.toLowerCase()]: fileSchema,
     ["googledrive"]: fileSchema, // Alias for convenience
     [Apps.GoogleCalendar.toLowerCase()]: eventSchema,
-    ["googleCalendar"]: eventSchema, // Alias for convenience
+    ["googlecalendar"]: eventSchema, // Alias for convenience
     [Apps.Slack.toLowerCase()]: chatMessageSchema,
     [Apps.DataSource.toLowerCase()]: datasourceFileSchema,
   }

--- a/server/search/mappers.ts
+++ b/server/search/mappers.ts
@@ -235,12 +235,12 @@ export const VespaSearchResponseToSearchResult = (
             }
             return ChatMessageResponseSchema.parse(fields)
           } else if (
-            (child.fields as { sddocname?: string }).sddocname === 
+            (child.fields as { sddocname?: string }).sddocname ===
             datasourceFileSchema
           ) {
             const dsFields = child.fields as VespaFileSearch & {
-              fileName?: string 
-              fileSize?: number 
+              fileName?: string
+              fileSize?: number
             }
             const processedChunks = getSortedScoredChunks(
               dsFields.matchfeatures,
@@ -437,4 +437,21 @@ export const entityToSchemaMapper = (
     }
   }
   return entitySchemaMap[entityName || ""] || null
+}
+
+export const appToSchemaMapper = (appName?: string): VespaSchema | null => {
+  if (!appName) {
+    return null
+  }
+  const lowerAppName = appName.toLowerCase()
+  const schemaMap: Record<string, VespaSchema> = {
+    [Apps.Gmail.toLowerCase()]: mailSchema,
+    [Apps.GoogleDrive.toLowerCase()]: fileSchema,
+    ["googledrive"]: fileSchema, // Alias for convenience
+    [Apps.GoogleCalendar.toLowerCase()]: eventSchema,
+    ["googleCalendar"]: eventSchema, // Alias for convenience
+    [Apps.Slack.toLowerCase()]: chatMessageSchema,
+    [Apps.DataSource.toLowerCase()]: datasourceFileSchema,
+  }
+  return schemaMap[lowerAppName] || null
 }


### PR DESCRIPTION
Fix schema determination from app/entity add fall back if schema not found

### Description

<!-- Summarize the changes in this PR. -->
<!-- Explain the purpose of the change (e.g., bug fix, feature, refactor). -->
<!-- Describe how this change affects the system or users. -->

### Testing
Tested Locally

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of search results when no documents are found, providing a clearer user message.
  - Enhanced fallback behavior when search cannot determine the correct schema, ensuring more robust responses.

- **Bug Fixes**
  - More accurate schema determination for search queries, especially when only the app name is provided.

- **Chores**
  - Standardized internal handling of special cases for missing results and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->