### PR TITLE
build(dockerfile): Pin base image and improve ONNX runtime installation

### DIFF
--- a/deployment/Dockerfile-vespa-gpu
+++ b/deployment/Dockerfile-vespa-gpu
@@ -1,14 +1,10 @@
-FROM vespaengine/vespa:latest
-
-# Switch to root to install packages
+FROM vespaengine/vespa:8.554.5
 USER root
 
-# Install CUDA-enabled ONNX runtime for Vespa
-# Using dnf directly as it's the package manager in the base image
-RUN dnf -y install dnf-plugins-core && \
+# Install required tools and matching CUDA ONNX runtime
+RUN dnf -y install 'dnf-command(config-manager)' && \
     dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && \
-    dnf -y install vespa-onnxruntime-cuda && \
+    dnf -y install $(rpm -q --queryformat '%{NAME}-cuda-%{VERSION}' vespa-onnxruntime) && \
     dnf clean all
 
-# Switch back to vespa user (UID 1000 is typical for vespaengine/vespa)
-USER 1000
+USER vespa  # or USER 1000


### PR DESCRIPTION
Pin the base image to version 8.554.5 for reproducible builds. Refactor the ONNX runtime installation to dynamically determine and install the CUDA-enabled version compatible with the base image. Simplify user switching by using the `vespa` username instead of a hardcoded UID.

### Description

<!-- Summarize the changes in this PR. -->
<!-- Explain the purpose of the change (e.g., bug fix, feature, refactor). -->
<!-- Describe how this change affects the system or users. -->

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
