### PR TITLE
Uat server fix (#892)

### DIFF
--- a/deployment/portable/deploy.sh
+++ b/deployment/portable/deploy.sh
@@ -202,19 +202,26 @@ setup_permissions() {
     USER_UID="1000"
     USER_GID="1000"
 
-    # Use busybox containers to set permissions without requiring sudo
-    docker run --rm -v "$(pwd)/$DATA_DIR/postgres-data:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
-    docker run --rm -v "$(pwd)/$DATA_DIR/vespa-data:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
-    docker run --rm -v "$(pwd)/$DATA_DIR/vespa-models:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
-    docker run --rm -v "$(pwd)/$DATA_DIR/app-uploads:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
-    docker run --rm -v "$(pwd)/$DATA_DIR/app-logs:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
-    docker run --rm -v "$(pwd)/$DATA_DIR/app-assets:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
-    docker run --rm -v "$(pwd)/$DATA_DIR/app-migrations:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
-    docker run --rm -v "$(pwd)/$DATA_DIR/app-downloads:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
-    docker run --rm -v "$(pwd)/$DATA_DIR/grafana-storage:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
-    docker run --rm -v "$(pwd)/$DATA_DIR/ollama-data:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
+    # Directories that need standard 1000:1000 ownership
+    STANDARD_DIRS=(
+        "postgres-data"
+        "vespa-data"
+        "vespa-models"
+        "app-uploads"
+        "app-logs"
+        "app-assets"
+        "app-migrations"
+        "app-downloads"
+        "grafana-storage"
+        "ollama-data"
+    )
 
-    # Initialize prometheus and loki directories with correct permissions
+    # Use busybox containers to set permissions without requiring sudo
+    for dir in "${STANDARD_DIRS[@]}"; do
+        docker run --rm -v "$(pwd)/$DATA_DIR/$dir:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
+    done
+
+    # Special directories with custom ownership requirements
     docker run --rm -v "$(pwd)/$DATA_DIR/prometheus-data:/data" busybox sh -c 'mkdir -p /data && chown -R 65534:65534 /data' 2>/dev/null || true
     docker run --rm -v "$(pwd)/$DATA_DIR/loki-data:/data" busybox sh -c 'mkdir -p /data && chown -R 10001:10001 /data' 2>/dev/null || true
     docker run --rm -v "$(pwd)/$DATA_DIR/promtail-data:/data" busybox sh -c 'mkdir -p /data && chown -R 10001:10001 /data' 2>/dev/null || true

--- a/deployment/portable/deploy.sh
+++ b/deployment/portable/deploy.sh
@@ -132,8 +132,8 @@ setup_environment() {
     
     # Create necessary directories with proper permissions
     echo " Creating data directories..."
-    mkdir -p "$DATA_DIR"/{postgres-data,vespa-data,app-uploads,app-logs,app-assets,app-migrations,app-downloads,grafana-storage,loki-data,promtail-data,prometheus-data,ollama-data}
-    
+    mkdir -p "$DATA_DIR"/{postgres-data,vespa-data,app-uploads,app-logs,app-assets,app-migrations,app-downloads,grafana-storage,loki-data,promtail-data,prometheus-data,ollama-data,vespa-models}
+
     # Create Vespa tmp directory
     mkdir -p "$DATA_DIR"/vespa-data/tmp
     
@@ -197,14 +197,15 @@ setup_environment() {
 
 setup_permissions() {
     echo -e "${YELLOW} Setting directory permissions using Docker containers...${NC}"
-    
+
     # Set UID and GID to 1000 to avoid permission issues
     USER_UID="1000"
     USER_GID="1000"
-    
+
     # Use busybox containers to set permissions without requiring sudo
     docker run --rm -v "$(pwd)/$DATA_DIR/postgres-data:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
     docker run --rm -v "$(pwd)/$DATA_DIR/vespa-data:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
+    docker run --rm -v "$(pwd)/$DATA_DIR/vespa-models:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
     docker run --rm -v "$(pwd)/$DATA_DIR/app-uploads:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
     docker run --rm -v "$(pwd)/$DATA_DIR/app-logs:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
     docker run --rm -v "$(pwd)/$DATA_DIR/app-assets:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
@@ -212,12 +213,12 @@ setup_permissions() {
     docker run --rm -v "$(pwd)/$DATA_DIR/app-downloads:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
     docker run --rm -v "$(pwd)/$DATA_DIR/grafana-storage:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
     docker run --rm -v "$(pwd)/$DATA_DIR/ollama-data:/data" busybox chown -R "$USER_UID:$USER_GID" /data 2>/dev/null || true
-    
+
     # Initialize prometheus and loki directories with correct permissions
     docker run --rm -v "$(pwd)/$DATA_DIR/prometheus-data:/data" busybox sh -c 'mkdir -p /data && chown -R 65534:65534 /data' 2>/dev/null || true
     docker run --rm -v "$(pwd)/$DATA_DIR/loki-data:/data" busybox sh -c 'mkdir -p /data && chown -R 10001:10001 /data' 2>/dev/null || true
     docker run --rm -v "$(pwd)/$DATA_DIR/promtail-data:/data" busybox sh -c 'mkdir -p /data && chown -R 10001:10001 /data' 2>/dev/null || true
-    
+
     echo -e "${GREEN} Permissions configured${NC}"
 }
 
@@ -284,7 +285,15 @@ update_app() {
 update_infrastructure() {
     echo -e "${YELLOW} Updating infrastructure services...${NC}"
     INFRA_COMPOSE=$(get_infrastructure_compose)
-    docker-compose -f docker-compose.yml -f "$INFRA_COMPOSE" pull
+
+    # Setup environment and permissions first
+    setup_environment
+    setup_permissions
+
+    # Pull images that are available in registries (ignore failures for custom builds)
+    docker-compose -f docker-compose.yml -f "$INFRA_COMPOSE" pull || echo -e "${YELLOW}Some images require building (this is normal for custom images)${NC}"
+
+    # Build and start all services (--build will handle custom images)
     docker-compose -f docker-compose.yml -f "$INFRA_COMPOSE" up -d --force-recreate --build
     echo -e "${GREEN} Infrastructure services updated${NC}"
 }

--- a/deployment/portable/docker-compose.app.yml
+++ b/deployment/portable/docker-compose.app.yml
@@ -39,7 +39,6 @@ services:
       - NODE_ENV=production
       - DATABASE_HOST=xyne-db
       - VESPA_HOST=vespa
-      - HOST=http://localhost
     volumes:
       # Application data volumes
       - ${XYNE_DATA_DIR:-./data}/app-uploads:/usr/src/app/server/storage

--- a/deployment/portable/docker-compose.infrastructure-cpu.yml
+++ b/deployment/portable/docker-compose.infrastructure-cpu.yml
@@ -93,6 +93,10 @@ services:
     depends_on:
       vespa:
         condition: service_healthy
+    environment:
+      - VESPA_CONFIGSERVERS=vespa
+    volumes:
+      - ${XYNE_DATA_DIR:-./data}/vespa-models:/app/vespa/models
     networks:
       - xyne
     restart: "no"

--- a/deployment/portable/docker-compose.infrastructure.yml
+++ b/deployment/portable/docker-compose.infrastructure.yml
@@ -102,6 +102,10 @@ services:
     depends_on:
       vespa:
         condition: service_healthy
+    environment:
+      - VESPA_CONFIGSERVERS=vespa
+    volumes:
+      - ${XYNE_DATA_DIR:-./data}/vespa-models:/app/vespa/models
     networks:
       - xyne
     restart: "no"

--- a/deployment/portable/vespa-deploy/Dockerfile
+++ b/deployment/portable/vespa-deploy/Dockerfile
@@ -1,17 +1,28 @@
-FROM curlimages/curl:latest
+FROM vespaengine/vespa:latest
 
 # Switch to root user to install packages and set permissions
 USER root
 
-# Install bash and other necessary tools
-RUN apk add --no-cache bash
+# Install required packages for bun installation
+RUN dnf -y install curl unzip
+
+# Install bun globally
+RUN curl -fsSL https://bun.sh/install | bash && \
+    mv /root/.bun/bin/bun /usr/local/bin/bun && \
+    chmod +x /usr/local/bin/bun
 
 WORKDIR /app/vespa
 
 # Copy the vespa server code (relative to project root build context)
 COPY server/vespa .
 
-# Make the script executable
-RUN chmod +x deploy-docker.sh
+# Make the script executable and ensure vespa user owns the directory
+RUN chmod +x deploy-docker.sh && \
+    chown -R vespa:vespa /app/vespa
 
+# Switch back to vespa user
+USER vespa
+
+# Override the default entrypoint to run our script directly
+ENTRYPOINT []
 CMD ["./deploy-docker.sh"]

--- a/server/vespa/deploy-docker.sh
+++ b/server/vespa/deploy-docker.sh
@@ -1,6 +1,6 @@
+#!/bin/sh
 ## FOR DOCKER ENV
 
-#!/bin/sh
 set -e
 
 mkdir -p models


### PR DESCRIPTION
* chore(deploy): simplify compose pull/build logic and clean env var

- Add second `docker‑compose pull` that ignores failures for images that must be built locally.
- Use `--build` flag in `docker‑compose up` to guarantee custom images are rebuilt when needed.
- Replace commented‑out line with explanatory comments describing pull/build behavior.
- Remove `HOST=http://localhost` from `docker‑compose.app.yml` to avoid environment conflicts.

* fix(dockerfile): add unzip and Bun runtime

- Install unzip to extract ZIP archives
- Install Bun JavaScript runtime
- Add Bun binary directory to PATH for deployment scripts

* refactor(docker): rewrite Dockerfile to use vespaengine/vespa:latest base image

- Switch base image from curlimages/curl to vespaengine/vespa:latest
- Install curl and unzip with dnf
- Add Bun via its installer and update PATH
- Switch back to the vespa user to avoid permission issues
- Set WORKDIR for Vespa services and user‑constrained context

* fix(Dockerfile): make deploy script executable before switching to non‑root user

- Perform `chmod +x deploy-docker.sh` while still running as root
- Delay switching to `vespa` until after the chmod
- Prevents permission restrictions that previously blocked making the script executable
- Maintains non‑root user for container runtime

* fix(portable-docker): add VESPA_CONFIGSERVERS env var to configserver

- Add `environment` section to configserver service in portable Docker‑Compose files
- Set `VESPA_CONFIGSERVERS=vespa` to force the configserver to use itself as the config host
- Fixes networking/initialization issue in portable deployments by ensuring proper service discovery and configuration during startup

* fix(dockerfile): clear inherited entrypoint in vespa-deploy image

- Add `ENTRYPOINT []` after switching to the `vespa` user and before `CMD ["./deploy-docker.sh"]`.
- Remove any default entrypoint that could override the intended script.
- Ensure `deploy-docker.sh` runs as the container’s main process for predictable execution.

* fix(scripts): remove stray shebang and restore single `#!/bin/sh`

- removed duplicate shebang from the middle of the script
- added the correct shebang at the top of the file
- ensured only one interpreter directive is present
- preserved the existing `set -e` guard and `mkdir -p models` lines
- guarantees clean execution under the intended shell

* fix(docker): add vespa-models directory and mount into container

- Create `vespa-models` folder for persistent Vespa model storage
- Mount `vespa-models` into the Vespa container at `/app/vespa/models`
- Mark the deployment script executable
- Chown `/app/vespa` to the `vespa` user to prevent permission issues
- Ensure models survive container restarts and run with correct ownership

* chore(docker): install bun globally in Dockerfile

- Move bun binary to /usr/local/bin
- Remove reliance on /root/.bun/bin in PATH
- Ensure bun is available system-wide inside container
- Simplify script execution and improve reproducibility

* fix(setup_permissions): set UID/GID for Vespa model data directory

- Add docker‑run command to set ownership of $DATA_DIR/vespa-models to 1000:1000
- Align permissions with other data volumes to avoid permission errors during deployment
- Minor whitespace adjustments for readability

* fix(deploy): add environment and permission setup before image pull

- Invoke `setup_environment` before pulling Docker images
- Invoke `setup_permissions` before pulling Docker images
- Ensures the deployment environment is properly configured
- Sets file‑system permissions ahead of image operations
- Reduces risk of runtime failures caused by missing or incorrect environment settings

### Description

<!-- Summarize the changes in this PR. -->
<!-- Explain the purpose of the change (e.g., bug fix, feature, refactor). -->
<!-- Describe how this change affects the system or users. -->

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vespa deployment now mounts a dedicated models directory and is configured to use a Vespa config server; services start with automatic rebuilds to pick up custom images.
* **Bug Fixes**
  * Removed a conflicting HOST environment variable from the app service to prevent binding issues.
* **Chores**
  * Deployment now prepares environment and permissions (single ownership setup) before pulling images; image pulls tolerate missing images.
* **Style**
  * Minor script shebang cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->