### PR TITLE
Workflow Refresh Issue fixed

### DIFF
--- a/frontend/src/components/workflow/WorkflowBuilder.tsx
+++ b/frontend/src/components/workflow/WorkflowBuilder.tsx
@@ -1120,12 +1120,14 @@ const StepNode: React.FC<NodeProps> = ({
 // Header component
 const Header = ({
   onBackToWorkflows,
+  onRefreshWorkflows,
   workflowName,
   selectedTemplate,
   onWorkflowNameChange,
   isEditable = true,
 }: { 
   onBackToWorkflows?: () => void; 
+  onRefreshWorkflows?: () => void;
   workflowName?: string;
   selectedTemplate?: WorkflowTemplate | null;
   onWorkflowNameChange?: (newName: string) => void;
@@ -1176,7 +1178,10 @@ const Header = ({
       <div className="text-slate-500 dark:text-gray-400 text-sm font-normal leading-5">
         <span
           className="cursor-pointer hover:text-slate-700 dark:hover:text-gray-300"
-          onClick={onBackToWorkflows}
+          onClick={() => {
+            onBackToWorkflows?.()
+            onRefreshWorkflows?.()
+          }}
         >
           Workflow
         </span>
@@ -1774,6 +1779,7 @@ interface WorkflowBuilderProps {
   onStepClick?: (step: Step) => void
   user?: UserDetail
   onBackToWorkflows?: () => void
+  onRefreshWorkflows?: () => void
   selectedTemplate?: WorkflowTemplate | null
   isLoadingTemplate?: boolean
   isEditableMode?: boolean
@@ -1785,6 +1791,7 @@ interface WorkflowBuilderProps {
 const WorkflowBuilderInternal: React.FC<WorkflowBuilderProps> = ({
   onStepClick,
   onBackToWorkflows,
+  onRefreshWorkflows,
   selectedTemplate,
   isLoadingTemplate,
   isEditableMode,
@@ -3181,6 +3188,7 @@ const WorkflowBuilderInternal: React.FC<WorkflowBuilderProps> = ({
       {/* Header */}
       <Header
         onBackToWorkflows={onBackToWorkflows}
+        onRefreshWorkflows={onRefreshWorkflows}
         workflowName={getWorkflowName()}
         selectedTemplate={selectedTemplate}
         onWorkflowNameChange={handleWorkflowNameChange}

--- a/frontend/src/routes/_authenticated/workflow.tsx
+++ b/frontend/src/routes/_authenticated/workflow.tsx
@@ -955,6 +955,7 @@ function WorkflowComponent() {
                     setIsExecutionMode(false)
                     setIsBuilderMode(true) // Reset to builder mode
                   }}
+                  onRefreshWorkflows={fetchWorkflows}
                   selectedTemplate={selectedTemplate}
                   isLoadingTemplate={isLoadingTemplate}
                   isEditableMode={selectedTemplate === null}


### PR DESCRIPTION
### Description

<!-- Summarize the changes in this PR. -->
<!-- Explain the purpose of the change (e.g., bug fix, feature, refactor). -->
<!-- Describe how this change affects the system or users. -->

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Workflow list can be refreshed automatically when navigating back from the Workflow Builder (e.g., via the breadcrumb); this is enabled when the parent view supplies a refresh callback.

- Improvements
  - Back-navigation in builder headers now triggers an optional refresh, providing a more consistent return to the workflows list while preserving existing behavior when no callback is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->