### PR TITLE
feat(docker): add GPU support and configurable metrics port (#884)

### DIFF
--- a/deployment/Dockerfile-vespa-gpu
+++ b/deployment/Dockerfile-vespa-gpu
@@ -1,14 +1,14 @@
-FROM vespaengine/vespa:latest
-
+FROM vespaengine/vespa:8.514.24
 # Switch to root to install packages
 USER root
-
 # Install CUDA-enabled ONNX runtime for Vespa
 # Using dnf directly as it's the package manager in the base image
-RUN dnf -y install dnf-plugins-core && \
-    dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo && \
-    dnf -y install vespa-onnxruntime-cuda && \
+RUN dnf -y install dnf-plugins-core
+RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo \
+ && dnf -y install cuda-libraries-12-2 \
+ && dnf clean all
+RUN curl -1sLf 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/setup.rpm.sh' | bash && \
+    dnf -y install vespa-onnxruntime-cuda-1.20.1 && \
     dnf clean all
-
 # Switch back to vespa user (UID 1000 is typical for vespaengine/vespa)
 USER 1000

--- a/deployment/docker-compose.dev.yml
+++ b/deployment/docker-compose.dev.yml
@@ -23,11 +23,17 @@ services:
     container_name: xyne-prometheus
     user: "65534:65534"
     volumes:
-      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-selfhosted.yml
+      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-template.yml
     ports:
     - "9090:9090"
+    environment:
+      - METRICS_PORT=${METRICS_PORT:-3001}
     command:
-      - "--config.file=/etc/prometheus/prometheus-selfhosted.yml"
+      - sh
+      - -c
+      - |
+        envsubst < /etc/prometheus/prometheus-template.yml > /etc/prometheus/prometheus.yml
+        exec prometheus --config.file=/etc/prometheus/prometheus.yml
     restart: always
     networks:
       - xyne

--- a/deployment/docker-compose.gpu.yml
+++ b/deployment/docker-compose.gpu.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   vespa:
-    image: xyne/vespa-gpu # Uses the custom GPU-enabled Vespa image
+    image: xyne/vespa-gpu:8.514 # Uses the custom GPU-enabled Vespa image
     runtime: nvidia
     deploy:
       resources:

--- a/deployment/docker-compose.metrics.yml
+++ b/deployment/docker-compose.metrics.yml
@@ -6,11 +6,17 @@ services:
     container_name: xyne-prometheus
     user: "65534:65534"
     volumes:
-      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-selfhosted.yml
+      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-template.yml
     ports:
     - "9090:9090"
+    environment:
+      - METRICS_PORT=${METRICS_PORT:-3001}
     command:
-      - "--config.file=/etc/prometheus/prometheus-selfhosted.yml"
+      - sh
+      - -c
+      - |
+        envsubst < /etc/prometheus/prometheus-template.yml > /etc/prometheus/prometheus.yml
+        exec prometheus --config.file=/etc/prometheus/prometheus.yml
     networks:
       - xyne
     extra_hosts:

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -23,11 +23,17 @@ services:
     container_name: xyne-prometheus
     user: "65534:65534"
     volumes:
-      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-selfhosted.yml
+      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-template.yml
     ports:
     - "9090:9090"
+    environment:
+      - METRICS_PORT=${METRICS_PORT:-3001}
     command:
-      - "--config.file=/etc/prometheus/prometheus-selfhosted.yml"
+      - sh
+      - -c
+      - |
+        envsubst < /etc/prometheus/prometheus-template.yml > /etc/prometheus/prometheus.yml
+        exec prometheus --config.file=/etc/prometheus/prometheus.yml
     restart: always
     networks:
       - xyne

--- a/deployment/docker-compose.selfhost.yml
+++ b/deployment/docker-compose.selfhost.yml
@@ -43,11 +43,17 @@ services:
     container_name: xyne-prometheus
     user: "65534:65534"
     volumes:
-      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-selfhosted.yml
+      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-template.yml
     ports:
       - "9090:9090"
+    environment:
+      - METRICS_PORT=${METRICS_PORT:-3001}
     command:
-      - "--config.file=/etc/prometheus/prometheus-selfhosted.yml"
+      - sh
+      - -c
+      - |
+        envsubst < /etc/prometheus/prometheus-template.yml > /etc/prometheus/prometheus.yml
+        exec prometheus --config.file=/etc/prometheus/prometheus.yml
     restart: always
     networks:
       - xyne

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -44,11 +44,17 @@ services:
     container_name: xyne-prometheus
     user: "65534:65534"
     volumes:
-      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-selfhosted.yml
+      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-template.yml
     ports:
       - "9090:9090"
+    environment:
+      - METRICS_PORT=${METRICS_PORT:-3001}
     command:
-      - "--config.file=/etc/prometheus/prometheus-selfhosted.yml"
+      - sh
+      - -c
+      - |
+        envsubst < /etc/prometheus/prometheus-template.yml > /etc/prometheus/prometheus.yml
+        exec prometheus --config.file=/etc/prometheus/prometheus.yml
     restart: always
     networks:
       - xyne

--- a/deployment/prometheus-selfhosted.yml
+++ b/deployment/prometheus-selfhosted.yml
@@ -9,7 +9,7 @@ scrape_configs:
     metrics_path: /metrics  # default path in your Hono app
     scrape_interval: 2s
     static_configs:
-      - targets: ['host.docker.internal:3001'] #replace  with your application's service name e.g. 'xyne-app:3000' or the host-name:port where your server is hosted
+      - targets: ['host.docker.internal:${METRICS_PORT:-3001}'] #replace  with your application's service name e.g. 'xyne-app:3000' or the host-name:port where your server is hosted
   # - job_name: 'pm2'
   #   metrics_path: /
   #   scrape_interval: 2s

--- a/server/vespa/deploy.sh
+++ b/server/vespa/deploy.sh
@@ -53,8 +53,8 @@ fi
 
 
 echo "Deploying vespa..."
-vespa deploy --wait 960 --target http://${VESPA_HOST}:19071
+${VESPA_CLI_PATH:-vespa} deploy --wait 960
 echo "Restarting vespa...."
 docker restart vespa
 # vespa destroy
-vespa status --wait 75 --target http://${VESPA_HOST}:19071
+${VESPA_CLI_PATH:-vespa} status --wait 75

--- a/server/vespa/validation-overrides.xml
+++ b/server/vespa/validation-overrides.xml
@@ -2,4 +2,5 @@
   <allow until="2025-04-25">indexing-change</allow>
   <allow until='2025-04-25'>field-type-change</allow>
   <allow until='2025-04-25'>global-document-change</allow> 
+  <allow until='2025-08-25'>schema-removal</allow>
 </validation-overrides>


### PR DESCRIPTION
- Bump Vespa base image to 8.514.24
- Split DNF install into separate steps and install CUDA libraries
- Pin onnxruntime-cu118 to 1.20.1
- Mount Prometheus config as a template and inject METRICS_PORT via envsubst (default 3001)
- Expose METRICS_PORT as an environment variable to the container
- Update deployment script to accept optional VESPA_CLI_PATH and remove hard‑coded host/port
- Add validation override for schema‑removal

### Description

<!-- Summarize the changes in this PR. -->
<!-- Explain the purpose of the change (e.g., bug fix, feature, refactor). -->
<!-- Describe how this change affects the system or users. -->

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
