### PR TITLE
fix:Mail existance check in vespa

### DIFF
--- a/server/search/vespaClient.ts
+++ b/server/search/vespaClient.ts
@@ -1020,7 +1020,7 @@ class VespaClient {
     // Construct the YQL query using userMap with sameElement
     const yqlQuery = `select docId from mail where userMap contains sameElement(key contains "${email}", value contains "${docId}")`
 
-    const url = `${this.vespaEndpoint}/search/?yql=${encodeURIComponent(yqlQuery)}&hits=1`
+    const url = `${this.vespaEndpoint}/search/?yql=${encodeURIComponent(yqlQuery)}&hits=1&timeout=5s`
 
     try {
       const response = await this.fetchWithRetry(url, {


### PR DESCRIPTION
### Description

By default timeout was .5 sec , since finding a key value pair in map is time heavy,
which resulted in gateway timeout error, to avoid that changed the timeout to 5 seconds

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a 5s timeout on mail search requests to prevent indefinite waits when the backend is slow, improving responsiveness and stability.
* **Chores**
  * Updated search request configuration; no changes to user workflows or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->