### PR TITLE
fix: chatBox input disappearing on enter when streaming

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -2692,13 +2692,17 @@ export const ChatBox = React.forwardRef<ChatBoxRef, ChatBoxProps>(
                   if (e.defaultPrevented) return
                 }
 
-                if (
-                  e.key === "Enter" &&
-                  !e.shiftKey &&
-                  query.trim().length > 0
-                ) {
-                  e.preventDefault()
-                  handleSendMessage()
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault() // Always prevent default for Enter (unless Shift+Enter)
+                  
+                  if (
+                    query.trim().length > 0 &&
+                    !isStreaming &&
+                    !retryIsStreaming &&
+                    !isUploadingFiles
+                  ) {
+                    handleSendMessage()
+                  }
                 }
               }}
               style={{


### PR DESCRIPTION
### Description

chatBox input disappearing on enter when streaming

### Testing

tested locally.

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved message input: Enter sends only when the message is ready; Shift+Enter inserts a newline. Enter now consistently avoids unintended form submissions for smoother typing.

* **Bug Fixes**
  * Prevents accidental sends while a response is streaming, retrying, or files are uploading, avoiding disruptions and duplicate messages and ensuring sends occur only when the app is idle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->