### PR TITLE
Fixed file content retrieval: used wrong format for names

### DIFF
--- a/server/api/files.ts
+++ b/server/api/files.ts
@@ -403,7 +403,7 @@ export const handleAttachmentServe = async (c: Context) => {
 
     // Set appropriate headers
     c.header("Content-Type", fileType || "application/octet-stream")
-    c.header("Content-Disposition", `inline; filename="${fileName}"`)
+    c.header("Content-Disposition", `inline; filename*=UTF-8''${encodeURIComponent(fileName || 'file')}`)
     c.header("Cache-Control", "public, max-age=31536000") // Cache for 1 year
 
     // Stream the file

--- a/server/api/knowledgeBase.ts
+++ b/server/api/knowledgeBase.ts
@@ -1660,7 +1660,7 @@ export const GetFileContentApi = async (c: Context) => {
     return new Response(new Uint8Array(fileContent), {
       headers: {
         "Content-Type": collectionFile.mimeType || "application/octet-stream",
-        "Content-Disposition": `inline; filename="${collectionFile.originalName}"`,
+        "Content-Disposition": `inline; filename*=UTF-8''${encodeURIComponent(collectionFile.originalName || 'file')}`,
         "Cache-Control": "private, max-age=3600",
       },
     })


### PR DESCRIPTION
### Description

<!-- Summarize the changes in this PR. -->
<!-- Explain the purpose of the change (e.g., bug fix, feature, refactor). -->
<!-- Describe how this change affects the system or users. -->

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserves non‑ASCII characters in downloaded and inline file names by using RFC 5987 encoding.
  - Prevents garbled or quoted filenames across browsers when serving attachments and file previews.
  - Applies consistent UTF‑8 handling with a safe fallback name when original filenames are missing.

- **Chores**
  - Improved HTTP header formatting for file responses without altering existing behavior or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->