### PR TITLE
fix:Added zod validation for serviceAccount file upload

### DIFF
--- a/server/types.ts
+++ b/server/types.ts
@@ -90,7 +90,22 @@ export type SlackConfig = z.infer<typeof UpdatedAtValSchema>
 export type OAuthStartQuery = z.infer<typeof oauthStartQuerySchema>
 
 export const addServiceConnectionSchema = z.object({
-  "service-key": z.any(),
+  "service-key": z
+    .instanceof(File)
+    .refine(
+      (file) =>
+        file.type === "application/json" || file.name?.endsWith(".json"),
+      "File must be a JSON file",
+    )
+    .refine(async (file) => {
+      try {
+        const content = await file.text()
+        JSON.parse(content) // Just validate it's valid JSON
+        return true
+      } catch {
+        return false
+      }
+    }, "File must contain valid JSON"),
   app: z.nativeEnum(Apps),
   email: z.string().email(),
   whitelistedEmails: z.string().optional(),
@@ -101,8 +116,23 @@ export type ServiceAccountConnection = z.infer<
 >
 
 export const updateServiceConnectionSchema = z.object({
-  "service-key": z.any(),
-  connectorId: z.string(),
+  "service-key": z
+    .instanceof(File)
+    .refine(
+      (file) =>
+        file.type === "application/json" || file.name?.endsWith(".json"),
+      "File must be a JSON file",
+    )
+    .refine(async (file) => {
+      try {
+        const content = await file.text()
+        JSON.parse(content) // Just validate it's valid JSON
+        return true
+      } catch {
+        return false
+      }
+    }, "File must contain valid JSON"),
+  connectorId: z.string().min(1, "Connector ID is required"),
 })
 
 export type UpdateServiceAccountConnection = z.infer<


### PR DESCRIPTION
### Description

Earlier we skipped the file validation check at backend
Added File instance check , to verify the uploaded file is of extension json

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Service key upload now strictly accepts JSON files only; non-JSON files are rejected with clear error messages.
  * Uploaded service key files are validated to ensure they contain valid JSON content before submission.
  * Updating a service connection now requires a non-empty Connector ID, with a helpful validation message if missing.
  * Improves form feedback and prevents invalid submissions during add/update flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->