### PR TITLE
fix(knowledgemanagment):  shows correct msg in frontend for duplicate files

### DIFF
--- a/frontend/src/routes/_authenticated/knowledgeManagement.tsx
+++ b/frontend/src/routes/_authenticated/knowledgeManagement.tsx
@@ -863,14 +863,19 @@ function KnowledgeManagementContent() {
       
       // Create detailed success message based on actual upload results
       let description = `Successfully created knowledge base "${collectionName.trim()}"`
+      const details = []
       if (totalSuccessful > 0) {
-        description += ` with ${totalSuccessful} file${totalSuccessful !== 1 ? 's' : ''}`
+        details.push(`${totalSuccessful} file${totalSuccessful !== 1 ? 's' : ''} uploaded`)
       }
       if (totalSkipped > 0) {
-        description += `, ${totalSkipped} duplicate${totalSkipped !== 1 ? 's' : ''} skipped`
+        details.push(`${totalSkipped} duplicate${totalSkipped !== 1 ? 's' : ''} skipped`)
       }
       if (totalFailed > 0) {
-        description += `, ${totalFailed} failed`
+        details.push(`${totalFailed} failed`)
+      }
+
+      if (details.length > 0) {
+        description += `: ${details.join(', ')}`
       }
       description += "."
       
@@ -1045,6 +1050,11 @@ function KnowledgeManagementContent() {
         toast.success({
           title: "Files Added",
           description,
+        })
+      } else if (totalFailed > 0) {
+        toast.error({
+          title: "Add Files Failed",
+          description: `${totalFailed} file${totalFailed !== 1 ? 's' : ''} failed to upload. Please try again.`,
         })
       } else {
         toast.error({


### PR DESCRIPTION
### Description

-  shows correct msg in frontend for duplicate files

### Testing

- tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upload feedback now shows aggregated per-batch results after all batches finish, with counts of successful, skipped, and failed files.
  * Applies to both creating a new knowledge base and adding files to an existing collection for consistent summaries.
  * Toast messages now reflect actual batch outcomes rather than generic totals; progress indicators and modals remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->