### PR TITLE
fix(index): fix redirect to agent without refresh from home page

### DIFF
--- a/frontend/src/routes/_authenticated/index.tsx
+++ b/frontend/src/routes/_authenticated/index.tsx
@@ -22,9 +22,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip"
 import { Tip } from "@/components/Tooltip"
-import { ToolsListItem } from "@/types"
+import { ToolsListItem, indexSearchParamsSchema } from "@/types"
 import { AgentCard } from "@/components/AgentCard"
-import { z } from "zod"
 
 enum Tabs {
   Search = "search",
@@ -443,14 +442,10 @@ const Index = () => {
   )
 }
 
-const searchParams = z.object({
-  agentId: z.string().optional(),
-})
-
 export const Route = createFileRoute("/_authenticated/")({
   component: () => {
     return <Index />
   },
-  validateSearch: (search) => searchParams.parse(search),
+  validateSearch: (search) => indexSearchParamsSchema.parse(search),
   errorComponent: errorComponent,
 })

--- a/frontend/src/routes/_authenticated/index.tsx
+++ b/frontend/src/routes/_authenticated/index.tsx
@@ -152,12 +152,8 @@ const Index = () => {
   const searchParams = useSearch({ from: "/_authenticated/" })
 
   useEffect(() => {
-    if (searchParams?.agentId) {
-      setPersistedAgentId(searchParams.agentId)
-    } else {
-      setPersistedAgentId(null)
-    }
-  }, [searchParams?.agentId])
+    setPersistedAgentId(searchParams.agentId || null);
+  }, [searchParams.agentId]);
 
   useEffect(() => {
     if (!autocompleteQuery) {

--- a/frontend/src/routes/_authenticated/index.tsx
+++ b/frontend/src/routes/_authenticated/index.tsx
@@ -246,11 +246,9 @@ const Index = () => {
         searchParams.sources = selectedSources.join(",")
       }
       // If agentId is provided, use it, otherwise use the persisted agent ID from the URL
-      if (agentId) {
-        searchParams.agentId = agentId
-      } else if (persistedAgentId) {
-        searchParams.agentId = persistedAgentId
-      }
+      if (agentId || persistedAgentId) {
+        searchParams.agentId = agentId || persistedAgentId as string
+      } 
       if (isAgenticMode) {
         searchParams.agentic = true
       }

--- a/frontend/src/routes/_authenticated/index.tsx
+++ b/frontend/src/routes/_authenticated/index.tsx
@@ -24,6 +24,7 @@ import {
 import { Tip } from "@/components/Tooltip"
 import { ToolsListItem } from "@/types"
 import { AgentCard } from "@/components/AgentCard"
+import { z } from "zod"
 
 enum Tabs {
   Search = "search",
@@ -442,12 +443,14 @@ const Index = () => {
   )
 }
 
+const searchParams = z.object({
+  agentId: z.string().optional(),
+})
+
 export const Route = createFileRoute("/_authenticated/")({
   component: () => {
     return <Index />
   },
-  validateSearch: (search: Record<string, unknown>) => ({
-    agentId: search.agentId as string | undefined,
-  }),
+  validateSearch: (search) => searchParams.parse(search),
   errorComponent: errorComponent,
 })

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -24,6 +24,10 @@ export const searchSchema = z.object({
   entity: z.string().min(1).optional(),
 })
 
+export const indexSearchParamsSchema = z.object({
+  agentId: z.string().optional(),
+})
+
 export const toolsListItemSchema = z.object({
   connectorId: z.string(),
   tools: z.array(z.string()),


### PR DESCRIPTION
### Description

- fix redirect to fav agent without refresh from home page

### Testing

- tested locally



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Agent selection via URL (?agentId=...) is detected, validated on incoming links, and preserved during navigation.
  - Chat UI accepts and displays the agent selected by the URL or persisted state.
  - Search/Ask flows prefer an explicitly provided agentId and fall back to the persisted selection.

- Bug Fixes
  - Ensures the same agent is consistently used across search and ask flows.
  - Clears the saved agent when the URL no longer includes an agentId to avoid stale selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->