### PR TITLE
dark mode fix for kb

### DIFF
--- a/frontend/src/components/CitationLink.tsx
+++ b/frontend/src/components/CitationLink.tsx
@@ -48,7 +48,7 @@ export const createCitationLink =
             <TooltipTrigger asChild>
               <span
                 {...linkProps}
-                className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-[6px] py-[2px] mx-[2px] bg-gray-200 hover:bg-gray-300 dark:bg-gray-900 dark:hover:bg-gray-800 text-black-700 dark:text-gray-300 rounded-full text-[10px] font-mono font-medium cursor-pointer transition-colors duration-150"
+                className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-[6px] py-[2px] mx-[2px] bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-800 text-black-700 dark:text-gray-300 rounded-full text-[10px] font-mono font-medium cursor-pointer transition-colors duration-150"
                 onClick={(e) => {
                   e.preventDefault()
                   e.stopPropagation()
@@ -64,14 +64,14 @@ export const createCitationLink =
             <TooltipContent
               side="top"
               align="center"
-              className="max-w-sm p-0 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-lg rounded-lg overflow-hidden"
+              className="max-w-sm p-0 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-700 shadow-lg rounded-lg overflow-hidden"
               onPointerDownOutside={(e) => {
                 // Prevent closing when clicking inside the tooltip
                 e.preventDefault()
               }}
             >
               <div
-                className="flex items-start gap-3 p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-750 transition-colors"
+                className="flex items-start gap-3 p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
                 onClick={(e) => {
                   e.preventDefault()
                   e.stopPropagation()

--- a/frontend/src/components/CitationPreview.tsx
+++ b/frontend/src/components/CitationPreview.tsx
@@ -110,7 +110,6 @@ export const CitationPreview: React.FC<CitationPreviewProps> = React.memo(
               source={file}
               className="h-full"
               style={{ height: "100%", overflow: "auto", padding: "16px" }}
-              theme={"light"}
             />
           )
         case "docx":
@@ -120,7 +119,7 @@ export const CitationPreview: React.FC<CitationPreviewProps> = React.memo(
               key={citation.docId}
               source={file}
               className="h-full"
-              style={{ height: "100%", overflow: "auto" }}
+              style={{ overflow: "visible" }}
               options={{
                 renderHeaders: true,
                 renderFooters: true,
@@ -232,7 +231,11 @@ export const CitationPreview: React.FC<CitationPreviewProps> = React.memo(
             </div>
           )}
 
-          {!loading && !error && documentContent && renderViewer()}
+          {!loading && !error && documentContent && (
+            <div className="h-full overflow-auto">
+              {renderViewer()}
+            </div>
+          )}
         </div>
       </div>
     )

--- a/frontend/src/components/DocxViewer.tsx
+++ b/frontend/src/components/DocxViewer.tsx
@@ -152,6 +152,68 @@ export const DocxViewer: React.FC<DocxViewerProps> = ({
         undefined,
         renderOptions,
       )
+
+      // After rendering, remove any inline width constraints and make it responsive
+      if (containerRef.current) {
+        // Remove width constraints from all sections
+        const sections = containerRef.current.querySelectorAll(
+          'section.docx-preview, section.docx-viewer'
+        );
+        sections.forEach((el) => {
+          const section = el as HTMLElement;
+          section.style.removeProperty('width');
+          section.style.removeProperty('max-width');
+          section.style.removeProperty('min-width');
+          section.style.width = '100%';
+          section.style.maxWidth = '100%';
+          section.style.minWidth = 'auto';
+        });
+
+        // Remove width constraints from all wrappers
+        const wrappers = containerRef.current.querySelectorAll(
+          '.docx, .docx-wrapper, .docx-preview-wrapper'
+        );
+        wrappers.forEach((el) => {
+          const wrapper = el as HTMLElement;
+          wrapper.style.removeProperty('width');
+          wrapper.style.removeProperty('max-width');
+          wrapper.style.removeProperty('min-width');
+          wrapper.style.width = '100%';
+          wrapper.style.maxWidth = '100%';
+          wrapper.style.minWidth = 'auto';
+        });
+
+        // Make tables responsive
+        const tables = containerRef.current.querySelectorAll('table');
+        tables.forEach((table) => {
+          const tableEl = table as HTMLElement;
+          tableEl.style.width = '100%';
+          tableEl.style.maxWidth = '100%';
+          tableEl.style.minWidth = 'auto';
+          tableEl.style.tableLayout = 'fixed'; // Better for responsive tables
+          
+          // Make all cells wrap content properly
+          const cells = tableEl.querySelectorAll('td, th');
+          cells.forEach((cell) => {
+            const cellEl = cell as HTMLElement;
+            cellEl.style.overflowWrap = 'break-word';
+            cellEl.style.whiteSpace = 'normal';
+            cellEl.style.maxWidth = '0'; // Forces text wrapping
+            cellEl.style.minWidth = '100px';
+            cellEl.style.boxSizing = 'border-box';
+            cellEl.style.padding = '5px';
+          });
+        });
+
+        // Make images responsive
+        const images = containerRef.current.querySelectorAll('img');
+        images.forEach((img) => {
+          const imgEl = img as HTMLElement;
+          imgEl.style.maxWidth = '100%';
+          imgEl.style.height = 'auto';
+          imgEl.style.width = 'auto';
+        });
+      }
     } catch (e) {
       const errorMessage =
         e instanceof Error ? e.message : "Failed to load document"
@@ -224,9 +286,33 @@ export const DocxViewer: React.FC<DocxViewerProps> = ({
            padding-top: 40px !important;
            margin: 0;
            padding: 40px 60px;
-           /* Allow the consumer to control width; override any inline widths from library */
+           /* Make it fully responsive */
            width: auto !important;
            max-width: none !important;
+           min-width: auto !important;
+           box-sizing: border-box !important;
+         }
+         
+         /* Responsive padding for different screen sizes */
+         @media (min-width: 640px) {
+           .docx-preview-wrapper > section.docx-preview,
+           section.docx-viewer {
+             padding: 30px 40px;
+           }
+         }
+         
+         @media (min-width: 768px) {
+           .docx-preview-wrapper > section.docx-preview,
+           section.docx-viewer {
+             padding: 40px 60px;
+           }
+         }
+         
+         @media (min-width: 1024px) {
+           .docx-preview-wrapper > section.docx-preview,
+           section.docx-viewer {
+             padding: 50px 80px;
+           }
          }
          
          .docx-preview { 
@@ -249,15 +335,26 @@ export const DocxViewer: React.FC<DocxViewerProps> = ({
         
         .docx-preview table { 
           border-collapse: collapse; 
-          width: 100%;
+          width: 100% !important;
+          max-width: 100% !important;
+          min-width: auto !important;
           margin: 1em 0;
+          table-layout: fixed !important; /* Better for responsive tables */
+          word-wrap: break-word;
+          overflow-wrap: break-word;
+          overflow-x: auto; /* Allow horizontal scroll if needed */
         }
         
         .docx-preview table td, 
         .docx-preview table th { 
           border: 1px solid #ddd;
           padding: 8px;
-          vertical-align: top; 
+          vertical-align: top;
+          word-wrap: break-word;
+          overflow-wrap: break-word;
+          white-space: normal;
+          max-width: 0; /* Forces text wrapping */
+          min-width: 100px; /* Minimum width for readability */
         }
         
         .docx-preview p { 
@@ -270,6 +367,13 @@ export const DocxViewer: React.FC<DocxViewerProps> = ({
         .docx-preview h4 { font-size: 1.5em; font-weight: bold; margin: 0.67em 0; }
         .docx-preview h5 { font-size: 1.25em; font-weight: bold; margin: 0.67em 0; }
         .docx-preview h6 { font-size: 1em; font-weight: bold; margin: 0.67em 0; }
+
+        .docx-preview_heading1 { font-size: 2.5em; font-weight: bold; margin: 0.67em 0; }
+        .docx-preview_heading2 { font-size: 2em; font-weight: bold; margin: 0.67em 0; }
+        .docx-preview_heading3 { font-size: 1.75em; font-weight: bold; margin: 0.67em 0; }
+        .docx-preview_heading4 { font-size: 1.5em; font-weight: bold; margin: 0.67em 0; }
+        .docx-preview_heading5 { font-size: 1.25em; font-weight: bold; margin: 0.67em 0; }
+        .docx-preview_heading6 { font-size: 1em; font-weight: bold; margin: 0.67em 0; }
         
         .docx-preview img { 
           max-width: 100%; 

--- a/frontend/src/components/DocxViewer.tsx
+++ b/frontend/src/components/DocxViewer.tsx
@@ -167,15 +167,17 @@ export const DocxViewer: React.FC<DocxViewerProps> = ({
       className={`enhanced-docx-viewer ${className}`}
       style={{
         backgroundColor: "white",
-        minHeight: "100vh",
+        minHeight: "100%",
+        height: "auto",
+        width: "100%",
         ...style,
       }}
     >
       {loading && showLoading && (
-        <div className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-90 z-10">
+        <div className="absolute inset-0 flex items-center justify-center bg-white/90 dark:bg-[#1E1E1E]/90 z-10">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
-            <p className="text-gray-600">Loading document...</p>
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-600 dark:border-gray-300 mx-auto mb-4"></div>
+            <p className="text-gray-600 dark:text-gray-300">Loading document...</p>
           </div>
         </div>
       )}
@@ -197,22 +199,34 @@ export const DocxViewer: React.FC<DocxViewerProps> = ({
       <style
         dangerouslySetInnerHTML={{
           __html: `
+         .enhanced-docx-viewer {
+           background: white !important;
+           min-height: 100% !important;
+           height: auto !important;
+           width: 100% !important;
+         }
+         
          .docx-preview-wrapper { 
            background: white !important; 
            padding: 0; 
            display: flex; 
            flex-flow: column; 
            align-items: center; 
+           min-height: 100% !important;
+           height: auto !important;
+           width: 100% !important;
          }
          
-         .docx-preview-wrapper > section.docx-preview { 
+         .docx-preview-wrapper > section.docx-preview, 
+         section.docx-viewer { 
            background: white; 
            box-shadow: none !important; 
            padding-top: 40px !important;
            margin: 0;
            padding: 40px 60px;
-           max-width: 850px;
-           width: 100%;
+           /* Allow the consumer to control width; override any inline widths from library */
+           width: auto !important;
+           max-width: none !important;
          }
          
          .docx-preview { 

--- a/frontend/src/components/PdfViewer.tsx
+++ b/frontend/src/components/PdfViewer.tsx
@@ -482,7 +482,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
                     <button
                       onClick={goToPreviousPage}
                       disabled={currentPage <= 1}
-                      className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition-colors"
+                      className="px-4 py-2 bg-gray-600 dark:bg-gray-700 text-white rounded hover:bg-gray-700 dark:hover:bg-gray-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition-colors"
                     >
                       Previous
                     </button>
@@ -510,7 +510,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
                   <button
                     onClick={goToNextPage}
                     disabled={currentPage >= totalPages}
-                    className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition-colors"
+                    className="px-4 py-2 bg-gray-600 dark:bg-gray-700 text-white rounded hover:bg-gray-700 dark:hover:bg-gray-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition-colors"
                   >
                     Next
                   </button>
@@ -550,7 +550,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
                 />
                 {pageRendering && (
                   <div className="absolute inset-0 flex items-center justify-center bg-white dark:bg-[#2d2d2d] bg-opacity-75">
-                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-600 dark:border-gray-300"></div>
                   </div>
                 )}
               </div>

--- a/frontend/src/components/PdfViewer.tsx
+++ b/frontend/src/components/PdfViewer.tsx
@@ -3,6 +3,7 @@ import * as pdfjsLib from "pdfjs-dist"
 import type { PDFDocumentProxy, PDFPageProxy } from "pdfjs-dist"
 import "pdfjs-dist/web/pdf_viewer.css"
 import { authFetch } from "@/utils/authFetch"
+import { useTheme } from "@/components/ThemeContext"
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = "/pdf.worker.min.js"
 
@@ -35,6 +36,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
   displayMode = "continuous",
   showNavigation = false,
 }) => {
+  const { theme } = useTheme()
   const containerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const textLayerRef = useRef<HTMLDivElement>(null)
@@ -434,26 +436,26 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
     <div
       className={`enhanced-pdf-viewer ${className}`}
       style={{
-        backgroundColor: "#f5f5f5",
+        backgroundColor: theme === "dark" ? "#1E1E1E" : "#f5f5f5",
         minHeight: "100%",
         position: "relative",
         ...style,
       }}
     >
       {loading && showLoading && (
-        <div className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-90 z-10">
+        <div className="absolute inset-0 flex items-center justify-center bg-white/90 dark:bg-[#1E1E1E]/90 z-10">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
-            <p className="text-gray-600">Loading PDF...</p>
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-600 dark:border-gray-300 mx-auto mb-4"></div>
+            <p className="text-gray-600 dark:text-gray-300">Loading PDF...</p>
           </div>
         </div>
       )}
 
       {error && !loading && (
-        <div className="absolute inset-0 flex items-center justify-center bg-white z-10">
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4 max-w-md">
-            <p className="text-red-800 font-semibold">Error loading PDF</p>
-            <p className="text-red-600 text-sm mt-1">{error}</p>
+        <div className="absolute inset-0 flex items-center justify-center bg-white dark:bg-[#1E1E1E] z-10">
+          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 max-w-md">
+            <p className="text-red-800 dark:text-red-200 font-semibold">Error loading PDF</p>
+            <p className="text-red-600 dark:text-red-300 text-sm mt-1">{error}</p>
             <button
               onClick={() => {
                 setError(null)
@@ -473,14 +475,14 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
         <>
           {/* Navigation bar */}
           {showNavigation && totalPages > 1 && (
-            <div className="sticky top-0 bg-white shadow-md z-20 p-4">
+            <div className="sticky top-0 bg-white dark:bg-[#1E1E1E] shadow-md z-20 p-4 border-b border-gray-200 dark:border-gray-700">
               <div className="flex items-center justify-center gap-4">
                 {displayMode === "paginated" && (
                   <>
                     <button
                       onClick={goToPreviousPage}
                       disabled={currentPage <= 1}
-                      className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+                      className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition-colors"
                     >
                       Previous
                     </button>
@@ -488,7 +490,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
                 )}
 
                 <div className="flex items-center gap-2">
-                  <span className="text-sm text-gray-600">Page</span>
+                  <span className="text-sm text-gray-600 dark:text-gray-300">Page</span>
                   <input
                     type="number"
                     min="1"
@@ -499,16 +501,16 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
                         : currentPage
                     }
                     onChange={(e) => goToPage(parseInt(e.target.value) || 1)}
-                    className="w-16 px-2 py-1 border border-gray-300 rounded text-center bg-white text-gray-800"
+                    className="w-16 px-2 py-1 border border-gray-300 dark:border-gray-600 rounded text-center bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-200"
                   />
-                  <span className="text-sm text-gray-600">of {totalPages}</span>
+                  <span className="text-sm text-gray-600 dark:text-gray-300">of {totalPages}</span>
                 </div>
 
                 {displayMode === "paginated" && (
                   <button
                     onClick={goToNextPage}
                     disabled={currentPage >= totalPages}
-                    className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+                    className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 disabled:bg-gray-300 dark:disabled:bg-gray-600 disabled:cursor-not-allowed transition-colors"
                   >
                     Next
                   </button>
@@ -527,7 +529,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
                 minHeight: showNavigation ? "calc(100vh - 80px)" : "100vh",
               }}
             >
-              <div className="pdf-page-container bg-white shadow-lg relative">
+              <div className="pdf-page-container bg-white dark:bg-[#2d2d2d] shadow-lg relative">
                 <canvas
                   ref={canvasRef}
                   className="pdf-canvas"
@@ -547,7 +549,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
                   }}
                 />
                 {pageRendering && (
-                  <div className="absolute inset-0 flex items-center justify-center bg-white bg-opacity-75">
+                  <div className="absolute inset-0 flex items-center justify-center bg-white dark:bg-[#2d2d2d] bg-opacity-75">
                     <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
                   </div>
                 )}
@@ -571,7 +573,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
                       key={pageNum}
                       id={`pdf-page-wrapper-${pageNum}`}
                       data-page-num={pageNum}
-                      className="pdf-page-container bg-white shadow-lg relative"
+                      className="pdf-page-container bg-white dark:bg-[#2d2d2d] shadow-lg relative"
                     >
                       <canvas
                         id={`pdf-page-${pageNum}`}
@@ -590,7 +592,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
                           lineHeight: 1,
                         }}
                       />
-                      <div className="absolute top-2 right-2 bg-black bg-opacity-60 text-white px-2 py-1 rounded text-sm">
+                      <div className="absolute top-2 right-2 bg-black dark:bg-[#404040] bg-opacity-60 dark:bg-opacity-80 text-white dark:text-gray-200 px-2 py-1 rounded text-sm">
                         Page {pageNum}
                       </div>
                     </div>

--- a/frontend/src/components/ReadmeViewer.tsx
+++ b/frontend/src/components/ReadmeViewer.tsx
@@ -205,7 +205,7 @@ export const ReadmeViewer: React.FC<ReadmeViewerProps> = ({
         [data-color-mode="dark"] .wmde-markdown h5,
         [data-color-mode="dark"] .wmde-markdown h6 {
           color: #c9d1d9 !important;
-          border-bottom-color: ${theme === "dark" ? "#404040" : "#eaecef"} !important;
+          border-bottom-color: #404040 !important;
         }
         
         [data-color-mode="dark"] .wmde-markdown a {
@@ -217,42 +217,42 @@ export const ReadmeViewer: React.FC<ReadmeViewerProps> = ({
         }
         
         [data-color-mode="dark"] .wmde-markdown blockquote {
-          border-left-color: ${theme === "dark" ? "#404040" : "#dfe2e5"} !important;
-          color: ${theme === "dark" ? "#8b949e" : "#6a737d"} !important;
+          border-left-color: #404040 !important;
+          color: #8b949e !important;
         }
         
         [data-color-mode="dark"] .wmde-markdown table {
-          border-color: ${theme === "dark" ? "#404040" : "#dfe2e5"} !important;
+          border-color: #404040 !important;
         }
         
         [data-color-mode="dark"] .wmde-markdown table th,
         [data-color-mode="dark"] .wmde-markdown table td {
-          border-color: ${theme === "dark" ? "#404040" : "#dfe2e5"} !important;
+          border-color: #404040 !important;
         }
         
         [data-color-mode="dark"] .wmde-markdown table tr:nth-child(2n) {
-          background-color: ${theme === "dark" ? "#2d2d2d" : "#f6f8fa"} !important;
+          background-color: #2d2d2d !important;
         }
         
         [data-color-mode="dark"] .wmde-markdown hr {
-          border-color: ${theme === "dark" ? "#404040" : "#e1e4e8"} !important;
+          border-color: #404040 !important;
         }
         
         [data-color-mode="dark"] .wmde-markdown ul,
         [data-color-mode="dark"] .wmde-markdown ol {
-          color: ${theme === "dark" ? "#c9d1d9" : "#24292e"} !important;
+          color: #c9d1d9 !important;
         }
         
         [data-color-mode="dark"] .wmde-markdown li {
-          color: ${theme === "dark" ? "#c9d1d9" : "#24292e"} !important;
+          color: #c9d1d9 !important;
         }
         
         [data-color-mode="dark"] .wmde-markdown strong {
-          color: ${theme === "dark" ? "#f0f6fc" : "#24292e"} !important;
+          color: #f0f6fc !important;
         }
         
         [data-color-mode="dark"] .wmde-markdown em {
-          color: ${theme === "dark" ? "#c9d1d9" : "#24292e"} !important;
+          color: #c9d1d9 !important;
         }
         
         @media print {

--- a/frontend/src/components/ReadmeViewer.tsx
+++ b/frontend/src/components/ReadmeViewer.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useMemo } from "react"
 import MarkdownPreview from "@uiw/react-markdown-preview"
 import "@uiw/react-markdown-preview/markdown.css"
 import { authFetch } from "@/utils/authFetch"
+import { useTheme } from "@/components/ThemeContext"
 
 interface ReadmeViewerProps {
   /** Either a URL or File object */
@@ -12,8 +13,6 @@ interface ReadmeViewerProps {
   showLoading?: boolean
   /** Custom styles for the container */
   style?: React.CSSProperties
-  /** Theme mode */
-  theme?: "light" | "dark"
 }
 
 export const ReadmeViewer: React.FC<ReadmeViewerProps> = ({
@@ -21,11 +20,11 @@ export const ReadmeViewer: React.FC<ReadmeViewerProps> = ({
   className = "",
   showLoading = true,
   style = {},
-  theme = "light",
 }) => {
   const [loading, setLoading] = useState<boolean>(true)
   const [error, setError] = useState<string | null>(null)
   const [markdownContent, setMarkdownContent] = useState<string>("")
+  const { theme } = useTheme()
 
   // Use a stable key for the source to avoid unnecessary re-renders
   const sourceKey = useMemo(() => {
@@ -111,18 +110,14 @@ export const ReadmeViewer: React.FC<ReadmeViewerProps> = ({
 
   return (
     <div
-      className={`readme-viewer ${className}`}
-      style={{
-        backgroundColor: theme === "dark" ? "#1e1e1e" : "white",
-        minHeight: "100vh",
-        ...style,
-      }}
+      className={`readme-viewer min-h-screen bg-white dark:bg-[#1E1E1E] ${className}`}
+      style={style}
       data-color-mode={theme}
     >
       {loading && showLoading && (
-        <div className="absolute inset-0 flex items-center justify-center bg-white dark:bg-gray-900 bg-opacity-90 z-10">
+        <div className="absolute inset-0 flex items-center justify-center bg-white/90 dark:bg-[#1E1E1E]/90 z-10">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-600 dark:border-gray-300 mx-auto mb-4"></div>
             <p className="text-gray-600 dark:text-gray-300">
               Loading document...
             </p>
@@ -131,7 +126,7 @@ export const ReadmeViewer: React.FC<ReadmeViewerProps> = ({
       )}
 
       {error && !loading && (
-        <div className="absolute inset-0 flex items-center justify-center bg-white dark:bg-gray-900 z-10">
+        <div className="absolute inset-0 flex items-center justify-center bg-white dark:bg-[#1E1E1E] z-10">
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 max-w-md">
             <p className="text-red-800 dark:text-red-200 font-semibold">
               Error loading document
@@ -189,10 +184,13 @@ export const ReadmeViewer: React.FC<ReadmeViewerProps> = ({
         
         .wmde-markdown pre {
           background-color: ${theme === "dark" ? "#2d2d2d" : "#f6f8fa"} !important;
+          border: 1px solid ${theme === "dark" ? "#404040" : "#e1e4e8"} !important;
         }
         
         .wmde-markdown code {
           background-color: ${theme === "dark" ? "#2d2d2d" : "rgba(175, 184, 193, 0.2)"} !important;
+          color: ${theme === "dark" ? "#e1e4e8" : "#24292e"} !important;
+          border: 1px solid ${theme === "dark" ? "#404040" : "#e1e4e8"} !important;
         }
         
         /* Ensure proper text color in dark mode */
@@ -207,6 +205,54 @@ export const ReadmeViewer: React.FC<ReadmeViewerProps> = ({
         [data-color-mode="dark"] .wmde-markdown h5,
         [data-color-mode="dark"] .wmde-markdown h6 {
           color: #c9d1d9 !important;
+          border-bottom-color: ${theme === "dark" ? "#404040" : "#eaecef"} !important;
+        }
+        
+        [data-color-mode="dark"] .wmde-markdown a {
+          color: #58a6ff !important;
+        }
+        
+        [data-color-mode="dark"] .wmde-markdown a:hover {
+          color: #79c0ff !important;
+        }
+        
+        [data-color-mode="dark"] .wmde-markdown blockquote {
+          border-left-color: ${theme === "dark" ? "#404040" : "#dfe2e5"} !important;
+          color: ${theme === "dark" ? "#8b949e" : "#6a737d"} !important;
+        }
+        
+        [data-color-mode="dark"] .wmde-markdown table {
+          border-color: ${theme === "dark" ? "#404040" : "#dfe2e5"} !important;
+        }
+        
+        [data-color-mode="dark"] .wmde-markdown table th,
+        [data-color-mode="dark"] .wmde-markdown table td {
+          border-color: ${theme === "dark" ? "#404040" : "#dfe2e5"} !important;
+        }
+        
+        [data-color-mode="dark"] .wmde-markdown table tr:nth-child(2n) {
+          background-color: ${theme === "dark" ? "#2d2d2d" : "#f6f8fa"} !important;
+        }
+        
+        [data-color-mode="dark"] .wmde-markdown hr {
+          border-color: ${theme === "dark" ? "#404040" : "#e1e4e8"} !important;
+        }
+        
+        [data-color-mode="dark"] .wmde-markdown ul,
+        [data-color-mode="dark"] .wmde-markdown ol {
+          color: ${theme === "dark" ? "#c9d1d9" : "#24292e"} !important;
+        }
+        
+        [data-color-mode="dark"] .wmde-markdown li {
+          color: ${theme === "dark" ? "#c9d1d9" : "#24292e"} !important;
+        }
+        
+        [data-color-mode="dark"] .wmde-markdown strong {
+          color: ${theme === "dark" ? "#f0f6fc" : "#24292e"} !important;
+        }
+        
+        [data-color-mode="dark"] .wmde-markdown em {
+          color: ${theme === "dark" ? "#c9d1d9" : "#24292e"} !important;
         }
         
         @media print {

--- a/frontend/src/components/ReadmeViewer.tsx
+++ b/frontend/src/components/ReadmeViewer.tsx
@@ -110,7 +110,7 @@ export const ReadmeViewer: React.FC<ReadmeViewerProps> = ({
 
   return (
     <div
-      className={`readme-viewer min-h-screen bg-white dark:bg-[#1E1E1E] ${className}`}
+      className={`readme-viewer relative min-h-full bg-white dark:bg-[#1E1E1E] ${className}`}
       style={style}
       data-color-mode={theme}
     >

--- a/frontend/src/components/SimpleFileTree.tsx
+++ b/frontend/src/components/SimpleFileTree.tsx
@@ -36,7 +36,7 @@ const SimpleFileTree = ({
   const flatItems = flattenTree(items)
 
   return (
-    <div className="text-gray-700 text-sm">
+    <div className="text-sm text-gray-700 dark:text-gray-300">
       {flatItems.map(({ node, level }, index) => (
         <FileNodeComponent
           key={index}
@@ -66,22 +66,20 @@ const FileNodeComponent = ({
 }) => {
   const [isHovered, setIsHovered] = useState(false)
   const isSelected = selectedFile === node
-  const isClickableFile =
-    node.type === "file" &&
-    (node.name.toLowerCase().endsWith(".docx") ||
-      node.name.toLowerCase().endsWith(".pdf") ||
-      node.name.toLowerCase().endsWith(".md"))
+  const isClickableFile = node.type === "file"
 
   return (
     <div
       className={`relative flex items-center py-2 px-4 cursor-pointer transition-colors duration-150 rounded-md ml-3 m-3 ${
         isSelected
-          ? "bg-gray-200 dark:bg-slate-700 text-gray-900 dark:text-gray-100"
+          ? "bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-100"
           : isHovered
-            ? "bg-gray-200 text-gray-800"
-            : "text-gray-700 hover:text-gray-800"
+          ? "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-200"
+          : "text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-[#404040]"
       }`}
-      style={{ paddingLeft: `${level * 24 + 16}px` }}
+      style={{ 
+        paddingLeft: `${level * 24 + 16}px`,
+      }}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onClick={(e) => {
@@ -98,25 +96,29 @@ const FileNodeComponent = ({
       {/* Indentation lines for nested items */}
       {/* {level > 0 && (
         <div
-          className="absolute left-0 top-0 bottom-0 border-l border-gray-200"
-          style={{ left: `${(level - 1) * 24 + 16}px` }}
+          className="absolute left-0 top-0 bottom-0 border-l border-gray-300 dark:border-[#404040]"
+          style={{ 
+            left: `${(level - 1) * 24 + 16}px`,
+          }}
         />
       )} */}
 
       {node.type === "folder" && (
         <>
-          <span className="mr-2 flex items-center flex-shrink-0">
+          <span className="mr-2 flex items-center flex-shrink-0 text-gray-500 dark:text-gray-400">
             {node.isOpen ? (
-              <ChevronDown size={12} className="text-gray-500" />
+              <ChevronDown size={12} />
             ) : (
-              <ChevronRight size={12} className="text-gray-500" />
+              <ChevronRight size={12} />
             )}
           </span>
         </>
       )}
 
       <span
-        className={`text-sm leading-relaxed truncate min-w-0 ${isSelected ? "font-medium text-gray-900" : "text-gray-700"}`}
+        className={`text-sm leading-relaxed truncate min-w-0 ${
+          isSelected ? "font-medium" : ""
+        }`}
         title={node.name}
       >
         {node.name}

--- a/frontend/src/routes/_authenticated/knowledgeManagement.tsx
+++ b/frontend/src/routes/_authenticated/knowledgeManagement.tsx
@@ -109,12 +109,12 @@ const DocumentViewerContainer = memo(
     loadingDocument: boolean
   }) => {
     return (
-      <div className="flex-1 overflow-y-auto bg-white relative">
+      <div className="flex-1 overflow-y-auto bg-white dark:bg-[#1E1E1E] relative">
         {loadingDocument && (
-          <div className="absolute inset-0 bg-white bg-opacity-90 z-10 flex items-center justify-center">
+          <div className="absolute inset-0 bg-white/90 dark:bg-[#1E1E1E]/90 z-10 flex items-center justify-center">
             <div className="text-center">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
-              <p className="text-gray-600">Loading document...</p>
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-600 dark:border-gray-300 mx-auto mb-4"></div>
+              <p className="text-gray-600 dark:text-gray-300">Loading document...</p>
             </div>
           </div>
         )}
@@ -151,12 +151,6 @@ const DocumentViewerContainer = memo(
                 }
                 className="h-full"
                 style={{ height: "100%", overflow: "auto" }}
-                theme={
-                  document.documentElement.getAttribute("data-color-mode") ===
-                  "dark"
-                    ? "dark"
-                    : "light"
-                }
               />
             ) : (
               <div className="h-full p-6 overflow-auto">
@@ -195,7 +189,7 @@ const DocumentViewerContainer = memo(
           </div>
         ) : (
           <div className="flex items-center justify-center h-full">
-            <p className="text-gray-500">Select a document to view</p>
+            <p className="text-gray-500 dark:text-gray-400">Select a document to view</p>
           </div>
         )}
       </div>
@@ -946,10 +940,10 @@ function RouteComponent() {
           // Document viewer layout
           <div className="flex h-full flex-col lg:flex-row">
             {/* Left pane - File tree */}
-            <div className="bg-gray-100 flex flex-col border-r border-gray-200 w-full lg:w-[300px] lg:min-w-[250px] lg:max-w-[400px] h-64 lg:h-full">
+            <div className="bg-gray-100 dark:bg-[#1E1E1E] flex flex-col border-r border-gray-200 dark:border-gray-700 w-full lg:w-[300px] lg:min-w-[250px] lg:max-w-[400px] h-64 lg:h-full">
               {/* Collection Header */}
               <div className="px-4 py-4">
-                <h2 className="text-sm font-bold font-mono text-gray-400 uppercase tracking-wider truncate">
+                <h2 className="text-sm font-bold font-mono text-gray-400 dark:text-gray-500 uppercase tracking-wider truncate">
                   {selectedDocument.collection.name}
                 </h2>
               </div>
@@ -1048,20 +1042,20 @@ function RouteComponent() {
             </div>
 
             {/* Right pane - Document viewer */}
-            <div className="flex-1 flex flex-col bg-white min-h-0">
+            <div className="flex-1 flex flex-col bg-white dark:bg-[#1E1E1E] min-h-0">
               {/* Document header */}
-              <div className="h-12 bg-white flex items-center px-6 border-b border-gray-200">
+              <div className="h-12 bg-white dark:bg-[#1E1E1E] flex items-center px-6 border-b border-gray-200 dark:border-gray-700">
                 <div className="flex items-center gap-4">
                   <Button
                     onClick={handleBackToCollections}
                     variant="ghost"
                     size="sm"
-                    className="flex items-center gap-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 px-2 py-1 h-auto"
+                    className="flex items-center gap-2 text-gray-600 dark:text-gray-300 hover:text-gray-800 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-[#2d2d2d] px-2 py-1 h-auto"
                   >
                     <ArrowLeft size={16} />
                   </Button>
                   <div className="flex items-center gap-3 min-w-0">
-                    <span className="text-sm font-medium text-gray-700 truncate">
+                    <span className="text-sm font-medium text-gray-700 dark:text-gray-200 truncate">
                       {selectedDocument.file.name}
                     </span>
                   </div>
@@ -1088,7 +1082,7 @@ function RouteComponent() {
                   <Button
                     onClick={() => setShowNewCollection(true)}
                     disabled={isUploading}
-                    className="bg-slate-800 hover:bg-slate-700 text-white rounded-full px-4 py-2 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="bg-slate-800 hover:bg-slate-700 dark:bg-[#2d2d2d] dark:hover:bg-[#404040] text-white rounded-full px-4 py-2 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <Plus size={16} />
                     <span className="font-mono text-[12px] font-medium">
@@ -1166,7 +1160,7 @@ function RouteComponent() {
                       <div className="flex items-center gap-4">
                         <Plus
                           size={16}
-                          className={`cursor-pointer ${isUploading ? "opacity-50 cursor-not-allowed" : ""}`}
+                          className={`cursor-pointer text-gray-600 dark:text-gray-400 ${isUploading ? "opacity-50 cursor-not-allowed" : ""}`}
                           onClick={(e) => {
                             e.stopPropagation()
                             !isUploading && handleOpenAddFilesModal(collection)
@@ -1176,7 +1170,7 @@ function RouteComponent() {
                           <DropdownMenuTrigger asChild>
                             <MoreHorizontal
                               size={16}
-                              className={`cursor-pointer ${isUploading ? "opacity-50 cursor-not-allowed" : ""}`}
+                              className={`cursor-pointer text-gray-600 dark:text-gray-400 ${isUploading ? "opacity-50 cursor-not-allowed" : ""}`}
                               onClick={(e) => e.stopPropagation()}
                             />
                           </DropdownMenuTrigger>


### PR DESCRIPTION
### Description

added dark mode for kb viewers and citation viewers

### Testing

toggle between theme to test
tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Comprehensive dark mode across Knowledge Management, PDF, DOCX, Markdown/README, and file tree.
  - Retry button on PDF errors.
  - All files in the tree are clickable/openable.

- Style
  - Updated dark-mode colors for badges, tooltips, overlays, headers, and lists.
  - Improved preview scrolling with a dedicated scroll container; DOCX sizing, tables, images, and headings are now more responsive.
  - Loading and error overlays now theme-aware with refined spinners and text.
  - Markdown/README now follows the app theme (no per-component theme prop).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->