### PR TITLE
feat(dx): Add husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -u
+
+# Function to check formatting and then format if necessary
+check_and_format() {
+    # Temporarily disable exit on error
+    set +e
+    cd server
+    bunx @biomejs/biome check ../ --formatter-enabled=true --linter-enabled=false --vcs-use-ignore-file=true --organize-imports-enabled=false
+    CHECK_STATUS=$?
+    # set -e
+    if [ $CHECK_STATUS -ne 0 ]; then
+        echo "Formatting issues detected. Running formatter..."
+
+        # Format all applicable files, not just staged ones
+        bun run format
+        
+        echo "Files have been formatted. Please add them to staging and commit again."
+        exit 1
+    fi
+}
+
+# Run the check and format function
+check_and_format

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,8 @@
       "./migrations",
       "./server/eval-results",
       "./server/eval-data",
-      "./server/tuning-data"
+      "./server/tuning-data",
+      "./deployment/grafana"
     ]
   },
   "formatter": {

--- a/server/package.json
+++ b/server/package.json
@@ -4,11 +4,12 @@
   "type": "module",
   "version": "0.3.0",
   "devDependencies": {
-    "@faker-js/faker": "^9.3.0",
     "@biomejs/biome": "1.9.4",
+    "@faker-js/faker": "^9.3.0",
     "@types/bun": "latest",
     "@types/uuid": "^10.0.0",
     "drizzle-kit": "^0.24.2",
+    "husky": "^9.1.7",
     "p-queue": "^8.0.1"
   },
   "peerDependencies": {
@@ -21,7 +22,8 @@
     "build": "bunx --bun vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "format": "bunx biome format --write ../"
+    "format": "bunx biome format --write ../",
+    "prepare": "cd .. && husky .husky"
   },
   "dependencies": {
     "@aws-sdk/client-bedrock": "^3.797.0",


### PR DESCRIPTION
### Description

Adds a Husky pre-commit hook to enforce code formatting. While committing if unformatted code is detected, the commit fails, formatting is applied automatically, and the the updated files must be restaged and recommitted.

### Testing

Tested locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a pre-commit hook to automatically check and fix code formatting before commits.
  - Introduced Husky as a development dependency to manage git hooks.
  - Updated project scripts to support Husky integration.
  - Expanded formatting tool ignore list to exclude a new deployment directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->