### PR TITLE
fix(knowledgemanagment): screen freeze fix 

### DIFF
--- a/frontend/src/routes/_authenticated/knowledgeManagement.tsx
+++ b/frontend/src/routes/_authenticated/knowledgeManagement.tsx
@@ -248,6 +248,8 @@ function RouteComponent() {
     savedState.uploadingCollectionName,
   )
 
+  const [openDropdown, setOpenDropdown] = useState<string | null>(null)
+
   // Save upload state to localStorage whenever it changes
   useEffect(() => {
     saveUploadState({
@@ -484,6 +486,7 @@ function RouteComponent() {
     setTargetFolder(null)
     setCollectionName("")
     setSelectedFiles([])
+    setOpenDropdown(null)
   }
 
   const handleUpload = async () => {
@@ -1166,7 +1169,10 @@ function RouteComponent() {
                             !isUploading && handleOpenAddFilesModal(collection)
                           }}
                         />
-                        <DropdownMenu>
+                        <DropdownMenu
+                          open={openDropdown === collection.id}
+                          onOpenChange={(open) => setOpenDropdown(open ? collection.id : null)}
+                        >
                           <DropdownMenuTrigger asChild>
                             <MoreHorizontal
                               size={16}
@@ -1188,8 +1194,10 @@ function RouteComponent() {
                             <DropdownMenuItem
                               onClick={(e) => {
                                 e.stopPropagation()
-                                !isUploading &&
+                                if (!isUploading) {
                                   setDeletingCollection(collection)
+                                  setOpenDropdown(null)
+                                }
                               }}
                               disabled={isUploading}
                             >


### PR DESCRIPTION
### Description

- when deleting kb or opening delete kb modal screen getting freezed , fixed it 

### Testing

- tested locally



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures only one collection dropdown can be open at a time for clearer navigation.
  * Automatically closes dropdowns after actions (e.g., delete, cancel) and when modals close to prevent stuck menus.
  * Maintains consistent dropdown state during uploads and edits to avoid overlapping or lingering menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->