### PR TITLE
Added Mapper in mail Schema

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -30,11 +30,12 @@ import {
   Citation,
   Apps,
   SelectPublicAgent,
+  PublicUser,
   ConnectorType,
   AuthType,
   ConnectorStatus,
   UserRole,
-} from "shared/types" // Add SelectPublicAgent
+} from "shared/types" // Add SelectPublicAgent, PublicUser
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -74,6 +75,7 @@ interface SearchResult {
   name?: string
   title?: string
   filename?: string
+  mailId?: string
   from?: string
   timestamp?: number
   updatedAt?: number
@@ -82,6 +84,7 @@ interface SearchResult {
   type?: string
   email?: string
   photoLink?: string
+  userMap?: Record<string, string>
 }
 
 interface ChatBoxProps {
@@ -106,6 +109,7 @@ interface ChatBoxProps {
   setIsReasoningActive: (
     value: boolean | ((prevState: boolean) => boolean),
   ) => void
+  user: PublicUser // Added user prop
 }
 
 const availableSources: SourceItem[] = [
@@ -226,6 +230,7 @@ export const ChatBox = ({
   agentIdFromChatData, // Destructure new prop
   isReasoningActive,
   setIsReasoningActive,
+  user, // Destructure user prop
   setIsAgenticMode,
   isAgenticMode = false,
 }: ChatBoxProps) => {
@@ -726,6 +731,7 @@ export const ChatBox = ({
         credentials: "include",
       })
       const data = await response.json()
+
       const fetchedTotalCount = data.count || 0
       setTotalCount(fetchedTotalCount)
 
@@ -997,10 +1003,12 @@ export const ChatBox = ({
       title: displayTitle,
       url: resultUrl,
       docId: result.docId,
+      mailId: result.mailId,
       app: result.app,
       entity: result.entity,
       type: "global",
       photoLink: result.photoLink,
+      userMap: result.userMap, // Ensure userMap is passed
     }
 
     const input = inputRef.current
@@ -1172,6 +1180,48 @@ export const ChatBox = ({
         }
       }
     }
+
+    // Replace data-doc-id and data-reference-id with mailId
+    const tempDiv = document.createElement("div")
+    tempDiv.innerHTML = htmlMessage
+    const pills = tempDiv.querySelectorAll("a.reference-pill")
+
+    pills.forEach((pill) => {
+      const mailId = pill.getAttribute("data-mail-id")
+      const userMap = pill.getAttribute("user-map")
+      const docId =
+        pill.getAttribute("data-doc-id") ||
+        pill.getAttribute("data-reference-id")
+      if (userMap) {
+        try {
+          const parsedUserMap = JSON.parse(userMap)
+          if (user?.email && parsedUserMap[user.email]) {
+            pill.setAttribute(
+              "href",
+              `https://mail.google.com/mail/u/0/#inbox/${parsedUserMap[user.email]}`,
+            )
+          } else {
+            console.warn(
+              `No mapping found for user email: ${user?.email} in userMap.`,
+            )
+          }
+        } catch (error) {
+          console.error("Failed to parse userMap:", error)
+        }
+      }
+
+      if (mailId) {
+        pill.setAttribute("data-doc-id", mailId)
+        pill.setAttribute("data-reference-id", mailId)
+      } else {
+        console.warn(
+          `No mailId found for pill with docId: ${docId}. Skipping replacement.`,
+        )
+      }
+    })
+
+    htmlMessage = tempDiv.innerHTML
+
     handleSend(
       htmlMessage,
       activeSourceIds.length > 0 ? activeSourceIds : undefined,

--- a/frontend/src/components/Pill.tsx
+++ b/frontend/src/components/Pill.tsx
@@ -15,7 +15,6 @@ interface PillProps {
 }
 
 export const Pill: React.FC<PillProps> = ({ newRef }) => {
-  // Renamed from ReferencePill
   const pillRef = React.useRef<HTMLAnchorElement | null>(null)
 
   React.useEffect(() => {
@@ -85,9 +84,13 @@ export const Pill: React.FC<PillProps> = ({ newRef }) => {
       className="reference-pill bg-[#F1F5F9] dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 text-[#2074FA] dark:text-blue-400 text-sm font-semibold rounded px-0.5 inline-flex items-baseline cursor-pointer no-underline self-center"
       contentEditable={false}
       data-reference-id={newRef.id}
-      {...(newRef.docId && { "data-doc-id": newRef.docId })}
-      {...(newRef.app && { "data-app": newRef.app })}
-      {...(newRef.entity && { "data-entity": newRef.entity })}
+      {...(newRef.docId ? { "data-doc-id": newRef.docId } : {})}
+      {...(newRef.mailId ? { "data-mail-id": newRef.mailId } : {})}
+      {...(newRef.app ? { "data-app": newRef.app } : {})}
+      {...(newRef.entity ? { "data-entity": newRef.entity } : {})}
+      {...(newRef.userMap
+        ? { "user-map": JSON.stringify(newRef.userMap) }
+        : {})} // Ensure userMap is serialized
       title={newRef.title}
     >
       {displayIcon}

--- a/frontend/src/routes/_authenticated/agent.tsx
+++ b/frontend/src/routes/_authenticated/agent.tsx
@@ -1416,6 +1416,7 @@ function AgentComponent() {
               <ChatBox
                 role={user?.role}
                 query={query}
+                user={user}
                 setQuery={setQuery}
                 handleSend={handleSend}
                 handleStop={handleStop}

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -874,6 +874,7 @@ export const ChatPage = ({
               agentIdFromChatData={data?.chat?.agentId ?? null} // Pass agentId from loaded chat data
               isReasoningActive={isReasoningActive}
               setIsReasoningActive={setIsReasoningActive}
+              user={user} // Pass user prop
             />
           </div>
           <Sources

--- a/frontend/src/routes/_authenticated/index.tsx
+++ b/frontend/src/routes/_authenticated/index.tsx
@@ -281,6 +281,7 @@ const Index = () => {
                 <ChatBox
                   role={user?.role}
                   query={query}
+                  user={user}
                   setQuery={setQuery}
                   handleSend={handleAsk}
                   allCitations={new Map()} // Change this line

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -55,4 +55,6 @@ export interface Reference {
   entity?: string
   type: "citation" | "global"
   photoLink?: string
+  mailId?: string
+  userMap?: Record<string, string>
 }

--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -97,6 +97,7 @@ import {
   getDocumentOrNull,
   searchVespaThroughAgent,
   searchVespaAgent,
+  GetDocument,
 } from "@/search/vespa"
 import {
   Apps,
@@ -467,6 +468,19 @@ export const ChatBookmarkApi = async (c: Context) => {
       message: "Could not bookmark chat",
     })
   }
+}
+export const replaceDocIdwithUserDocId = async (
+  docId: string,
+  email: string,
+) => {
+  const res = await GetDocument(mailSchema, docId)
+  // Check if userMap exists in fields and cast to any to access it
+
+  const userMap =
+    res.fields && "userMap" in res.fields
+      ? (res.fields as any).userMap
+      : undefined
+  return userMap[email] || docId
 }
 
 function buildContext(
@@ -2872,6 +2886,18 @@ export const MessageApi = async (c: Context) => {
               }
               if (chunk.citation) {
                 const { index, item } = chunk.citation
+                if (item && item.app == Apps.Gmail) {
+                  item.docId = await replaceDocIdwithUserDocId(
+                    item.docId,
+                    email,
+                  )
+                  if (item.url) {
+                    item.url = item.url.replace(
+                      /inbox\/[^/]+/,
+                      `inbox/${item.docId}`,
+                    )
+                  }
+                }
                 citations.push(item)
                 citationMap[index] = citations.length - 1
                 Logger.info(
@@ -3293,6 +3319,18 @@ export const MessageApi = async (c: Context) => {
                 }
                 if (chunk.citation) {
                   const { index, item } = chunk.citation
+                  if (item && item.app == Apps.Gmail) {
+                    item.docId = await replaceDocIdwithUserDocId(
+                      item.docId,
+                      email,
+                    )
+                    if (item.url) {
+                      item.url = item.url.replace(
+                        /inbox\/[^/]+/,
+                        `inbox/${item.docId}`,
+                      )
+                    }
+                  }
                   citations.push(item)
                   citationMap[index] = citations.length - 1
                   Logger.info(

--- a/server/api/search.ts
+++ b/server/api/search.ts
@@ -235,7 +235,7 @@ export const SearchApi = async (c: Context) => {
   }
 
   // TODO: deduplicate for google admin and contacts
-  const newResults = VespaSearchResponseToSearchResult(results)
+  const newResults = VespaSearchResponseToSearchResult(results,email)
   newResults.groupCount = groupCount
   return c.json(newResults)
 }

--- a/server/integrations/google/sync.ts
+++ b/server/integrations/google/sync.ts
@@ -1184,6 +1184,9 @@ const handleGmailChanges = async (
                   await insert(mailData, mailSchema)
                   stats.added += 1
                   changesExist = true
+                } else {
+                  // we are inserting with updated userMap
+                  await insert(mailData, mailSchema)
                 }
               } catch (error) {
                 // Handle errors if the message no longer exists

--- a/server/search/mappers.ts
+++ b/server/search/mappers.ts
@@ -114,6 +114,7 @@ const maxSearchChunks = 1
 
 export const VespaSearchResponseToSearchResult = (
   resp: VespaSearchResponse,
+  email?:string,
 ): SearchResponse => {
   const { root, trace } = resp
   const children = root.children || []
@@ -167,6 +168,8 @@ export const VespaSearchResponseToSearchResult = (
           ) {
             // Directly use child.fields
             const fields = child.fields as VespaMailSearch & { type?: string }
+            if(email && fields.userMap)
+            fields.docId=fields.userMap[email] || fields.docId
             fields.type = mailSchema
             fields.relevance = child.relevance
             // matchfeatures is already part of fields

--- a/server/search/types.ts
+++ b/server/search/types.ts
@@ -433,6 +433,7 @@ export const MailSchema = z.object({
   chunks: z.array(z.string()),
   timestamp: z.number(),
   app: z.nativeEnum(Apps),
+  userMap: z.record(z.string()),
   entity: z.nativeEnum(MailEntity),
   permissions: z.array(z.string()),
   from: z.string(),
@@ -1022,6 +1023,8 @@ export const MailResponseSchema = VespaMailGetSchema.pick({
   from: true,
   relevance: true,
   timestamp: true,
+  userMap: true,
+  mailId: true,
 })
   .strip()
   .extend({

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -16,6 +16,7 @@ import {
   type VespaDataSource,
   type VespaDataSourceFile,
   type VespaDataSourceSearch,
+  SlackEntity,
 } from "@/search/types"
 import type {
   VespaAutocompleteResponse,
@@ -1112,7 +1113,8 @@ export const searchVespa = async (
   }
   span?.setAttribute("vespaPayload", JSON.stringify(hybridDefaultPayload))
   try {
-    return await vespa.search<VespaSearchResponse>(hybridDefaultPayload)
+    let result = await vespa.search<VespaSearchResponse>(hybridDefaultPayload)
+    return result
   } catch (error) {
     throw new ErrorPerformingSearch({
       cause: error as Error,
@@ -1419,7 +1421,17 @@ export const ifDocumentsExist = async (
 
 export const ifMailDocumentsExist = async (
   mailIds: string[],
-): Promise<Record<string, { exists: boolean; updatedAt: number | null }>> => {
+): Promise<
+  Record<
+    string,
+    {
+      docId: string
+      exists: boolean
+      updatedAt: number | null
+      userMap: Record<string, string>
+    }
+  >
+> => {
   try {
     return await vespa.ifMailDocumentsExist(mailIds)
   } catch (error) {
@@ -1770,8 +1782,8 @@ export const getItems = async (
   }
 
   try {
-    // Assuming vespa.getItems maps to a generic search in the client
-    return await vespa.search<VespaSearchResponse>(searchPayload)
+    let result = await vespa.getItems(searchPayload)
+    return result
   } catch (error) {
     const searchError = new ErrorPerformingSearch({
       cause: error as Error,

--- a/server/vespa/schemas/mail.sd
+++ b/server/vespa/schemas/mail.sd
@@ -15,6 +15,13 @@ schema mail {
       indexing: attribute | summary
       attribute: fast-search
     }
+  # This will map the useremail with the docId, which is required for the Url construction
+  # every users has different docId for the same mail
+    field userMap type map<string,string>{
+      indexing: summary
+      struct-field key   { indexing: attribute }
+      struct-field value { indexing: attribute }
+    }
 
     field subject type string {
       indexing: summary | index


### PR DESCRIPTION


### Description

Earlier Using messageId for Vespa existence checks broke mail redirects since docId is unique per user and required for mail construction.So we loss the docId of users.
Solution: Added Mapper in mail schema to map user email with docId. Now citations use original docId and pills update links using userMap.

### Testing



### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
