### PR TITLE
fix(slack): fixing the private channel invocation issue

### DIFF
--- a/server/integrations/slack/client.ts
+++ b/server/integrations/slack/client.ts
@@ -1126,7 +1126,14 @@ export const processSlackEvent = async (event: any) => {
     const { user, text, channel, ts, thread_ts } = event;
 
     try {
-      await webClient.conversations.join({ channel });
+      try {
+        const channelInfo = await webClient.conversations.info({ channel });
+        if (channelInfo.ok && channelInfo.channel?.is_channel && !channelInfo.channel?.is_private) {
+          await webClient.conversations.join({ channel });
+        }
+      } catch (joinError: any) {
+        Logger.debug(`Could not join channel ${channel}: ${joinError.message}`);
+      }
 
       if (!user) {
         Logger.warn("No user ID found in app_mention event");

--- a/server/integrations/slack/config.ts
+++ b/server/integrations/slack/config.ts
@@ -18,6 +18,10 @@ export const MAX_CITATIONS_IN_MODAL = 2
 export const MAX_CITATIONS_IN_SHARED = 5
 export const MAX_SOURCES_IN_MODAL = 20
 
+export const FRONTEND_BASE_URL = process.env.NODE_ENV === "production"
+  ? process.env.HOST || "https://xyne.juspay.net"
+  : "http://localhost:5173"
+
 // Constants from client.ts
 export const CACHE_TTL = 10 * 60 * 1000 // 10 minutes
 export const MODAL_RESULTS_DISPLAY_LIMIT = 5
@@ -37,13 +41,8 @@ export const ACTION_IDS = {
   PREVIOUS_SOURCE_PAGE: "previous_source_page",
 }
 
-
-
 // Constants for slack Ingestion
-export const periodicSaveState = 4000 // 4 seconds
-
-  
-
+export const periodicSaveState = 4000 // 4 seconds  
 
 // Constants from client.ts
 export const EVENT_CACHE_TTL = 30000; // 30 seconds

--- a/server/integrations/slack/config.ts
+++ b/server/integrations/slack/config.ts
@@ -18,9 +18,11 @@ export const MAX_CITATIONS_IN_MODAL = 2
 export const MAX_CITATIONS_IN_SHARED = 5
 export const MAX_SOURCES_IN_MODAL = 20
 
-export const FRONTEND_BASE_URL = process.env.NODE_ENV === "production"
-  ? process.env.HOST || "https://xyne.juspay.net"
-  : "http://localhost:5173"
+export const FRONTEND_BASE_URL = process.env.FRONTEND_URL || (
+  process.env.NODE_ENV === "production"
+    ? process.env.HOST || "http://localhost:3000"
+    : "http://localhost:5173"
+)
 
 // Constants from client.ts
 export const CACHE_TTL = 10 * 60 * 1000 // 10 minutes

--- a/server/integrations/slack/formatters.ts
+++ b/server/integrations/slack/formatters.ts
@@ -38,6 +38,9 @@ import {
   validateConversationHistory,
 } from "./types";
 
+// Add frontend URL constant
+const FRONTEND_BASE_URL = process.env.FRONTEND_BASE_URL || "http://localhost:5173";
+
 /**
  * Helper function to parse and format result data
  * @param result The search result object
@@ -923,6 +926,11 @@ export function createAgentResponseModal(
       let url = citation.url || "";
       let title = rawTitle;
 
+      // Check if URL is an internal document path and convert to frontend URL
+      if (url && url.startsWith('/dataSource/')) {
+        url = `${FRONTEND_BASE_URL}${url}`;
+      }
+
       // Check for and parse Slack's <url|text> format
       const slackLinkMatch = rawTitle.match(/<(https?:\/\/[^|]+)\|([\s\S]+)>/);
       if (slackLinkMatch) {
@@ -1117,6 +1125,11 @@ export function createSharedAgentResponseBlocks(
       const rawTitle = citation?.title || citation?.name || "Untitled";
       let url = citation?.url || "";
       let title = rawTitle;
+
+      // Check if URL is an internal document path and convert to frontend URL
+      if (url && url.startsWith('/dataSource/')) {
+        url = `${FRONTEND_BASE_URL}${url}`;
+      }
 
       const slackLinkMatch = rawTitle.match(/<(https?:\/\/[^|]+)\|([\s\S]+)>/);
       if (slackLinkMatch) {

--- a/server/integrations/slack/formatters.ts
+++ b/server/integrations/slack/formatters.ts
@@ -1,4 +1,3 @@
-// Define types for Slack blocks to avoid import issues
 import type {
   SectionBlock,
   HeaderBlock,
@@ -26,6 +25,7 @@ import {
   MAX_CITATIONS_IN_MODAL,
   MAX_CITATIONS_IN_SHARED,
   MAX_SOURCES_IN_MODAL,
+  FRONTEND_BASE_URL
 } from "./config";
 import {
   type SearchResult,
@@ -37,9 +37,6 @@ import {
   validateAgents,
   validateConversationHistory,
 } from "./types";
-
-// Add frontend URL constant
-const FRONTEND_BASE_URL = process.env.FRONTEND_BASE_URL || "http://localhost:5173";
 
 /**
  * Helper function to parse and format result data
@@ -839,6 +836,8 @@ export const createAgentResponseBlocks = (
  */
 export function cleanAgentResponse(response: string): string {
   return response
+    .replace(/<[^>]*>[\s\S]*?<\/[^>]*>/g, "") // Remove content between matching XML-like tags (e.g., <analysis_and_planning>...</analysis_and_planning>)
+    .replace(/<[^>]*>/g, "") // Remove any standalone tags that might remain
     .replace(/:\w+:/g, "") // Remove emoji codes like :robot_face:, :books:
     .replace(/\[\d+\]/g, "") // Remove citation numbers
     .replace(/\*\*(.*?)\*\*/g, "*$1*") // Convert **bold** to *bold*


### PR DESCRIPTION
This PR enhances the Slack integration by ensuring reliable channel joining and improves internal link handling for frontend routing in shared Slack messages.

#### Changes

**`client.ts`**

* Updated `processSlackEvent`:

  * Added a nested `try-catch` block to **safely attempt joining public channels**.
  * Prevents errors if the bot is already in the channel or lacks permission.
  * Logs meaningful debug messages for failed joins.

**`formatters.ts`**

* Introduced a `FRONTEND_BASE_URL` constant sourced from environment variables.
* Updated link formatting logic in:

  * `createAgentResponseModal`
  * `createSharedAgentResponseBlocks`
* If a citation URL starts with `/dataSource/`, it now gets **converted to a full frontend URL** using the base URL (e.g., `FRONTEND_BASE_URL/dataSource/{id}`).

---

#### Purpose

* Prevent redundant or failed attempts to join Slack channels.
* Ensure **internal document links** are correctly rendered as clickable links in Slack by resolving them to full frontend URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Slack channel join attempts by only joining public channels and logging join failures without interrupting processing.

* **New Features**
  * Internal document links shared in Slack now display as full URLs, making them accessible directly from Slack messages and modals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->