### PR TITLE
feat(chats): Stream images in LLM response

### DIFF
--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect, useCallback } from "react"
 import { useQueryClient } from "@tanstack/react-query"
 import { useRouter } from "@tanstack/react-router"
 import { api } from "@/api"
-import { ChatSSEvents, Citation } from "shared/types"
+import { ChatSSEvents, Citation, ImageCitation } from "shared/types"
 import { toast } from "@/hooks/use-toast"
 import { ToolsListItem } from "@/types"
 
@@ -12,6 +12,7 @@ interface StreamState {
   partial: string
   thinking: string
   sources: Citation[]
+  imageCitations: ImageCitation[]
   citationMap: Record<number, number>
   messageId?: string
   chatId?: string
@@ -24,6 +25,7 @@ interface StreamInfo {
   partial: string
   thinking: string
   sources: Citation[]
+  imageCitations: ImageCitation[]
   citationMap: Record<number, number>
   messageId?: string
   chatId?: string
@@ -238,6 +240,7 @@ export const startStream = async (
     partial: "",
     thinking: "",
     sources: [],
+    imageCitations: [],
     citationMap: {},
     messageId: undefined,
     chatId: chatId || undefined,
@@ -262,6 +265,20 @@ export const startStream = async (
     const { contextChunks, citationMap } = JSON.parse(event.data)
     streamState.sources = contextChunks
     streamState.citationMap = citationMap
+    notifySubscribers(streamKey)
+  })
+
+  streamState.es.addEventListener(ChatSSEvents.ImageCitationUpdate, (event) => {
+    const imageCitation: ImageCitation = JSON.parse(event.data)
+    // Check if this citation key already exists to avoid duplicates
+    const existingIndex = streamState.imageCitations.findIndex(
+      (ic) => ic.citationKey === imageCitation.citationKey,
+    )
+    if (existingIndex >= 0) {
+      streamState.imageCitations[existingIndex] = imageCitation
+    } else {
+      streamState.imageCitations.push(imageCitation)
+    }
     notifySubscribers(streamKey)
   })
 
@@ -404,6 +421,7 @@ export const getStreamState = (streamKey: string): StreamInfo => {
       partial: "",
       thinking: "",
       sources: [],
+      imageCitations: [],
       citationMap: {},
       messageId: undefined,
       chatId: undefined,
@@ -415,6 +433,7 @@ export const getStreamState = (streamKey: string): StreamInfo => {
     partial: stream.partial,
     thinking: stream.thinking,
     sources: stream.sources,
+    imageCitations: stream.imageCitations,
     citationMap: stream.citationMap,
     messageId: stream.messageId,
     chatId: stream.chatId,
@@ -664,6 +683,7 @@ export const useChatStream = (
         partial: "",
         thinking: "",
         sources: [],
+        imageCitations: [],
         citationMap: {},
         messageId: undefined,
         chatId: chatId || undefined,
@@ -743,6 +763,23 @@ export const useChatStream = (
         streamState.sources = contextChunks
         streamState.citationMap = citationMap
       })
+
+      eventSource.addEventListener(
+        ChatSSEvents.ImageCitationUpdate,
+        (event) => {
+          const imageCitation: ImageCitation = JSON.parse(event.data)
+          console.log("Processing retry image citation", imageCitation)
+          // Check if this citation key already exists to avoid duplicates
+          const existingIndex = streamState.imageCitations.findIndex(
+            (ic) => ic.citationKey === imageCitation.citationKey,
+          )
+          if (existingIndex >= 0) {
+            streamState.imageCitations[existingIndex] = imageCitation
+          } else {
+            streamState.imageCitations.push(imageCitation)
+          }
+        },
+      )
 
       eventSource.addEventListener(ChatSSEvents.ResponseMetadata, (event) => {
         const { messageId: newMessageId } = JSON.parse(event.data)

--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -270,15 +270,7 @@ export const startStream = async (
 
   streamState.es.addEventListener(ChatSSEvents.ImageCitationUpdate, (event) => {
     const imageCitation: ImageCitation = JSON.parse(event.data)
-    // Check if this citation key already exists to avoid duplicates
-    const existingIndex = streamState.imageCitations.findIndex(
-      (ic) => ic.citationKey === imageCitation.citationKey,
-    )
-    if (existingIndex >= 0) {
-      streamState.imageCitations[existingIndex] = imageCitation
-    } else {
-      streamState.imageCitations.push(imageCitation)
-    }
+    streamState.imageCitations = imageCitation
     notifySubscribers(streamKey)
   })
 
@@ -768,16 +760,7 @@ export const useChatStream = (
         ChatSSEvents.ImageCitationUpdate,
         (event) => {
           const imageCitation: ImageCitation = JSON.parse(event.data)
-          console.log("Processing retry image citation", imageCitation)
-          // Check if this citation key already exists to avoid duplicates
-          const existingIndex = streamState.imageCitations.findIndex(
-            (ic) => ic.citationKey === imageCitation.citationKey,
-          )
-          if (existingIndex >= 0) {
-            streamState.imageCitations[existingIndex] = imageCitation
-          } else {
-            streamState.imageCitations.push(imageCitation)
-          }
+          streamState.imageCitations = imageCitation
         },
       )
 

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -1400,7 +1400,6 @@ const Sources = ({
   ) : null
 }
 
-// Image Citation Component
 interface ImageCitationComponentProps {
   citationKey: string
   imageCitations: ImageCitation[]
@@ -1423,6 +1422,7 @@ const ImageCitationComponent: React.FC<ImageCitationComponentProps> = ({
     )
   }
 
+  // TODO: Fetch image data from API instead of using base64
   const imageSrc = `data:${imageCitation.mimeType};base64,${imageCitation.imageData}`
 
   const ImageModal = () => {
@@ -1430,7 +1430,6 @@ const ImageCitationComponent: React.FC<ImageCitationComponentProps> = ({
       setIsModalOpen(false)
     }
 
-    // Handle escape key
     useEffect(() => {
       const handleKeyDown = (e: KeyboardEvent) => {
         if (e.key === "Escape") {
@@ -2073,7 +2072,6 @@ export const ChatMessage = ({
     text = splitGroupedCitationsWithSpaces(text)
 
     text = text.replace(textToImageCitationIndex, (match, citationKey) => {
-      console.log("Found image citation:", match, "key:", citationKey)
       return `![image-citation:${citationKey}](image-citation:${citationKey})`
     })
 

--- a/server/ai/provider/bedrock.ts
+++ b/server/ai/provider/bedrock.ts
@@ -174,7 +174,6 @@ export class BedrockProvider extends BaseProvider {
         )
         const userText = textBlocks.map((tb) => tb.text).join("\n")
 
-        // Create new content array with labeled images
         const newContent = createLabeledImageContent(
           userText,
           otherBlocks,
@@ -289,7 +288,6 @@ export class BedrockProvider extends BaseProvider {
         )
         const userText = textBlocks.map((tb) => tb.text).join("\n")
 
-        // Create new content array with labeled images
         const newContent = createLabeledImageContent(
           userText,
           otherBlocks,

--- a/server/ai/provider/bedrock.ts
+++ b/server/ai/provider/bedrock.ts
@@ -19,6 +19,39 @@ const Logger = getLogger(Subsystem.AI)
 import config from "@/config"
 const { StartThinkingToken, EndThinkingToken } = config
 import { findImageByName } from "@/ai/provider/base"
+const createLabeledImageContent = (
+  userText: string,
+  otherBlocks: ContentBlock[],
+  imageParts: ContentBlock[],
+  imageFileNames: string[],
+): ContentBlock[] => {
+  const newContent: ContentBlock[] = [
+    {
+      text:
+        "You may receive image(s) as part of the conversation. If images are attached, treat them as essential context for the user's question. When referring to images in your response, please use the labels provided [docIndex_imageNumber] (e.g., [0_12], [7_2], etc.).\n\n" +
+        userText,
+    },
+    ...otherBlocks,
+  ]
+
+  imageParts.forEach((imagePart, index) => {
+    const imageFileName = imageFileNames[index]
+    // format: docIndex_docId_imageNumber
+    const match = imageFileName.match(/^([0-9]+)_(.+)_([0-9]+)$/)
+    if (match) {
+      const docIndex = match[1]
+      const docId = match[2]
+      const imageNum = match[3]
+
+      newContent.push({
+        text: `\n--- imageNumber: ${imageNum}, docIndex: ${docIndex}) ---`,
+      })
+    }
+    newContent.push(imagePart)
+  })
+
+  return newContent
+}
 
 // Helper function to convert images to Bedrock format
 const buildBedrockImageParts = async (
@@ -29,22 +62,26 @@ const buildBedrockImageParts = async (
   )
 
   const imagePromises = imagePaths.map(async (imgPath) => {
-    // Check if the file already has an extension, if not add .png
-    const match = imgPath.match(/^(.+)_([0-9]+)$/)
+    //  format: docIndex_docId_imageNumber
+    const match = imgPath.match(/^([0-9]+)_(.+)_([0-9]+)$/)
     if (!match) {
-      Logger.error(`Invalid image path: ${imgPath}`)
+      Logger.error(
+        `Invalid image path format: ${imgPath}. Expected format: docIndex_docId_imageNumber`,
+      )
       throw new Error(`Invalid image path: ${imgPath}`)
     }
 
-    // Validate that the docId doesn't contain path traversal characters
-    const docId = match[1]
+    const docIndex = match[1]
+    const docId = match[2]
+    const imageNumber = match[3]
+
     if (docId.includes("..") || docId.includes("/") || docId.includes("\\")) {
       Logger.error(`Invalid docId containing path traversal: ${docId}`)
       throw new Error(`Invalid docId: ${docId}`)
     }
 
     const imageDir = path.join(baseDir, docId)
-    const absolutePath = findImageByName(imageDir, match[2])
+    const absolutePath = findImageByName(imageDir, imageNumber)
     const extension = path.extname(absolutePath).toLowerCase()
 
     // Map file extensions to Bedrock format values
@@ -136,15 +173,14 @@ export class BedrockProvider extends BaseProvider {
           (c) => !(typeof c === "object" && "text" in c),
         )
         const userText = textBlocks.map((tb) => tb.text).join("\n")
-        const combinedText =
-          "You may receive image(s) as part of the conversation. If images are attached, treat them as essential context for the user's question.\n\n" +
-          userText
-        // Create new content array with combined text and images
-        const newContent = [
-          { text: combinedText },
-          ...otherBlocks,
-          ...imageParts,
-        ]
+
+        // Create new content array with labeled images
+        const newContent = createLabeledImageContent(
+          userText,
+          otherBlocks,
+          imageParts,
+          params.imageFileNames!,
+        )
         return {
           ...message,
           content: newContent,
@@ -159,7 +195,7 @@ export class BedrockProvider extends BaseProvider {
           text:
             modelParams.systemPrompt! +
             "\n\n" +
-            "Important: In case you don't have the context, you can use the images in the context to answer questions.",
+            "Important: In case you don't have the context, you can use the images in the context to answer questions. When referring to specific images in your response, please use the image labels provided to help users understand which image you're referencing.",
         },
       ],
       messages: transformedMessages,
@@ -252,15 +288,14 @@ export class BedrockProvider extends BaseProvider {
           (c) => !(typeof c === "object" && "text" in c),
         )
         const userText = textBlocks.map((tb) => tb.text).join("\n")
-        const combinedText =
-          "You may receive image(s) as part of the conversation. If images are attached, treat them as essential context for the user's question.\n\n" +
-          userText
-        // Create new content array with combined text and images
-        const newContent = [
-          { text: combinedText },
-          ...otherBlocks,
-          ...imageParts,
-        ]
+
+        // Create new content array with labeled images
+        const newContent = createLabeledImageContent(
+          userText,
+          otherBlocks,
+          imageParts,
+          params.imageFileNames!,
+        )
         return {
           ...message,
           content: newContent,
@@ -268,10 +303,6 @@ export class BedrockProvider extends BaseProvider {
       }
       return message
     })
-
-    console.log("transformedMessages", transformedMessages)
-    console.log("imageFileNames", params.imageFileNames)
-    console.log("modelId", modelParams.modelId)
 
     const command = new ConverseStreamCommand({
       modelId: modelParams.modelId,
@@ -281,7 +312,7 @@ export class BedrockProvider extends BaseProvider {
           text:
             modelParams.systemPrompt! +
             "\n\n" +
-            "Important: In case you don't have the context, you can use the images in the context to answer questions.",
+            "Important: In case you don't have the context, you can use the images in the context to answer questions. When referring to specific images in your response, please use the image labels provided to help users understand which image you're referencing.",
         },
       ],
       messages: transformedMessages,

--- a/server/api/chat/types.ts
+++ b/server/api/chat/types.ts
@@ -86,6 +86,7 @@ export interface MinimalAgentFragment {
   content: string
   source: Citation
   confidence: number
+  imageFileNames?: string[]
 }
 
 export const messageFeedbackSchema = z.object({

--- a/server/api/chat/types.ts
+++ b/server/api/chat/types.ts
@@ -73,6 +73,14 @@ export const MinimalCitationSchema = z.object({
 
 export type Citation = z.infer<typeof MinimalCitationSchema>
 
+export interface ImageCitation {
+  citationKey: string
+  imagePath: string
+  imageData: string
+  mimeType: string
+  item: Citation
+}
+
 export interface MinimalAgentFragment {
   id: string // Unique ID for the fragment
   content: string

--- a/server/api/chat/types.ts
+++ b/server/api/chat/types.ts
@@ -77,8 +77,8 @@ export interface ImageCitation {
   citationKey: string
   imagePath: string
   imageData: string
-  mimeType: string
   item: Citation
+  mimeType?: string
 }
 
 export interface MinimalAgentFragment {

--- a/server/api/chat/utils.ts
+++ b/server/api/chat/utils.ts
@@ -222,7 +222,7 @@ export const extractImageFileNames = (
     if (imageContent) {
       const docId = imageContent.split("_")[0]
       const docIndex =
-        results?.findIndex((c) => (c.fields as any).docId === docId) || 0
+        results?.findIndex((c) => (c.fields as any).docId === docId) || -1
 
       if (docIndex === -1) {
         console.warn(

--- a/server/db/schema/messages.ts
+++ b/server/db/schema/messages.ts
@@ -48,6 +48,9 @@ export const messages = pgTable(
     modelId: text("modelId").notNull(),
     email: text("email").notNull(),
     sources: jsonb("sources").notNull().default(sql`'[]'::jsonb`),
+    imageCitations: jsonb("image_citations")
+      .notNull()
+      .default(sql`'[]' ::jsonb`),
     fileIds: jsonb("fileIds").notNull().default(sql`'[]'::jsonb`),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()

--- a/server/docxChunks.ts
+++ b/server/docxChunks.ts
@@ -911,7 +911,9 @@ export async function extractTextAndImagesWithChunksFromDocx(
 
               const imageExtension = path.extname(imagePath).toLowerCase()
               if (
-                !DATASOURCE_CONFIG.SUPPORTED_IMAGE_TYPES.has(imageExtension)
+                !DATASOURCE_CONFIG.SUPPORTED_IMAGE_TYPES.has(
+                  `image/${imageExtension.slice(1)}`,
+                )
               ) {
                 Logger.warn(
                   `Unsupported image format: ${imageExtension}. Skipping image: ${imagePath}`,

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -55,7 +55,7 @@ import { z } from "zod"
 // @ts-ignore
 export type { MessageReqType } from "@/api/search"
 // @ts-ignore
-export type { Citation } from "@/api/chat"
+export type { Citation, ImageCitation } from "@/api/chat"
 export type {
   SelectPublicMessage,
   PublicUser,
@@ -341,6 +341,7 @@ export enum ChatSSEvents {
   End = "e",
   ChatTitleUpdate = "ct",
   CitationsUpdate = "cu",
+  ImageCitationUpdate = "icu",
   Reasoning = "rz",
   Error = "er",
 }


### PR DESCRIPTION
### Description
- If LLM makes up answer from an image, show the image in chats

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for image citations in chat messages, enabling inline display and interactive zoom of referenced images within chat responses.
  * Image citations are streamed and rendered alongside text citations during chat interactions.
  * Users can view and interact with images associated with citations directly in the chat interface.

* **Bug Fixes**
  * Improved error handling and logging for image citation processing and retrieval.

* **Chores**
  * Database schema updated to store image citations with chat messages for consistent history and retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->