### PR TITLE
fix(reasoning): Fix incorrect citations in reasoning

### DIFF
--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -3068,7 +3068,7 @@ export const MessageApi = async (c: Context) => {
                 email: user.email,
                 sources: citations,
                 message: processMessage(answer, citationMap, email),
-                thinking: processMessage(thinking, citationMap, email), // process it for consistency citations
+                thinking: processMessage(thinking, citationMap, email),
                 modelId:
                   ragPipelineConfig[RagPipelineStages.AnswerOrRewrite].modelId,
               })
@@ -3548,7 +3548,7 @@ export const MessageApi = async (c: Context) => {
                 email: user.email,
                 sources: citations,
                 message: processMessage(answer, citationMap, email),
-                thinking: processMessage(thinking, citationMap, email), // process it for consistency citations
+                thinking: processMessage(thinking, citationMap, email),
                 modelId:
                   ragPipelineConfig[RagPipelineStages.AnswerOrRewrite].modelId,
               })


### PR DESCRIPTION
### Description
- Fixed an issue where citations in the reasoning section displayed incorrect indices.
- Root cause: only the message content was being processed and stored in the DB, not the reasoning.
- Now, reasoning content is also processed before storing, resolving the inconsistency.

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in citation formatting for assistant messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->