### PR TITLE
fix(citation preview): added back button in citation preview

### DIFF
--- a/frontend/src/components/CitationPreview.tsx
+++ b/frontend/src/components/CitationPreview.tsx
@@ -184,8 +184,7 @@ export const CitationPreview: React.FC<CitationPreviewProps> = React.memo(
             {showBackButton && onBackToSources && (
               <button
                 onClick={onBackToSources}
-                className="mr-4 p-2 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors rounded-md hover:bg-gray-100 dark:hover:bg-gray-800"
-                title="Back to sources"
+                className="mr-4 p-2 text-gray-600 dark:text-gray-300 transition-colors rounded-md"
               >
                 <ArrowLeft size={20} />
               </button>

--- a/frontend/src/components/CitationPreview.tsx
+++ b/frontend/src/components/CitationPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react"
-import { X, FileText, ExternalLink } from "lucide-react"
+import { X, FileText, ExternalLink, ArrowLeft } from "lucide-react"
 import { Citation } from "shared/types"
 import PdfViewer from "./PdfViewer"
 import DocxViewer from "./DocxViewer"
@@ -11,10 +11,12 @@ interface CitationPreviewProps {
   citation: Citation | null
   isOpen: boolean
   onClose: () => void
+  onBackToSources?: () => void
+  showBackButton?: boolean
 }
 
 export const CitationPreview: React.FC<CitationPreviewProps> = React.memo(
-  ({ citation, isOpen, onClose }) => {
+  ({ citation, isOpen, onClose, onBackToSources, showBackButton = false }) => {
     const [documentContent, setDocumentContent] = useState<Blob | null>(null)
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<string | null>(null)
@@ -178,20 +180,32 @@ export const CitationPreview: React.FC<CitationPreviewProps> = React.memo(
       <div className="fixed top-0 right-0 bottom-0 w-[47.5%] border-l border-gray-200 dark:border-gray-700 bg-white dark:bg-[#1E1E1E] flex flex-col z-50 shadow-lg">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-          <div className="flex-1 min-w-0">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white truncate">
-              {citation.title.split("/").pop() || "Document Preview"}
-            </h3>
-            {citation?.app && (
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                Source:{" "}
-                {citation.title.replace(/\/[^/]*$/, "") || "Unknown Source"}
-              </p>
+          <div className="flex items-center flex-1 min-w-0">
+            {showBackButton && onBackToSources && (
+              <button
+                onClick={onBackToSources}
+                className="mr-4 p-2 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors rounded-md hover:bg-gray-100 dark:hover:bg-gray-800"
+                title="Back to sources"
+              >
+                <ArrowLeft size={20} />
+              </button>
             )}
+            <div className="flex-1 min-w-0">
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white truncate">
+                {citation.title.split("/").pop() || "Document Preview"}
+              </h3>
+              {citation?.app && (
+                <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                  Source:{" "}
+                  {citation.title.replace(/\/[^/]*$/, "") || "Unknown Source"}
+                </p>
+              )}
+            </div>
           </div>
           <button
             onClick={onClose}
-            className="ml-4 p-2 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors"
+            className="ml-4 p-2 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 transition-colors rounded-md hover:bg-gray-100 dark:hover:bg-gray-800"
+            title="Close preview"
           >
             <X size={20} />
           </button>

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -473,6 +473,7 @@ export const ChatPage = ({
   const [selectedCitation, setSelectedCitation] = useState<Citation | null>(
     null,
   )
+  const [cameFromSources, setCameFromSources] = useState(false)
 
   // Compute disableRetry flag for retry buttons
   const disableRetry = isStreaming || retryIsStreaming || isSharedChat
@@ -1059,7 +1060,7 @@ export const ChatPage = ({
   }
 
   // Handler for citation clicks - moved before conditional returns
-  const handleCitationClick = useCallback((citation: Citation) => {
+  const handleCitationClick = useCallback((citation: Citation, fromSources: boolean = false) => {
     if (!citation || !citation.clId || !citation.itemId) {
       // For citations without clId or itemId, open as regular link
       if (citation.url) {
@@ -1069,17 +1070,36 @@ export const ChatPage = ({
     }
     setSelectedCitation(citation)
     setIsCitationPreviewOpen(true)
-    // Close sources panel when opening citation preview
-    setShowSources(false)
-    setCurrentCitations([])
-    setCurrentMessageId(null)
+    setCameFromSources(fromSources)
+    // Only close sources panel when opening citation preview, but preserve state for back navigation
+    if (fromSources) {
+      setShowSources(false)
+      // Don't clear currentCitations and currentMessageId when coming from sources
+    } else {
+      // Clear sources state when coming from inline citations
+      setShowSources(false)
+      setCurrentCitations([])
+      setCurrentMessageId(null)
+    }
   }, [])
 
   // Memoized callback for closing citation preview - moved before conditional returns
   const handleCloseCitationPreview = useCallback(() => {
     setIsCitationPreviewOpen(false)
     setSelectedCitation(null)
+    setCameFromSources(false)
   }, [])
+
+  // Handler for back to sources navigation
+  const handleBackToSources = useCallback(() => {
+    if (currentCitations.length > 0 && currentMessageId) {
+      // Re-open the sources panel with the previous state
+      setShowSources(true)
+      setIsCitationPreviewOpen(false)
+      setSelectedCitation(null)
+      setCameFromSources(false)
+    }
+  }, [currentCitations, currentMessageId])
 
   const scrollToBottom = () => {
     const container = messagesContainerRef.current
@@ -1400,6 +1420,8 @@ export const ChatPage = ({
         citation={selectedCitation}
         isOpen={isCitationPreviewOpen}
         onClose={handleCloseCitationPreview}
+        showBackButton={cameFromSources}
+        onBackToSources={handleBackToSources}
       />
     </div>
   )
@@ -1473,7 +1495,7 @@ const CitationList = ({
   onCitationClick,
 }: {
   citations: Citation[]
-  onCitationClick?: (citation: Citation) => void
+  onCitationClick?: (citation: Citation, fromSources?: boolean) => void
 }) => {
   return (
     <ul className={`mt-2`}>
@@ -1483,7 +1505,7 @@ const CitationList = ({
           className="border-[#E6EBF5] dark:border-gray-700 border-[1px] rounded-[10px] mt-[12px] w-[85%] cursor-pointer hover:border-gray-400 dark:hover:border-gray-500 transition-colors"
           onClick={(e) => {
             e.preventDefault()
-            onCitationClick?.(citation)
+            onCitationClick?.(citation, true)
           }}
         >
           <div className="flex pl-[12px] pt-[12px]">
@@ -1519,7 +1541,7 @@ const Sources = ({
   showSources: boolean
   citations: Citation[]
   closeSources: () => void
-  onCitationClick?: (citation: Citation) => void
+  onCitationClick?: (citation: Citation, fromSources?: boolean) => void
 }) => {
   return showSources ? (
     <div
@@ -1537,7 +1559,10 @@ const Sources = ({
         />
       </div>
       <div className="flex-1 overflow-y-auto px-[40px] pb-[24px]">
-        <CitationList citations={citations} onCitationClick={onCitationClick} />
+        <CitationList 
+          citations={citations} 
+          onCitationClick={(citation) => onCitationClick?.(citation, true)} 
+        />
       </div>
     </div>
   ) : null

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -1072,12 +1072,9 @@ export const ChatPage = ({
     setIsCitationPreviewOpen(true)
     setCameFromSources(fromSources)
     // Only close sources panel when opening citation preview, but preserve state for back navigation
-    if (fromSources) {
-      setShowSources(false)
-      // Don't clear currentCitations and currentMessageId when coming from sources
-    } else {
+    setShowSources(false)
+    if (!fromSources) {
       // Clear sources state when coming from inline citations
-      setShowSources(false)
       setCurrentCitations([])
       setCurrentMessageId(null)
     }
@@ -1559,10 +1556,7 @@ const Sources = ({
         />
       </div>
       <div className="flex-1 overflow-y-auto px-[40px] pb-[24px]">
-        <CitationList 
-          citations={citations} 
-          onCitationClick={(citation) => onCitationClick?.(citation, true)} 
-        />
+        <CitationList citations={citations} onCitationClick={onCitationClick} />
       </div>
     </div>
   ) : null


### PR DESCRIPTION
### Description

- added back button in citation preview

### Testing

- tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Back button in Citation Preview when opened from Sources to return to Sources without losing context.
  - Citation clicks now preserve source-panel state when coming from Sources, enabling consistent back-navigation.

- **Style**
  - Refreshed Citation Preview header to accommodate back button.
  - Improved Close button with rounded corners, hover background, and tooltip; back button includes a tooltip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->