### PR TITLE
fix(chat):  chat not showing after streaming 

### DIFF
--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -431,11 +431,14 @@ export const startStream = async (
         if (!old?.messages) return old
         
         // When streaming completes, consolidate all accumulated data (response, citations, thinking) into a final message object
-       // Save the complete assistant message to React Query cache to persist the conversation history
+        // Save the complete assistant message to React Query cache to persist the conversation history
+        // Use streamState.response if available (from CitationsUpdate for web search), otherwise use streamState.partial (from ResponseUpdate for regular chat)
+        const finalMessage = streamState.response || streamState.partial
+        
         const newAssistantMessage = {
           externalId: streamState.messageId,
           messageRole: "assistant",
-          message: streamState.response,
+          message: finalMessage,
           sources: streamState.sources,
           citationMap: streamState.citationMap,
           thinking: streamState.thinking,


### PR DESCRIPTION
### Description

- chat not showing after stream ends , which come due to this pr :https://github.com/xynehq/xyne/pull/768 
-  Use streamState.response if available (from CitationsUpdate for web search), otherwise use streamState.partial (from ResponseUpdate for regular chat)

### Testing

- tested locally




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the final assistant message is reliably populated at the end of a chat stream by falling back to the accumulated text when a finalized response isn’t available.
  * Prevents empty or missing messages in edge cases, improving conversation continuity and reliability.
  * No changes to public APIs or behavior of citations, sources, or attachments; only end-of-stream message selection is made more robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->