### PR TITLE
feat:Service Account update

### DIFF
--- a/server/api/admin.ts
+++ b/server/api/admin.ts
@@ -27,6 +27,7 @@ import {
   type OAuthStartQuery,
   type SaaSJob,
   type ServiceAccountConnection,
+  type UpdateServiceAccountConnection,
   type ApiKeyMCPConnector,
   type StdioMCPConnector,
   MCPClientStdioConfig,
@@ -465,6 +466,70 @@ export const AddServiceConnection = async (c: Context) => {
     })
   }
   // })
+}
+
+export const UpdateServiceConnection = async (c: Context) => {
+  const { sub, workspaceId } = c.get(JwtPayloadKey)
+  loggerWithChild({ email: sub }).info("UpdateServiceConnection")
+  const email = sub
+  const userRes = await getUserByEmail(db, email)
+  if (!userRes || !userRes.length) {
+    throw new NoUserFound({})
+  }
+  const [user] = userRes
+  // @ts-ignore
+  const form: UpdateServiceAccountConnection = c.req.valid("form")
+  const serviceKeyData = await form["service-key"].text()
+  const connectorId = form.connectorId
+
+  try {
+    // Get the existing connector
+    const existingConnector = await getConnectorByExternalId(
+      db,
+      connectorId,
+      user.id,
+    )
+    if (!existingConnector) {
+      throw new HTTPException(404, {
+        message: "Service account connector not found",
+      })
+    }
+
+    // Verify it's a service account connector
+    if (existingConnector.authType !== AuthType.ServiceAccount) {
+      throw new HTTPException(400, {
+        message: "Connector is not a service account type",
+      })
+    }
+
+    // Update the connector with new credentials
+    await updateConnector(db, existingConnector.id, {
+      credentials: serviceKeyData,
+      status: ConnectorStatus.Connected,
+    })
+
+    return c.json({
+      success: true,
+      message: "Service account updated",
+      id: existingConnector.externalId,
+    })
+  } catch (error) {
+    const errMessage = getErrorMessage(error)
+    loggerWithChild({ email: email }).error(
+      error,
+      `${new AddServiceConnectionError({
+        cause: error as Error,
+      })} \n : ${errMessage} : ${(error as Error).stack}`,
+    )
+
+    if (error instanceof HTTPException) {
+      throw error
+    }
+
+    throw new HTTPException(500, {
+      message: "Error updating service account connection",
+    })
+  }
 }
 
 // adding first for slack

--- a/server/server.ts
+++ b/server/server.ts
@@ -23,6 +23,7 @@ import {
   addApiKeyConnectorSchema,
   addApiKeyMCPConnectorSchema,
   addServiceConnectionSchema,
+  updateServiceConnectionSchema,
   addStdioMCPConnectorSchema,
   answerSchema,
   createOAuthProvider,
@@ -40,6 +41,7 @@ import {
   AddApiKeyConnector,
   AddApiKeyMCPConnector,
   AddServiceConnection,
+  UpdateServiceConnection,
   CreateOAuthProvider,
   DeleteConnector,
   DeleteOauthConnector,
@@ -879,6 +881,11 @@ export const AppRoutes = app
     "/service_account",
     zValidator("form", addServiceConnectionSchema),
     AddServiceConnection,
+  )
+  .put(
+    "/service_account",
+    zValidator("form", updateServiceConnectionSchema),
+    UpdateServiceConnection,
   )
   .post(
     "/google/service_account/ingest_more",

--- a/server/types.ts
+++ b/server/types.ts
@@ -100,6 +100,15 @@ export type ServiceAccountConnection = z.infer<
   typeof addServiceConnectionSchema
 >
 
+export const updateServiceConnectionSchema = z.object({
+  "service-key": z.any(),
+  connectorId: z.string(),
+})
+
+export type UpdateServiceAccountConnection = z.infer<
+  typeof updateServiceConnectionSchema
+>
+
 export const addApiKeyConnectorSchema = z.object({
   app: z.nativeEnum(Apps),
   apiKey: z.string(),


### PR DESCRIPTION
### Description

Added option for admin to update the service account credentials by updating the form

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Admins can now update an existing Google Drive Service Account key directly from the UI via an upload form with validation, clear success/failure toasts, and seamless refresh.
  - Introduces an admin API to update service connections while retaining the existing creation endpoint.
  - Adds admin routes to view connector tools and update their status.
- Bug Fixes
  - Consistent authentication handling: unauthorized requests redirect to sign-in; generic error messaging for other failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->