### PR TITLE
Add ParentThreadId in Mail Schema

### DIFF
--- a/server/integrations/google/gmail/index.ts
+++ b/server/integrations/google/gmail/index.ts
@@ -261,8 +261,23 @@ export const parseMail = async (
   const cc = extractEmailAddresses(getHeader("Cc") ?? "")
   const bcc = extractEmailAddresses(getHeader("Bcc") ?? "")
   const subject = getHeader("Subject") || ""
+  const Reference = getHeader("References") || ""
+  const inReplyTo = getHeader("In-Reply-To") || ""
+  let firstReferenceId = ""
+  if (Reference) {
+    const match = Reference.match(/<([^>]+)>/)
+    if (match && match[1]) {
+      firstReferenceId = match[1]
+    }
+  }
   const mailId =
     getHeader("Message-Id")?.replace(/^<|>$/g, "") || messageId || undefined
+  let parentThreadId = mailId
+  if (Reference && firstReferenceId) {
+    parentThreadId = firstReferenceId
+  } else if (inReplyTo) {
+    parentThreadId = inReplyTo.replace(/^<|>$/g, "")
+  }
   let docId = messageId
   let userMap: Record<string, string> = {}
   let mailExist = false
@@ -472,6 +487,7 @@ export const parseMail = async (
     mailId: mailId,
     subject: subject,
     chunks: chunks,
+    parentThreadId: parentThreadId,
     timestamp: timestamp,
     app: Apps.Gmail,
     userMap: userMap,

--- a/server/search/types.ts
+++ b/server/search/types.ts
@@ -445,6 +445,7 @@ export const MailSchema = z.object({
   mailId: z.string().optional(), // Optional for threads
   subject: z.string().default(""), // Default to empty string to avoid zod errors when subject is missing
   chunks: z.array(z.string()),
+  parentThreadId: z.string().optional(),
   timestamp: z.number(),
   app: z.nativeEnum(Apps),
   userMap: z.optional(z.record(z.string())),

--- a/server/vespa/schemas/mail.sd
+++ b/server/vespa/schemas/mail.sd
@@ -6,6 +6,10 @@ schema mail {
       indexing: attribute | summary
       attribute: fast-search
     }
+    field parentThreadId type string {
+      indexing: attribute | summary
+      attribute: fast-search
+    }
 
     field threadId type string {
       indexing: attribute | summary


### PR DESCRIPTION


### Description

Previously, we only stored the threadId for each email, but threadId will be different for different users , so using threadId we can't can fetch all the replies of mail.
To Solve this 
Added a new field, parentThreadId, to the mail schema. The parentThreadId is set to the value of the parent mail’s Message-Id, extracted from the References or In-Reply-To headers. Now parentThreadId we can easily get all the replies of a mail.

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
