### PR TITLE
fix (History Modal) : padding and color fixed

### DIFF
--- a/frontend/src/components/HistoryModal.tsx
+++ b/frontend/src/components/HistoryModal.tsx
@@ -399,7 +399,7 @@ const HistoryModal = ({
 
   const renderChatList = (list: SelectPublicChat[]) => {
     return (
-      <ul>
+      <ul className="space-y-[4px]">
         {list.map((item, index) => (
           <li
             key={index}
@@ -407,7 +407,7 @@ const HistoryModal = ({
               item.externalId === existingChatId
                 ? "bg-[#EBEFF2] dark:bg-slate-700"
                 : ""
-            } hover:bg-[#EBEFF2] dark:hover:bg-slate-500 rounded-[6px] pt-[8px] pb-[8px] ml-[8px] mr-[8px] mb-[4px]`}
+            } ${item.externalId === existingChatId ? "" : "hover:bg-[#EBEFF2] dark:hover:bg-slate-500"} rounded-md py-2 mx-2`}
           >
             {isEditing && editedChatId === item.externalId ? (
               <input

--- a/frontend/src/components/HistoryModal.tsx
+++ b/frontend/src/components/HistoryModal.tsx
@@ -407,7 +407,7 @@ const HistoryModal = ({
               item.externalId === existingChatId
                 ? "bg-[#EBEFF2] dark:bg-slate-700"
                 : ""
-            } ${item.externalId === existingChatId ? "" : "hover:bg-[#EBEFF2] dark:hover:bg-slate-500"} rounded-md py-2 mx-2`}
+            } ${item.externalId === existingChatId ? "" : "hover:bg-[#EBEFF2] dark:hover:bg-slate-500"} rounded-md py-2 mx-2 mb-1`}
           >
             {isEditing && editedChatId === item.externalId ? (
               <input

--- a/frontend/src/components/HistoryModal.tsx
+++ b/frontend/src/components/HistoryModal.tsx
@@ -407,7 +407,7 @@ const HistoryModal = ({
               item.externalId === existingChatId
                 ? "bg-[#EBEFF2] dark:bg-slate-700"
                 : ""
-            } hover:bg-[#EBEFF2] dark:hover:bg-slate-700 rounded-[6px] pt-[8px] pb-[8px] ml-[8px] mr-[8px]`}
+            } hover:bg-[#EBEFF2] dark:hover:bg-slate-500 rounded-[6px] pt-[8px] pb-[8px] ml-[8px] mr-[8px] mb-[4px]`}
           >
             {isEditing && editedChatId === item.externalId ? (
               <input


### PR DESCRIPTION
### Description
- added padding and better color to history and favourite chats for better UI

### Testing
- tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Adjusted spacing and vertical separation for chat history items for clearer layout.
  - Removed the distinct active-item background so active rows now blend with the list; non-active rows show hover highlights only.
  - Updated dark-mode hover color for improved contrast, changed corner rounding, and refined paddings/margins.
  - Purely visual polish in the History modal with no behavior or data changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->