### PR TITLE
fix: multiple entity or app based query fix

### DIFF
--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -352,13 +352,13 @@ export const HybridDefaultProfile = (
     return `${
       app
         ? (Array.isArray(app) && app.length > 0)
-          ? `and ${app.map((a) => `app contains '${escapeYqlValue(a)}'`).join(" or ")}`
+          ? `and (${app.map((a) => `app contains '${escapeYqlValue(a)}'`).join(" or ")})`
           : "and app contains @app"
         : ""
     } ${
       entity
         ? Array.isArray(entity) && entity.length > 0
-          ? `and ${entity.map((e) => `entity contains '${escapeYqlValue(e)}'`).join(" or ")}`
+          ? `and (${entity.map((e) => `entity contains '${escapeYqlValue(e)}'`).join(" or ")})`
           : "and entity contains @entity"
         : ""
     }`.trim()


### PR DESCRIPTION
### Description
Earlier when multiple app or entity are passed to searchvespa , we joined them by 'or' condition 
now we added the multiple 'or' conditions inside the bracket


### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search filtering when selecting multiple apps or entities. OR conditions are now grouped correctly, ensuring results honor the intended AND/OR logic.
  * Resolves cases where searches returned too many or too few results under complex filters.
  * Improves accuracy and predictability of search outcomes across profiles, especially for hybrid queries using multiple app/entity selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->