### PR TITLE
fix:added the agent prompt to passed , while doing the web search

### DIFF
--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -1811,11 +1811,15 @@ export const webSearchQuestion = (
     params.webSearch = true
 
     if (!params.systemPrompt) {
-      params.systemPrompt = !isAgentPromptEmpty(params.agentPrompt)
-        ? webSearchSystemPrompt(userCtx) +
+      if (!isAgentPromptEmpty(params.agentPrompt)) {
+        const parsed = parseAgentPrompt(params.agentPrompt)
+        params.systemPrompt =
+          webSearchSystemPrompt(userCtx) +
           "\n\n" +
-          parseAgentPrompt(params.agentPrompt)
-        : webSearchSystemPrompt(userCtx)
+          `Name: ${parsed.name}\nDescription: ${parsed.description}\nPrompt: ${parsed.prompt}`
+      } else {
+        params.systemPrompt = webSearchSystemPrompt(userCtx)
+      }
     }
 
     const baseMessage: Message = {

--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -226,7 +226,7 @@ import {
   getPublicAgentsByUser,
   type SharedAgentUsageData,
 } from "@/db/sharedAgentUsage"
-import type {GroundingSupport } from "@google/genai"
+import type { GroundingSupport } from "@google/genai"
 
 const METADATA_NO_DOCUMENTS_FOUND = "METADATA_NO_DOCUMENTS_FOUND_INTERNAL"
 const METADATA_FALLBACK_TO_RAG = "METADATA_FALLBACK_TO_RAG_INTERNAL"
@@ -4082,7 +4082,7 @@ export const MessageApi = async (c: Context) => {
       enableWebSearch,
     }: MessageReqType = body
     const webSearchEnabled = enableWebSearch ?? false
-    const agentPromptValue = agentId && isCuid(agentId) ? agentId : undefined // Use undefined if not a valid CUID
+    let agentPromptValue = agentId && isCuid(agentId) ? agentId : undefined // Use undefined if not a valid CUID
     if (isAgentic && !enableWebSearch) {
       Logger.info(`Routing to MessageWithToolsApi`)
       return MessageWithToolsApi(c)
@@ -4103,6 +4103,7 @@ export const MessageApi = async (c: Context) => {
         agentPromptValue,
         userAndWorkspaceCheck.workspace.id,
       )
+      agentPromptValue = agentDetails?.prompt || agentPromptValue
       if (!isAgentic && !enableWebSearch && agentDetails) {
         Logger.info(`Routing to AgentMessageApi for agent ${agentPromptValue}.`)
         return AgentMessageApi(c)


### PR DESCRIPTION
### Description

Earlier we were not passing the agent prompt  while doing the websearch , which resulted in agent not respecting the prompt given to agent while its creation.
fix: added the agent prompt in final prompt construction

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved agent handling in chats: when an agent has a configured prompt, it’s now used consistently across routing and stored conversations for more reliable behavior.
  * Enhanced web search prompts: when an agent is used without a system prompt, a clear Name/Description/Prompt block is appended with proper spacing for better context.
* **Refactor**
  * Minor internal cleanup with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->