### PR TITLE
fix(agents): during rag off all app integrations not showing

### DIFF
--- a/frontend/src/routes/_authenticated/admin/integrations/mcp.tsx
+++ b/frontend/src/routes/_authenticated/admin/integrations/mcp.tsx
@@ -959,7 +959,7 @@ export const MCPClient = ({
 
   return (
     <div className="flex w-full h-full">
-      <Sidebar photoLink={user?.photoLink ?? ""} role={user?.role} />
+      <Sidebar photoLink={user?.photoLink ?? ""} role={user?.role} isAgentMode={agentWhiteList} />
       <IntegrationsSidebar role={user.role} isAgentMode={agentWhiteList} />
       <div className="w-full h-full py-8 px-4 overflow-y-auto flex flex-col items-center justify-center">
         <div className="flex flex-col items-center">

--- a/frontend/src/routes/_authenticated/agent.tsx
+++ b/frontend/src/routes/_authenticated/agent.tsx
@@ -957,9 +957,6 @@ function AgentComponent() {
         icon: getIcon(Apps.DataSource, "datasource", { w: 16, h: 16, mr: 8 }),
       }),
     )
-    if (!isRagOn) {
-      return dynamicDataSources
-    }
 
     const collectionSources: IntegrationSource[] = fetchedCollections.map(
       (cl) => ({


### PR DESCRIPTION

### Description

- fix agent sidebar icon not showing  in mcp file 
- during rag off all app integrations not showing in agent form 

### Testing

- tested locally



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Sidebar now adapts to agent mode for a more context-aware navigation experience.

- Bug Fixes
  - Data sources list is now consistent across settings, always combining integrations, dynamic sources, and collections.
  - Prevents missing or partial sources when specific toggles are disabled, ensuring predictable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->