### PR TITLE
fix(mcp): Handle tool response parsing errors

### DIFF
--- a/server/api/chat/agents.ts
+++ b/server/api/chat/agents.ts
@@ -1035,16 +1035,23 @@ export const MessageWithToolsApi = async (c: Context) => {
 
                     let formattedContent = "Tool returned no parsable content."
                     let newFragments: MinimalAgentFragment[] = []
-
+                    const isValidJSON = (str: string) => {
+                      try {
+                        JSON.parse(str);
+                        return true;
+                      } catch (e) {
+                        return false;
+                      }
+                    }
                     try {
                       if (
                         mcpToolResponse.content &&
                         mcpToolResponse.content[0] &&
                         mcpToolResponse.content[0].text
                       ) {
-                        const parsedJson = JSON.parse(
+                        const parsedJson = isValidJSON(mcpToolResponse.content[0].text) ? JSON.parse(
                           mcpToolResponse.content[0].text,
-                        )
+                        ) :  mcpToolResponse.content[0].text
                         if (isCustomMCP) {
                           const baseFragmentId = `mcp-${connectorId}-${toolName}`
                           // Convert the formatted response into a standard MinimalAgentFragment

--- a/server/api/chat/agents.ts
+++ b/server/api/chat/agents.ts
@@ -1070,11 +1070,11 @@ export const MessageWithToolsApi = async (c: Context) => {
                           if (mainContentParts.length > 2) {
                             formattedContent = mainContentParts.join("\n")
                           } else {
-                            formattedContent = `Tool Response: ${flattenObject(
+                            formattedContent = `Tool Response: ${typeof parsedJson !== "string" ? flattenObject(
                               parsedJson,
                             )
                               .map(([key, value]) => `- ${key}: ${value}`)
-                              .join("\n")}`
+                              .join("\n") : parsedJson}`
                           }
 
                           newFragments.push({


### PR DESCRIPTION
### Description
- Fixes an issue where DeepWiki tools were failing due to unhandled parsing errors in tool responses.
- Now checks if the response is parsable before attempting to parse it.
- If the response is not parsable, it is left as-is to prevent crashes or failed executions.

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of external tool responses to prevent errors from invalid JSON, ensuring smoother and more reliable chat interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->