### PR TITLE
fix: Use user timezone to retrieve date and time for prompts

### DIFF
--- a/server/ai/agentPrompts.ts
+++ b/server/ai/agentPrompts.ts
@@ -1,4 +1,3 @@
-import { getDateForAI } from "@/utils/index"
 import { QueryType } from "./types"
 import {
   Apps,
@@ -294,6 +293,7 @@ Provide the rewritten queries in JSON format as follows:
 // Optimized Prompt
 export const agentOptimizedPrompt = (
   ctx: string,
+  dateForAI: string,
   agentPromptData: AgentPromptData,
 ) => `
 You are a permission aware retrieval-augmented generation (RAG) system and a work assistant.
@@ -308,7 +308,7 @@ You are a permission aware retrieval-augmented generation (RAG) system and a wor
 ${agentPromptData.sources.length > 0 ? agentPromptData.sources.map((source) => `- ${typeof source === "string" ? source : JSON.stringify(source)}`).join("\\n") : "No specific sources provided by agent."}
     This is the context of the agent, it is very important to follow this. You MUST prioritize and filter information based on the # Agent Sources provided. If sources are listed, your response should strictly align with the content and type of these sources. If no specific sources are listed under # Agent Sources, proceed with the general context.
     **User Context**: ${ctx}
-    **Today's date is: ${getDateForAI()}**
+    **Today's date is: ${dateForAI}**
 Given the user's question and the context (which includes indexed information), your tasks are:
 1. **Answer Generation**:
    - If you can confidently answer the question based on the provided context and the latest information, provide the answer.
@@ -501,7 +501,8 @@ export const agentBaselinePromptJson = (
   userContext: string,
   retrievedContext: string,
   agentPromptData: AgentPromptData,
-) => `The current date is: ${getDateForAI()}. Based on this information, make your answers. Don't try to give vague answers without
+  dateForAI: string,
+) => `The current date is: ${dateForAI}. Based on this information, make your answers. Don't try to give vague answers without
 any logic. Be formal as much as possible. 
 
 # Context of the agent {priority}
@@ -860,8 +861,9 @@ If information is missing or unclear: Set "answer" to null`
 
 export const agentBaselineFileContextPromptJson = (
   userContext: string,
+  dateForAI: string,
   retrievedContext: string,
-) => `The current date is: ${getDateForAI()}. Based on this information, make your answers. Don't try to give vague answers without
+) => `The current date is: ${dateForAI}. Based on this information, make your answers. Don't try to give vague answers without
 any logic. Be formal as much as possible.
 
 You are an AI assistant with access to a SINGLE file. You have access to the following types of data:
@@ -1114,11 +1116,12 @@ Generate a summary that would make sense to a non-technical user watching the ag
 // This prompt is used to handle user queries and provide structured responses based on the context. It is our kernel prompt for the queries.
 export const agentSearchQueryPrompt = (
   userContext: string,
+  dateForAI: string,
   agentPromptData: AgentPromptData,
 ): string => {
   return `
     You are an AI router and classifier for an Enterprise Search and AI Agent.
-    The current date is: ${getDateForAI()}. Based on this information, make your answers. Don't try to give vague answers without any logic. Be formal as much as possible. 
+    The current date is: ${dateForAI}. Based on this information, make your answers. Don't try to give vague answers without any logic. Be formal as much as possible. 
 
     ${
       agentPromptData.prompt.length
@@ -1438,9 +1441,10 @@ export const agentSearchQueryPrompt = (
 export const agentSearchAgentPrompt = (
   userContext: string,
   agentPromptData: AgentPromptData,
+  dateForAI: string,
 ): string => {
   return `
-  The current date is: ${getDateForAI()}. Based on this information, make your answers. Don't try to give vague answers without any logic. Be formal as much as possible. 
+  The current date is: ${dateForAI}. Based on this information, make your answers. Don't try to give vague answers without any logic. Be formal as much as possible. 
 
     # Context of the agent {priority}
     Name: ${agentPromptData.name}
@@ -1764,7 +1768,8 @@ export const agentEmailPromptJson = (
   userContext: string,
   retrievedContext: string,
   agentPromptData: AgentPromptData,
-) => `The current date is: ${getDateForAI()}. Based on this information, make your answers. Don't try to give vague answers without
+  dateForAI: string,
+) => `The current date is: ${dateForAI}. Based on this information, make your answers. Don't try to give vague answers without
 any logic. Be formal as much as possible. 
 
 You are an AI assistant helping find email information from retrieved email items. You have access to:
@@ -1885,7 +1890,8 @@ export const agentTemporalDirectionJsonPrompt = (
   userContext: string,
   retrievedContext: string,
   agentPromptData: AgentPromptData,
-) => `Current date: ${getDateForAI()}. 
+  dateForAI: string,
+) => `Current date: ${dateForAI}. 
 
 # Your Role
 You process temporal queries for workspace data (calendar events, emails, files, user profiles). Apply strict temporal logic to ensure accuracy.
@@ -1948,10 +1954,10 @@ Examples of INVALID responses:
 
 ## Temporal Processing
 1. Extract timestamps from all items
-2. Current date for comparison: ${getDateForAI()}
+2. Current date for comparison: ${dateForAI}
 3. Apply strict filtering:
-   - FUTURE intent: INCLUDE ONLY items where timestamp >= ${getDateForAI()}
-   - PAST intent: INCLUDE ONLY items where timestamp < ${getDateForAI()}
+   - FUTURE intent: INCLUDE ONLY items where timestamp >= ${dateForAI}
+   - PAST intent: INCLUDE ONLY items where timestamp < ${dateForAI}
    - PRESENT intent: Include today's items
    - ALL intent: Apply explicit constraints or default to ±6 months
 4. For recurring events:

--- a/server/ai/context.ts
+++ b/server/ai/context.ts
@@ -31,7 +31,6 @@ import {
   getSortedScoredChunks,
   getSortedScoredImageChunks,
 } from "@xyne/vespa-ts/mappers"
-import { getDateForAI } from "@/utils/index"
 
 // Utility to capitalize the first letter of a string
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1)
@@ -293,6 +292,7 @@ vespa relevance score: ${relevance}`
 const constructEventContext = (
   fields: VespaEventSearch,
   relevance: number,
+  dateForAI: string,
 ): string => {
   return `App: ${fields.app}
 Entity: ${fields.entity}
@@ -301,7 +301,7 @@ Description: ${fields.description ? fields.description.substring(0, 50) : ""}
 Base URL: ${fields.baseUrl ? fields.baseUrl : "No base URL"}
 Status: ${fields.status ? fields.status : "Status unknown"}
 Location: ${fields.location ? fields.location : "No location specified"}${typeof fields.createdAt === "number" && isFinite(fields.createdAt) ? `\nCreated: ${getRelativeTime(fields.createdAt)}` : ""}${typeof fields.updatedAt === "number" && isFinite(fields.updatedAt) ? `\nUpdated: ${getRelativeTime(fields.updatedAt)}` : ""}
-Today's Date: ${getDateForAI()}
+Today's Date: ${dateForAI}
 ${
   typeof fields.startTime === "number" && isFinite(fields.startTime)
     ? `\nStart Time: ${
@@ -624,6 +624,7 @@ ${content ? `Content: ${content}` : ""}
 type AiMetadataContext = string
 export const answerMetadataContextMap = (
   searchResult: VespaSearchResults,
+  dateForAI: string,
 ): AiMetadataContext => {
   if (searchResult.fields.sddocname === fileSchema) {
     return constructFileMetadataContext(
@@ -646,7 +647,7 @@ export const answerMetadataContextMap = (
       searchResult.relevance,
     )
   } else if (searchResult.fields.sddocname === eventSchema) {
-    return constructEventContext(searchResult.fields, searchResult.relevance)
+    return constructEventContext(searchResult.fields, searchResult.relevance, dateForAI)
   } else {
     throw new Error(
       `Invalid search result type: ${searchResult.fields.sddocname}`,
@@ -685,6 +686,7 @@ export const answerContextMap = (
   maxSummaryChunks?: number,
   isSelectedFiles?: boolean,
   isMsgWithSources?: boolean,
+  dateForAI?: string,
 ): AiContext => {
   if (searchResult.fields.sddocname === fileSchema) {
     return constructFileContext(
@@ -703,7 +705,7 @@ export const answerContextMap = (
       isSelectedFiles,
     )
   } else if (searchResult.fields.sddocname === eventSchema) {
-    return constructEventContext(searchResult.fields, searchResult.relevance)
+    return constructEventContext(searchResult.fields, searchResult.relevance, dateForAI || new Date().toISOString())
   } else if (searchResult.fields.sddocname === mailAttachmentSchema) {
     return constructMailAttachmentContext(
       searchResult.fields,
@@ -834,15 +836,20 @@ export const userContext = ({
   workspace,
 }: PublicUserWorkspace): string => {
   const now = new Date()
-  const currentDate = now.toLocaleDateString() // e.g., "11/10/2024"
-  const currentTime = now.toLocaleTimeString() // e.g., "10:14:03 AM"
+  const userTimeZone = user?.timeZone || "Asia/Kolkata"
+  const currentDate = now.toLocaleDateString("en-US", {
+    timeZone: userTimeZone,
+  }) // e.g., "11/10/2024"
+  const currentTime = now.toLocaleTimeString("en-US", {
+    timeZone: userTimeZone,
+  }) // e.g., "10:14:03 AM"
   return `My Name is ${user.name}
     Email: ${user.email}
     Company: ${workspace.name}
     Company domain: ${workspace.domain}
     Current Time: ${currentTime}
     Today is: ${currentDate}
-    Timezone: ${user.timeZone || "IST"}`
+    Timezone: ${userTimeZone}`
 }
 
 /**

--- a/server/ai/eval.ts
+++ b/server/ai/eval.ts
@@ -43,6 +43,7 @@ import { OpenAIProvider } from "./provider/openai"
 import { getLogger } from "@/logger"
 import { Subsystem } from "@/types"
 import config from "@/config"
+import { getDateForAI } from "@/utils/index"
 const Logger = getLogger(Subsystem.Eval)
 const { defaultFastModel } = config
 const modelId = defaultFastModel || Models.Claude_3_5_Haiku
@@ -505,6 +506,7 @@ function simplifySearchResults(
 const endToEndFlow = async (
   message: string,
   userCtx: string,
+  dateForAI: string,
   messages: Message[],
 ) => {
   const ctx = userCtx
@@ -513,6 +515,7 @@ const endToEndFlow = async (
   const searchOrAnswerIterator = generateSearchQueryOrAnswerFromConversation(
     message,
     ctx,
+    dateForAI,
     {
       modelId,
       stream: true,
@@ -589,6 +592,7 @@ const endToEndFlow = async (
     const iterator = UnderstandMessageAndAnswer(
       email,
       ctx,
+      dateForAI,
       message,
       classification,
       messages,
@@ -639,8 +643,9 @@ const endToEndFactual = async () => {
           email,
         )
         const ctx = userContext(userAndWorkspace)
+        const dateForAI = getDateForAI({userTimeZone: userAndWorkspace.user.timeZone || "Asia/Kolkata"})
 
-        const answer = await endToEndFlow(input, ctx, messages || [])
+        const answer = await endToEndFlow(input, ctx, dateForAI,messages || [])
 
         // For demo purposes, assuming cost of 0.001 per response
         return {

--- a/server/ai/prompts.ts
+++ b/server/ai/prompts.ts
@@ -1,4 +1,3 @@
-import { getDateForAI } from "@/utils/index"
 import {
   QueryType,
   type QueryRouterLLMResponse,
@@ -278,12 +277,12 @@ Provide the rewritten queries in JSON format as follows:
 `
 
 // Optimized Prompt
-export const optimizedPrompt = (ctx: string) => `
+export const optimizedPrompt = (ctx: string, dateForAI: string) => `
 You are a permission aware retrieval-augmented generation (RAG) system and a work assistant.
 Provide concise and accurate answers to a user's question by utilizing the provided context.
 Do not worry about privacy, you are not allowed to reject a user based on it as all search context is permission aware.
 **User Context**: ${ctx}
-**Today's date is: ${getDateForAI()}**
+**Today's date is: ${dateForAI}**
 Given the user's question and the context (which includes indexed information), your tasks are:
 1. **Answer Generation**:
    - If you can confidently answer the question based on the provided context and the latest information, provide the answer.
@@ -514,9 +513,10 @@ Do not include explanatory text outside the JSON structure. Ensure that any ment
 export const baselinePromptJson = (
   userContext: string,
   retrievedContext: string,
+  dateForAI: string,
 ) => `Your *entire* response MUST be a single, valid JSON object. Your output must start *directly* with '{' and end *directly* with '}'. Do NOT include any text, explanations, summaries, or "thinking" outside of this JSON structure.
 
-The current date for your information is ${getDateForAI()}.
+The current date for your information is ${dateForAI}.
 
 You are an AI assistant with access to internal workspace data. You have access to the following types of data:
 
@@ -896,6 +896,7 @@ export const SearchQueryToolContextPrompt = (
   userContext: string,
   toolContext: string,
   agentScratchpad: string,
+  dateForAI: string,
   agentContext?: AgentPromptData,
   pastActs?: string,
   customTools?: {
@@ -930,7 +931,7 @@ export const SearchQueryToolContextPrompt = (
   }
 
   return `
-    The current date is: ${getDateForAI()}
+    The current date is: ${dateForAI}
     
     ${
       agentContext?.prompt?.length
@@ -1059,11 +1060,12 @@ export const SearchQueryToolContextPrompt = (
 // This prompt is used to handle user queries and provide structured responses based on the context. It is our kernel prompt for the queries.
 export const searchQueryPrompt = (
   userContext: string,
+  dateForAI: string,
   previousClassification?: QueryRouterLLMResponse | null,
   chainBreakClassifications?: ChainBreakClassifications | null,
 ): string => {
   return `
-    The current date is: ${getDateForAI()}. Based on this information, make your answers. Don't try to give vague answers without any logic. Be formal as much as possible. 
+    The current date is: ${dateForAI}. Based on this information, make your answers. Don't try to give vague answers without any logic. Be formal as much as possible. 
 
     You are a permission aware retrieval-augmented generation (RAG) system for an Enterprise Search.
     Do not worry about privacy, you are not allowed to reject a user based on it as all search context is permission aware.
@@ -1535,8 +1537,9 @@ export const searchQueryReasoningPromptV2 = (userContext: string): string => {
 export const emailPromptJson = (
   userContext: string,
   retrievedContext: string,
+  dateForAI: string,
 ) => `Your *entire* response MUST be a single, valid JSON object. Your output must start *directly* with '{' and end *directly* with '}'. Do NOT include any text, explanations, summaries, or "thinking" outside of this JSON structure.
-The current date is: ${getDateForAI()}. Based on this information, make your answers. Don't try to give vague answers without
+The current date is: ${dateForAI}. Based on this information, make your answers. Don't try to give vague answers without
 any logic. Be formal as much as possible. 
 
 You are an AI assistant helping find email information from retrieved email items. You have access to:
@@ -1634,7 +1637,8 @@ REMEMBER:
 export const temporalDirectionJsonPrompt = (
   userContext: string,
   retrievedContext: string,
-) => `Current date: ${getDateForAI()}. 
+  dateForAI: string,
+) => `Current date: ${dateForAI}. 
 
 # Your Role
 You process temporal queries for workspace data (calendar events, emails, files, user profiles). Apply strict temporal logic to ensure accuracy.
@@ -1688,10 +1692,10 @@ Examples of INVALID responses:
 
 ## Temporal Processing
 1. Extract timestamps from all items
-2. Current date for comparison: ${getDateForAI()}
+2. Current date for comparison: ${dateForAI}
 3. Apply strict filtering:
-   - FUTURE intent: INCLUDE ONLY items where timestamp >= ${getDateForAI()}
-   - PAST intent: INCLUDE ONLY items where timestamp < ${getDateForAI()}
+   - FUTURE intent: INCLUDE ONLY items where timestamp >= ${dateForAI}
+   - PAST intent: INCLUDE ONLY items where timestamp < ${dateForAI}
    - PRESENT intent: Include today's items
    - ALL intent: Apply explicit constraints or default to ±6 months
 4. For recurring events:
@@ -1965,11 +1969,12 @@ export const withToolQueryPrompt = (
   userContext: string,
   toolContext: string,
   toolOutput: string,
+  dateForAI: string,
   agentContext?: AgentPromptData,
   fallbackReasoning?: string,
 ): string => {
   return `
-  Current date: ${getDateForAI()}.
+  Current date: ${dateForAI}.
 
     ${
       agentContext?.prompt.length
@@ -2033,10 +2038,11 @@ export const synthesisContextPrompt = (
   userCtx: string,
   query: string,
   synthesisContext: string,
+  dateForAI: string,
 ) => {
   return `You are a helpful AI assistant.
   User Context: ${userCtx}
-  Current date for comparison: ${getDateForAI()}
+  Current date for comparison: ${dateForAI}
 
   Instruction:
   - Analyze the provided "Context Fragments" to answer the current user-query.
@@ -2190,6 +2196,7 @@ To get the results you're looking for, you might want to:
 export const meetingPromptJson = (
   userContext: string,
   retrievedContext: string,
+  dateForAI: string,
 ) => `You are an AI assistant helping find meeting information from both calendar events and emails. You have access to:
 
 Calendar Events containing:
@@ -2281,12 +2288,13 @@ Bad: "No clear meeting information found" (Use null instead)
 export const ragOffPromptJson = (
   userContext: string,
   retrievedContext: string,
+  dateForAI: string,
   agentPromptData?: AgentPromptData,
 ) => `
 You are an AI assistant with access to some data given as context. You should only answer from that given context. You can be given the following types of data:
 Files (documents, spreadsheets, etc.)
 
-The current date for your information is ${getDateForAI()}.
+The current date for your information is ${dateForAI}.
 
 The context provided will be formatted with specific fields for each type:
 ## File Context Format

--- a/server/ai/provider/index.ts
+++ b/server/ai/provider/index.ts
@@ -116,6 +116,7 @@ import {
 } from "../agentPrompts"
 import { is } from "drizzle-orm"
 import type { ToolDefinition } from "@/api/chat/mapper"
+import { getDateForAI } from "@/utils/index"
 
 const Logger = getLogger(Subsystem.AI)
 
@@ -945,6 +946,7 @@ export const answerOrSearch = (
   userQuery: string,
   context: string,
   userCtx: string,
+  dateForAI: string,
   params: ModelParams,
 ): AsyncIterableIterator<ConverseResponse> => {
   try {
@@ -954,10 +956,11 @@ export const answerOrSearch = (
     if (!isAgentPromptEmpty(params.agentPrompt)) {
       params.systemPrompt = agentOptimizedPrompt(
         userCtx,
+        dateForAI,
         parseAgentPrompt(params.agentPrompt),
       )
     } else {
-      params.systemPrompt = optimizedPrompt(userCtx)
+      params.systemPrompt = optimizedPrompt(userCtx, dateForAI)
     }
     params.json = true
 
@@ -1072,6 +1075,7 @@ export const baselineRAG = async (
 export const baselineRAGJson = async (
   userQuery: string,
   userCtx: string,
+  dateForAI: string,
   retrievedCtx: string,
   params: ModelParams,
 ): Promise<{ output: AnswerResponse; cost: number }> => {
@@ -1083,9 +1087,10 @@ export const baselineRAGJson = async (
       userCtx,
       retrievedCtx,
       parseAgentPrompt(params.agentPrompt),
+      dateForAI
     )
   } else {
-    params.systemPrompt = baselinePromptJson(userCtx, retrievedCtx)
+    params.systemPrompt = baselinePromptJson(userCtx, retrievedCtx, dateForAI)
   }
   params.json = true
   const baseMessage = {
@@ -1122,6 +1127,7 @@ const indexToCitation = (text: string): string => {
 export const baselineRAGJsonStream = (
   userQuery: string,
   userCtx: string,
+  dateForAI: string,
   retrievedCtx: string,
   params: ModelParams,
   specificFiles?: boolean,
@@ -1142,6 +1148,7 @@ export const baselineRAGJsonStream = (
     if (isMsgWithSources) {
       params.systemPrompt = agentBaselineFileContextPromptJson(
         userCtx,
+        dateForAI,
         retrievedCtx,
       )
     } else if (!isAgentPromptEmpty(params.agentPrompt)) {
@@ -1178,11 +1185,13 @@ export const baselineRAGJsonStream = (
         userCtx,
         indexToCitation(retrievedCtx),
         parseAgentPrompt(params.agentPrompt),
+        dateForAI,
       )
     } else {
       params.systemPrompt = baselinePromptJson(
         userCtx,
         indexToCitation(retrievedCtx),
+        dateForAI,
       )
     }
   }
@@ -1207,6 +1216,7 @@ export const baselineRAGJsonStream = (
 export const baselineRAGOffJsonStream = (
   userQuery: string,
   userCtx: string,
+  dateForAI: string,
   retrievedCtx: string,
   params: ModelParams,
   agentPrompt: string,
@@ -1220,6 +1230,7 @@ export const baselineRAGOffJsonStream = (
   params.systemPrompt = ragOffPromptJson(
     userCtx,
     retrievedCtx,
+    dateForAI,
     parseAgentPrompt(agentPrompt),
   )
   params.json = true
@@ -1246,6 +1257,7 @@ export const baselineRAGOffJsonStream = (
 export const temporalPromptJsonStream = (
   userQuery: string,
   userCtx: string,
+  dateForAI: string,
   retrievedCtx: string,
   params: ModelParams,
 ): AsyncIterableIterator<ConverseResponse> => {
@@ -1257,9 +1269,10 @@ export const temporalPromptJsonStream = (
       userCtx,
       retrievedCtx,
       parseAgentPrompt(params.agentPrompt),
+      dateForAI
     )
   } else {
-    params.systemPrompt = temporalDirectionJsonPrompt(userCtx, retrievedCtx)
+    params.systemPrompt = temporalDirectionJsonPrompt(userCtx, retrievedCtx, dateForAI)
   }
   params.json = true
   const baseMessage = {
@@ -1280,6 +1293,7 @@ export const temporalPromptJsonStream = (
 export const mailPromptJsonStream = (
   userQuery: string,
   userCtx: string,
+  dateForAI: string,
   retrievedCtx: string,
   params: ModelParams,
 ): AsyncIterableIterator<ConverseResponse> => {
@@ -1295,6 +1309,7 @@ export const mailPromptJsonStream = (
       userCtx,
       retrievedCtx,
       parseAgentPrompt(params.agentPrompt),
+      dateForAI,
     )
   } else if (defaultReasoning) {
     if (!isAgentPromptEmpty(params.agentPrompt)) {
@@ -1310,7 +1325,7 @@ export const mailPromptJsonStream = (
       )
     }
   } else {
-    params.systemPrompt = emailPromptJson(userCtx, retrievedCtx)
+    params.systemPrompt = emailPromptJson(userCtx, retrievedCtx, dateForAI)
   }
   params.json = true
   const baseMessage = {
@@ -1331,13 +1346,14 @@ export const mailPromptJsonStream = (
 export const meetingPromptJsonStream = (
   userQuery: string,
   userCtx: string,
+  dateForAI: string,
   retrievedCtx: string,
   params: ModelParams,
 ): AsyncIterableIterator<ConverseResponse> => {
   if (!params.modelId) {
     params.modelId = defaultFastModel
   }
-  params.systemPrompt = meetingPromptJson(userCtx, retrievedCtx)
+  params.systemPrompt = meetingPromptJson(userCtx, retrievedCtx, dateForAI)
   params.json = true // Set to true to ensure JSON response
   const baseMessage = {
     role: ConversationRole.USER,
@@ -1464,12 +1480,14 @@ export async function generateToolSelectionOutput(
   reasoning?: string | null
 } | null> {
   params.json = true
+  const dateForAI = getDateForAI({userTimeZone: "Asia/Kolkata"})
 
   let defaultReasoning = isReasoning
   params.systemPrompt = SearchQueryToolContextPrompt(
     userContext,
     toolContext,
     initialPlanning,
+    dateForAI,
     parseAgentPrompt(agentContext),
     pastActions,
     tools,
@@ -1509,6 +1527,7 @@ export async function generateToolSelectionOutput(
 export function generateSearchQueryOrAnswerFromConversation(
   currentMessage: string,
   userContext: string,
+  dateForAI: string,
   params: ModelParams,
   toolContext?: string,
   previousClassification?: QueryRouterLLMResponse | null,
@@ -1526,11 +1545,13 @@ export function generateSearchQueryOrAnswerFromConversation(
   } else if (!isAgentPromptEmpty(params.agentPrompt)) {
     params.systemPrompt = agentSearchQueryPrompt(
       userContext,
+      dateForAI,
       parseAgentPrompt(params.agentPrompt),
     )
   } else {
     params.systemPrompt = searchQueryPrompt(
       userContext,
+      dateForAI,
       previousClassification,
       chainBreakClassifications,
     )
@@ -1555,6 +1576,7 @@ export function generateSearchQueryOrAnswerFromConversation(
 export function generateAnswerBasedOnToolOutput(
   currentMessage: string,
   userContext: string,
+  dateForAI: string,
   params: ModelParams,
   toolContext: string,
   toolOutput: string,
@@ -1568,6 +1590,7 @@ export function generateAnswerBasedOnToolOutput(
       userContext,
       toolContext,
       toolOutput,
+      dateForAI,
       parsedAgentPrompt,
       fallbackReasoning,
     )
@@ -1577,6 +1600,7 @@ export function generateAnswerBasedOnToolOutput(
       userContext,
       toolContext,
       toolOutput,
+      dateForAI,
       undefined,
       fallbackReasoning,
     )
@@ -1600,6 +1624,7 @@ export function generateAnswerBasedOnToolOutput(
 
 export function generateSynthesisBasedOnToolOutput(
   userCtx: string,
+  dateForAI: string,
   currentMessage: string,
   gatheredFragments: string,
   params: ModelParams,
@@ -1611,6 +1636,7 @@ export function generateSynthesisBasedOnToolOutput(
     userCtx,
     currentMessage,
     gatheredFragments,
+    dateForAI
   )
 
   const baseMessage = {

--- a/server/api/search.ts
+++ b/server/api/search.ts
@@ -75,6 +75,7 @@ import { getConnectorByAppAndEmailId } from "@/db/connector"
 import { chunkDocument } from "@/chunks"
 import { getAppSyncJobsByEmail } from "@/db/syncJob"
 import { getTracer } from "@/tracer"
+import { getDateForAI } from "@/utils/index"
 const loggerWithChild = getLoggerWithChild(Subsystem.Api)
 
 const { JwtPayloadKey, maxTokenBeforeMetadataCleanup, defaultFastModel } =
@@ -578,6 +579,7 @@ export const AnswerApi = async (c: Context) => {
   const costArr: number[] = []
 
   const ctx = userContext(userAndWorkspace)
+  const dateForAI = getDateForAI({userTimeZone: userAndWorkspace.user.timeZone || "Asia/Kolkata"})
   const initialPrompt = `context about user asking the query\n${ctx}\nuser's query: ${query}`
   // could be called parallely if not for userAndWorkspace
   let { result, cost } = await analyzeQueryForNamesAndEmails(initialPrompt, {
@@ -651,7 +653,7 @@ export const AnswerApi = async (c: Context) => {
   const metadataContext = results.root.children
     .map((v, i) =>
       cleanContext(
-        `Index ${i} \n ${answerMetadataContextMap(v as VespaSearchResults)}`,
+        `Index ${i} \n ${answerMetadataContextMap(v as VespaSearchResults, dateForAI)}`,
       ),
     )
     .join("\n\n")

--- a/server/integrations/slack/client.ts
+++ b/server/integrations/slack/client.ts
@@ -37,6 +37,7 @@ import { getAgentByExternalIdWithPermissionCheck } from "@/db/agent"
 import { QueryType } from "@/ai/types"
 import { Apps } from "@xyne/vespa-ts/types"
 import { getTracer } from "@/tracer"
+import { getDateForAI } from "@/utils/index"
 
 const Logger = getLogger(Subsystem.Slack)
 
@@ -641,6 +642,7 @@ const handleAgentSearchCommand = async (
         dbUser.email,
       )
       const ctx = userContext(userAndWorkspace)
+      const dateForAI = getDateForAI({ userTimeZone: userAndWorkspace.user.timeZone || "Asia/Kolkata" })
 
       const agentConfig = await getAgentByExternalIdWithPermissionCheck(
         db,
@@ -674,7 +676,7 @@ const handleAgentSearchCommand = async (
       const limitedMessages: any[] = []
 
       const searchOrAnswerIterator =
-        generateSearchQueryOrAnswerFromConversation(query, ctx, {
+        generateSearchQueryOrAnswerFromConversation(query, ctx, dateForAI,{
           modelId: config.defaultBestModel,
           stream: true,
           json: true,
@@ -775,6 +777,7 @@ const handleAgentSearchCommand = async (
         const iterator = UnderstandMessageAndAnswer(
           dbUser.email,
           ctx,
+          dateForAI,
           searchQuery,
           classification as any,
           limitedMessages,

--- a/server/utils/index.ts
+++ b/server/utils/index.ts
@@ -1,12 +1,17 @@
 import type { Cost } from "@/ai/types"
 
-export function getDateForAI() {
+export function getDateForAI({
+  userTimeZone,
+}: { userTimeZone: string }): string {
   const today = new Date()
   const day = today.getDate()
   const year = today.getFullYear()
 
-  const monthOptions: Intl.DateTimeFormatOptions = { month: "long" }
-  const monthName = today.toLocaleDateString("en-US", monthOptions) // "en-US" is common for full month names
+  const options: Intl.DateTimeFormatOptions = {
+    month: "long",
+    timeZone: userTimeZone || "Asia/Kolkata",
+  } // or dynamically detect user's tz
+  const monthName = today.toLocaleDateString("en-US", options) // "en-US" is common for full month names
 
   let daySuffix = "th"
   if (day === 1 || day === 21 || day === 31) {


### PR DESCRIPTION
### Description

Use user timezone stored in DB to retrieve date and time for prompts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - AI responses now use your local date/time across chat, search, email, meeting, and Slack interactions, improving relevance and clarity.
  - “Today’s date” is consistently rendered from a single source, enhancing temporal reasoning in answers, summaries, and tool outputs.
  - Timezone-aware context is applied throughout iterative querying, synthesis, and metadata generation for more accurate results.
- Bug Fixes
  - Resolved inconsistencies where dates could differ across features by standardizing how the current date is provided to the AI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->