### PR TITLE
update(vespa): default recency boost

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -210,4 +210,5 @@ export default {
   MAX_IMAGE_SIZE_BYTES,
   MAX_SERVICE_ACCOUNT_FILE_SIZE_BYTES,
   vespaEndpoint: `http://${vespaBaseHost}:8080`,
+  defaultRecencyDecayRate: 0.1, // Decay rate for recency scoring in Vespa searches
 }

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -81,12 +81,11 @@ export const searchVespa = async (
     )
     isSlackConnected =
       connector && connector.status === ConnectorStatus.Connected
-  } catch (error) {
-    Logger.error(error, "Error fetching Slack connector")
-  }
+  } catch (error) {}
 
   return await vespa.searchVespa.bind(vespa)(query, email, app, entity, {
     ...options,
+    recencyDecayRate: options.recencyDecayRate || 0.1,
     isSlackConnected,
   })
 }
@@ -107,7 +106,12 @@ export const searchVespaAgent = async (
     app,
     entity,
     AgentApps,
-    { ...options, driveIds, clVespaIds },
+    {
+      ...options,
+      driveIds,
+      clVespaIds,
+      recencyDecayRate: options.recencyDecayRate || 0.1,
+    },
   )
 }
 

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -85,7 +85,8 @@ export const searchVespa = async (
 
   return await vespa.searchVespa.bind(vespa)(query, email, app, entity, {
     ...options,
-    recencyDecayRate: options.recencyDecayRate || 0.1,
+    recencyDecayRate:
+      options.recencyDecayRate || config.defaultRecencyDecayRate,
     isSlackConnected,
   })
 }
@@ -110,7 +111,8 @@ export const searchVespaAgent = async (
       ...options,
       driveIds,
       clVespaIds,
-      recencyDecayRate: options.recencyDecayRate || 0.1,
+      recencyDecayRate:
+        options.recencyDecayRate || config.defaultRecencyDecayRate,
     },
   )
 }


### PR DESCRIPTION
### Description
- Set the default recency boost value to `0.1`

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Search results now include configurable recency weighting; newer content can be prioritized.
  - A default recency decay value is applied when no explicit setting is provided.

- Chores
  - Connector fetch errors are now handled silently to reduce noisy logs and improve runtime stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->