### PR TITLE
fix: User Vespa Data Deletion 

### DIFF
--- a/frontend/src/routes/_authenticated/admin/integrations/google.tsx
+++ b/frontend/src/routes/_authenticated/admin/integrations/google.tsx
@@ -1225,6 +1225,7 @@ type DeleteUserDataFormValues = {
   endDate?: string
   // servicesToClear?: string // Will be replaced by individual booleans
   deleteOnlyIfSoleOwnerInPermissions?: boolean
+  deleteSyncJob?: boolean // Add new field for deleteSyncJob
   // New boolean fields for services
   clearDrive?: boolean
   clearGmail?: boolean
@@ -1254,6 +1255,9 @@ const submitDeleteUserDataForm = async (
       ...(value.deleteOnlyIfSoleOwnerInPermissions !== undefined && {
         deleteOnlyIfSoleOwnerInPermissions:
           value.deleteOnlyIfSoleOwnerInPermissions,
+      }),
+      ...(value.deleteSyncJob !== undefined && {
+        deleteSyncJob: value.deleteSyncJob,
       }),
     },
   }
@@ -1289,6 +1293,7 @@ const DeleteUserDataForm = ({
       endDate: "",
       // servicesToClear: "drive,gmail,calendar", // Removed
       deleteOnlyIfSoleOwnerInPermissions: true,
+      deleteSyncJob: true, // Default to true
       clearDrive: true, // Default to true
       clearGmail: true, // Default to true
       clearCalendar: true, // Default to true
@@ -1492,8 +1497,24 @@ const DeleteUserDataForm = ({
           )}
         />
         <Label htmlFor="delete-sole-owner">
-          Delete only if sole owner in permissions (default: true)
+          Delete only if sole owner in permissions
         </Label>
+      </div>
+
+      <div className="flex items-center space-x-2 mt-4">
+        <form.Field
+          name="deleteSyncJob"
+          children={(field) => (
+            <input
+              type="checkbox"
+              id="delete-sync-job"
+              checked={field.state.value ?? true}
+              onChange={(e) => field.handleChange(e.target.checked)}
+              className="h-4 w-4"
+            />
+          )}
+        />
+        <Label htmlFor="delete-sync-job">Delete Sync Job</Label>
       </div>
 
       <Button type="submit" disabled={form.state.isSubmitting} className="mt-4">

--- a/server/api/admin.ts
+++ b/server/api/admin.ts
@@ -757,10 +757,11 @@ export const AdminDeleteUserData = async (c: Context) => {
     const appsToDelete = options?.servicesToClear
     const deleteSyncJob = options?.deleteSyncJob
     if (deleteSyncJob) {
+      try{
       const deleteSyncJobResult = await clearUserSyncJob(
         db,
         emailToClear,
-        appsToDelete,
+        appsToDelete || [],
       )
       loggerWithChild({ email: sub }).info(
         {
@@ -768,8 +769,19 @@ export const AdminDeleteUserData = async (c: Context) => {
           targetEmail: emailToClear,
           results: deleteSyncJobResult,
         },
-        "User SyncJob deletion process completed.",
+        "SyncJob deletion process completed.",
       )
+    }
+    catch(error){
+      loggerWithChild({ email: sub }).error(
+        {
+          adminEmail: sub,
+          targetEmail: emailToClear,
+          results: error,
+        },
+        "Failed to delete user sync jobs.",
+      )
+    }
     }
     return c.json({
       success: true,

--- a/server/db/syncJob.ts
+++ b/server/db/syncJob.ts
@@ -89,7 +89,7 @@ export const updateSyncJob = async (
 export const clearUserSyncJob = async (
   trx: TxnOrClient,
   userEmail: string,
-  appsToDelete: string[] | any,
+  appsToDelete: string[],
 ) => {
   // Convert app names to their corresponding Apps enum values
   appsToDelete = appsToDelete.map(
@@ -111,6 +111,8 @@ export const clearUserSyncJob = async (
       )
     return `Successfully Deleted ${userEmail} ${appsToDelete.join(" ,")} syncJobs`
   } catch (error) {
-    return `Failed to Deleted ${userEmail} ${appsToDelete.join(" ,")} syncJobs`
+    throw new Error(
+      `Failed to delete sync jobs for ${userEmail} ${appsToDelete.join(" , ")} syncJobs: ${error}`,
+    )
   }
 }

--- a/server/integrations/dataDeletion.ts
+++ b/server/integrations/dataDeletion.ts
@@ -70,7 +70,9 @@ async function processPermissionUpdatesAndDeleteIfSoleOwner(
     const searchPayload = {
       yql: permissionQueryWithDateFilter,
       hits: BATCH_SIZE,
-      offset: offset,
+      // offset: offset,
+      // due to this we were missing documents in next search
+      // previous docs won't be there in next search as permission is updated
       timeout: "10s",
       "ranking.profile": "unranked",
     }
@@ -258,7 +260,9 @@ async function processDirectDeletesWithDateFilter(
       const searchPayload = {
         yql: directDeleteQueryWithDateFilter,
         hits: BATCH_SIZE,
-        offset: offset,
+        // offset: offset,
+        // due to this we were missing documents in next search
+        // previous docs won't be there in next search as permission is updated
         timeout: "10s",
         "ranking.profile": "unranked",
       }

--- a/server/types.ts
+++ b/server/types.ts
@@ -165,6 +165,7 @@ export const deleteUserDataSchema = z.object({
         .optional(),
       servicesToClear: z.array(z.string()).optional(), // e.g., ["drive", "gmail", "calendar"]
       deleteOnlyIfSoleOwnerInPermissions: z.boolean().optional(),
+      deleteSyncJob: z.boolean().optional().default(false),
     })
     .optional(),
 })


### PR DESCRIPTION
### Description

Earlier: we maintained the offset , and in each search we fetch the result after that offset
But in next search we won't have the past results because permission is updated,
so we don't need offset to do that,
Also added the option for admin and superAdmin to delete the syncJob of user along with vespa-data deletion

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option in the user data deletion form to also delete the associated sync job, with the checkbox enabled by default.
- **Improvements**
  - Updated the label for the existing permissions-related checkbox for clarity.
  - Enhanced backend handling to support deletion of sync jobs when requested.
- **Bug Fixes**
  - Improved data deletion reliability by adjusting search logic to prevent missing documents during batch processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->