### PR TITLE
Add fetchAllDataSourceFilesByName to support large data source file lists with pagination

### DIFF
--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -2482,7 +2482,7 @@ export const fetchAllDataSourceFilesByName = async (
   userEmail: string,
   concurrency = 3,
   batchSize = 400,
-): Promise<VespaSearchResponse | null> => {
+): Promise<VespaSearchResult[] | null> => {
   const Logger = getLogger(Subsystem.Vespa).child({
     module: "fetchAllDataSourceFilesByName",
   })
@@ -2572,15 +2572,7 @@ export const fetchAllDataSourceFilesByName = async (
 
   const allChildren = results.flatMap((r) => r.root.children ?? [])
 
-  return {
-    root: {
-      id: "root",
-      relevance: 1.0,
-      fields: { totalCount },
-      children: allChildren,
-      coverage: results[0].root.coverage, // optional
-    },
-  }
+  return allChildren
 }
 
 export const SlackHybridProfile = (


### PR DESCRIPTION
**Description**
This PR introduces a new helper fetchAllDataSourceFilesByName in vespa.ts to handle fetching more than 400 files from Vespa in batches.

**Issue:**
Previously, the YQL query had a hard limit of 400 results. If a user had uploaded more than 400 files to a data source, they could not see the full list, and the frontend displayed an error.

**![Image 16-07-25 at 1 21 AM](https://github.com/user-attachments/assets/3d857499-8a72-409a-a410-6ed2df9fb64f)**
This approach queries Vespa in paginated batches (using offset) to retrieve all matching documents seamlessly.

**Testing**
Verified locally by:

Uploading >1400 test files in data source.

Fetching all files via the new method.

Confirmed no errors in the response and all files visible in the UI.

**Additional Notes**
No breaking changes for other consumers of getDataSourceFilesByName.

Only server/api/dataSource.ts and server/search/vespa.ts are updated.

Other files were reformatted by the formatter but not committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved performance and reliability when listing or deleting data source files, especially for large data sets.
  * Enhanced error handling and logging for operations involving data source files.
  * Introduced paginated, concurrent batch fetching for data source files with fallback support.

* **Bug Fixes**
  * More robust handling of large numbers of data source files, reducing the chance of incomplete results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->