### PR TITLE
fix(reasoning-scroll-ui): auto-scrolling stops when there is human intervention

### DIFF
--- a/frontend/src/components/EnhancedReasoning.tsx
+++ b/frontend/src/components/EnhancedReasoning.tsx
@@ -446,31 +446,60 @@ export const EnhancedReasoning: React.FC<EnhancedReasoningProps> = ({
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [steps, setSteps] = useState<ReasoningStep[]>([])
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const [userHasScrolled, setUserHasScrolled] = useState(false)
 
   useEffect(() => {
     const parsedSteps = parseReasoningContent(content)
     setSteps(parsedSteps)
   }, [content])
 
+  // Check if user is at the bottom of the scroll container
+  const isScrolledToBottom = () => {
+    const container = scrollContainerRef.current
+    if (!container) return true
+
+    const threshold = 10 // pixels from bottom to consider "at bottom"
+    return (
+      container.scrollHeight - container.scrollTop - container.clientHeight <
+      threshold
+    )
+  }
+
+  // Handle manual scrolling by user
+  const handleScroll = () => {
+    const isAtBottom = isScrolledToBottom()
+    setUserHasScrolled(!isAtBottom)
+  }
+
+  // Reset user scroll state when streaming starts
+  useEffect(() => {
+    if (isStreaming) {
+      setUserHasScrolled(false)
+    }
+  }, [isStreaming])
+
   // Auto-scroll to bottom when new content arrives during streaming
   useEffect(() => {
     if (
       isStreaming &&
       !isCollapsed &&
+      !userHasScrolled &&
       scrollContainerRef.current &&
       steps.length > 0
     ) {
       const container = scrollContainerRef.current
       // Use setTimeout to ensure DOM has updated before scrolling
       setTimeout(() => {
-        // Scroll to the bottom smoothly
-        container.scrollTo({
-          top: container.scrollHeight,
-          behavior: "smooth",
-        })
+        // Only scroll if user hasn't manually scrolled
+        if (!userHasScrolled) {
+          container.scrollTo({
+            top: container.scrollHeight,
+            behavior: "smooth",
+          })
+        }
       }, 10)
     }
-  }, [steps, isStreaming, isCollapsed])
+  }, [steps, isStreaming, isCollapsed, userHasScrolled])
 
   if (!content.trim() && !isStreaming) {
     return null
@@ -501,6 +530,7 @@ export const EnhancedReasoning: React.FC<EnhancedReasoningProps> = ({
         <div className="w-full min-w-full max-w-none pl-3 mt-2">
           <div
             ref={scrollContainerRef}
+            onScroll={handleScroll}
             className="space-y-1 max-h-80 overflow-y-auto w-full min-w-full"
           >
             {steps.length > 0 ? (


### PR DESCRIPTION

### Description

auto-scrolling stops when there is human intervention

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scrolling behavior in the Enhanced Reasoning view to prevent automatic scrolling when users manually scroll away from the bottom during streaming updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->