### PR TITLE
fix: fixed history model to not show document chats

### DIFF
--- a/frontend/src/components/DocumentChat.tsx
+++ b/frontend/src/components/DocumentChat.tsx
@@ -573,16 +573,17 @@ import React, {
       agentIdFromChatBox?: string | null,
       toolsList?: ToolsListItem[] | null,
       selectedModel?: string,
+      selectedKbItems: string[] = [],
     ) => {
       if (!messageToSend || isStreaming || retryIsStreaming) return
   
       setUserHasScrolled(false)
       setQuery("")
   
-      // Automatically add the document ID to selected sources
-      const sourcesWithDocument = [...selectedSources]
-      if (!sourcesWithDocument.includes(documentId)) {
-        sourcesWithDocument.push(documentId)
+      // Automatically add the document ID to selected Kbitems
+      const kbItemsWithChat = [...selectedKbItems]
+      if (!kbItemsWithChat.includes(documentId)) {
+        kbItemsWithChat.push(documentId)
       }
   
       // Add user message optimistically to React Query cache with display text
@@ -604,12 +605,13 @@ import React, {
       try {
         await startStream(
           messageToSend,
-          sourcesWithDocument, // Use the sources array that includes the document ID
+          [],
           false, // isAgenticMode
           null,
           [],
           metadata,
           selectedModel,
+          kbItemsWithChat,
         )
       } catch (error) {
         // If there's an error, clear the optimistically added message from cache
@@ -641,15 +643,15 @@ import React, {
       }
     }
 
-    const handleRetry = async (messageId: string, selectedSources: string[] = [],) => {
+    const handleRetry = async (messageId: string, selectedKbItems: string[] = [],) => {
       if (!messageId || isStreaming) return
       setRetryIsStreaming(true)
-      // Automatically add the document ID to selected sources
-      const sourcesWithDocument = [...selectedSources]
-      if (!sourcesWithDocument.includes(documentId)) {
-        sourcesWithDocument.push(documentId)
+      // Automatically add the document ID to selected kbitems
+      const kbItemsWithChat = [...selectedKbItems]
+      if (!kbItemsWithChat.includes(documentId)) {
+        kbItemsWithChat.push(documentId)
       }
-      await retryMessage(messageId, false, undefined, undefined, sourcesWithDocument)
+      await retryMessage(messageId, false, undefined, undefined, [], kbItemsWithChat)
     }
   
     // Handle feedback

--- a/frontend/src/components/PdfViewer.tsx
+++ b/frontend/src/components/PdfViewer.tsx
@@ -474,7 +474,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
 
       {/* Navigation Controls */}
       {!loading && !error && numPages && showNavigation && (
-        <div className="sticky top-0 bg-white dark:bg-[#1E1E1E] shadow-md z-20 p-4 border-b border-gray-200 dark:border-gray-700 w-full">
+        <div className="sticky top-0 bg-white dark:bg-[#1E1E1E] shadow-md z-10 p-4 border-b border-gray-200 dark:border-gray-700 w-full">
           <div className="flex items-center justify-center">
             <div className="flex items-center bg-gray-100 dark:bg-gray-700 rounded-lg px-4 py-2 shadow-sm">
               {/* Previous Page Button */}

--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -257,6 +257,7 @@ export const startStream = async (
   preventNavigation?: boolean,
   setChatId?: (chatId: string) => void,
   selectedModel?: string,
+  selectedKbItems: string[] = [],
 ): Promise<void> => {
   if (!messageToSend) return
 
@@ -309,9 +310,9 @@ export const startStream = async (
     }
   }
 
-  // Add selectedSources parameter if provided
-  if (selectedSources && selectedSources.length > 0) {
-    url.searchParams.append("selectedSources", JSON.stringify(selectedSources))
+  // Add selectedKbItems parameter if provided
+  if (selectedKbItems && selectedKbItems.length > 0) {
+    url.searchParams.append("selectedKbItems", JSON.stringify(selectedKbItems))
   }
 
   if (modelConfig) {
@@ -750,6 +751,7 @@ export const useChatStream = (
       toolsList?: ToolsListItem[],
       metadata?: AttachmentMetadata[],
       selectedModel?: string,
+      selectedKbItems: string[] = [],
     ) => {
       const streamKey = currentStreamKey
 
@@ -767,6 +769,7 @@ export const useChatStream = (
         preventNavigation,
         setChatId,
         selectedModel,
+        selectedKbItems,
       )
 
       setStreamInfo(getStreamState(streamKey))
@@ -793,6 +796,7 @@ export const useChatStream = (
       attachmentFileIds?: string[],
       selectedModelConfig?: string | null,
       selectedSources: string[] = [],
+      selectedKbItems: string[] = [],
     ) => {
       if (!messageId) return
 
@@ -900,9 +904,9 @@ export const useChatStream = (
           attachmentFileIds.join(","),
         )
       }
-      // Add selectedSources parameter if provided
-      if (selectedSources && selectedSources.length > 0) {
-        url.searchParams.append("selectedSources", JSON.stringify(selectedSources))
+      // Add selectedKbItems parameter if provided
+      if (selectedKbItems && selectedKbItems.length > 0) {
+        url.searchParams.append("selectedKbItems", JSON.stringify(selectedKbItems))
       }
 
       let eventSource: EventSource

--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -5789,8 +5789,8 @@ export const MessageRetryApi = async (c: Context) => {
     const ctx = userContext(userAndWorkspace)
 
     // Extract sources from search parameters
-    const sources = c.req.query("selectedSources")
-    const isMsgWithSources = !!sources
+    const kbItems = c.req.query("selectedKbItems")
+    const isMsgWithKbItems = !!kbItems
 
     let newCitations: Citation[] = []
     // the last message before our assistant's message was the user's message
@@ -5887,7 +5887,7 @@ export const MessageRetryApi = async (c: Context) => {
               threadIds,
               ImageAttachmentFileIds,
               undefined,
-              isMsgWithSources,
+              isMsgWithKbItems,
               modelId,
             )
             stream.writeSSE({

--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -4251,7 +4251,7 @@ export const MessageApi = async (c: Context) => {
             title: "Untitled",
             attachments: [],
             agentId: agentPromptValue,
-            documentChat: isMsgWithSources || false,
+            kbChat: isMsgWithSources || false,
           })
 
           const insertedMsg = await insertMessage(tx, {

--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -58,6 +58,7 @@ import {
   selectPublicMessagesSchema,
   selectMessageSchema,
   sharedChats,
+  ChatType,
   type SelectChat,
   type SelectMessage,
 } from "@/db/schema"
@@ -4251,7 +4252,7 @@ export const MessageApi = async (c: Context) => {
             title: "Untitled",
             attachments: [],
             agentId: agentPromptValue,
-            isKbChat: isMsgWithKbItems || false,
+            chatType: isMsgWithKbItems ? ChatType.KbChat : ChatType.Default,
           })
 
           const insertedMsg = await insertMessage(tx, {

--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -4193,12 +4193,12 @@ export const MessageApi = async (c: Context) => {
     rootSpan.setAttribute("message", message)
 
     // Extract sources from search parameters
-    const sources = c.req.query("selectedSources")
-    const isMsgWithSources = !!sources
+    const kbItems = c.req.query("selectedKbItems")
+    const isMsgWithKbItems = !!kbItems
     let fileIds: string[] = []
-    if (sources) {
+    if (kbItems) {
       try {
-        const resp = await getCollectionFilesVespaIds(JSON.parse(sources), db)
+        const resp = await getCollectionFilesVespaIds(JSON.parse(kbItems), db)
         fileIds = resp
           .map((file) => file.vespaDocId || "")
           .filter((id) => id !== "")
@@ -4251,7 +4251,7 @@ export const MessageApi = async (c: Context) => {
             title: "Untitled",
             attachments: [],
             agentId: agentPromptValue,
-            kbChat: isMsgWithSources || false,
+            isKbChat: isMsgWithKbItems || false,
           })
 
           const insertedMsg = await insertMessage(tx, {
@@ -4433,7 +4433,7 @@ export const MessageApi = async (c: Context) => {
               threadIds,
               imageAttachmentFileIds,
               agentPromptValue,
-              isMsgWithSources,
+              isMsgWithKbItems,
               actualModelId || config.defaultBestModel,
             )
             stream.writeSSE({

--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -4251,6 +4251,7 @@ export const MessageApi = async (c: Context) => {
             title: "Untitled",
             attachments: [],
             agentId: agentPromptValue,
+            documentChat: isMsgWithSources || false,
           })
 
           const insertedMsg = await insertMessage(tx, {

--- a/server/db/chat.ts
+++ b/server/db/chat.ts
@@ -168,7 +168,11 @@ export const getPublicChats = async (
   offset: number,
   timeRange?: { from?: Date; to?: Date },
 ): Promise<SelectPublicChat[]> => {
-  const conditions = [eq(chats.email, email), eq(chats.isBookmarked, false)]
+  const conditions = [
+    eq(chats.email, email),
+    eq(chats.isBookmarked, false),
+    eq(chats.documentChat, false),
+  ]
 
   if (timeRange?.from) {
     conditions.push(gte(chats.createdAt, timeRange.from))

--- a/server/db/chat.ts
+++ b/server/db/chat.ts
@@ -171,7 +171,7 @@ export const getPublicChats = async (
   const conditions = [
     eq(chats.email, email),
     eq(chats.isBookmarked, false),
-    eq(chats.kbChat, false),
+    eq(chats.isKbChat, false),
   ]
 
   if (timeRange?.from) {

--- a/server/db/chat.ts
+++ b/server/db/chat.ts
@@ -5,6 +5,7 @@ import {
   selectChatSchema,
   selectMessageSchema,
   selectPublicChatSchema,
+  ChatType,
   type InsertChat,
   type InsertMessage,
   type SelectChat,
@@ -167,11 +168,12 @@ export const getPublicChats = async (
   pageSize: number,
   offset: number,
   timeRange?: { from?: Date; to?: Date },
+  chatType: ChatType = ChatType.Default,
 ): Promise<SelectPublicChat[]> => {
   const conditions = [
     eq(chats.email, email),
     eq(chats.isBookmarked, false),
-    eq(chats.isKbChat, false),
+    eq(chats.chatType, chatType),
   ]
 
   if (timeRange?.from) {

--- a/server/db/chat.ts
+++ b/server/db/chat.ts
@@ -171,7 +171,7 @@ export const getPublicChats = async (
   const conditions = [
     eq(chats.email, email),
     eq(chats.isBookmarked, false),
-    eq(chats.documentChat, false),
+    eq(chats.kbChat, false),
   ]
 
   if (timeRange?.from) {

--- a/server/db/schema/chats.ts
+++ b/server/db/schema/chats.ts
@@ -50,7 +50,7 @@ export const chats = pgTable(
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     platform: platformEnum(platform).notNull().default(Platform.Web),
     via_apiKey: boolean("via_apiKey").notNull().default(false),
-    documentChat: boolean("documentchat").notNull().default(false),
+    kbChat: boolean("kb_chat").notNull().default(false),
   },
   (table) => ({
     isBookmarkedIndex: index("is_bookmarked_index").on(table.isBookmarked),

--- a/server/db/schema/chats.ts
+++ b/server/db/schema/chats.ts
@@ -50,6 +50,7 @@ export const chats = pgTable(
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     platform: platformEnum(platform).notNull().default(Platform.Web),
     via_apiKey: boolean("via_apiKey").notNull().default(false),
+    documentChat: boolean("documentchat").notNull().default(false),
   },
   (table) => ({
     isBookmarkedIndex: index("is_bookmarked_index").on(table.isBookmarked),

--- a/server/db/schema/chats.ts
+++ b/server/db/schema/chats.ts
@@ -22,6 +22,18 @@ export const platformEnum = pgEnum(
   Object.values(Platform) as [string, ...string[]],
 )
 
+// Chat type enum for better scalability
+export enum ChatType {
+  Default  = "default",
+  KbChat = "kb_chat",
+}
+
+const chatType = "chat_type"
+export const chatTypeEnum = pgEnum(
+  chatType,
+  Object.values(ChatType) as [string, ...string[]],
+)
+
 export const chats = pgTable(
   "chats",
   {
@@ -50,7 +62,7 @@ export const chats = pgTable(
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     platform: platformEnum(platform).notNull().default(Platform.Web),
     via_apiKey: boolean("via_apiKey").notNull().default(false),
-    isKbChat: boolean("is_kb_chat").notNull().default(false),
+    chatType: chatTypeEnum(chatType).notNull().default(ChatType.Default),
   },
   (table) => ({
     isBookmarkedIndex: index("is_bookmarked_index").on(table.isBookmarked),

--- a/server/db/schema/chats.ts
+++ b/server/db/schema/chats.ts
@@ -50,7 +50,7 @@ export const chats = pgTable(
     deletedAt: timestamp("deleted_at", { withTimezone: true }),
     platform: platformEnum(platform).notNull().default(Platform.Web),
     via_apiKey: boolean("via_apiKey").notNull().default(false),
-    kbChat: boolean("kb_chat").notNull().default(false),
+    isKbChat: boolean("is_kb_chat").notNull().default(false),
   },
   (table) => ({
     isBookmarkedIndex: index("is_bookmarked_index").on(table.isBookmarked),


### PR DESCRIPTION
### Description

fixed history model to not show chats that belong to kb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Adjusted navigation header layering so it no longer overlaps PDF viewer content.

- Improvements
  - Public chats list can be filtered by chat type to exclude or include knowledge-base–derived conversations.
  - Chats created from knowledge-base items are now labeled for easier identification.

- New Features
  - Document chat and message streaming now support selecting knowledge-base items as contextual sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->