### PR TITLE
fix(search): make userMap optional

### DIFF
--- a/server/search/types.ts
+++ b/server/search/types.ts
@@ -433,7 +433,7 @@ export const MailSchema = z.object({
   chunks: z.array(z.string()),
   timestamp: z.number(),
   app: z.nativeEnum(Apps),
-  userMap: z.record(z.string()),
+  userMap: z.optional(z.record(z.string())),
   entity: z.nativeEnum(MailEntity),
   permissions: z.array(z.string()),
   from: z.string(),


### PR DESCRIPTION
### Description
Until we migrate to the new data, for older ingested gmail data user map has to be optional to prevent zod error during search.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved flexibility when handling mail data by making the user mapping field optional, preventing errors if the field is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->