### PR TITLE
refactor(vespa): upgrade Vespa image to 8.583.10 and enable GPU runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,9 @@ server/migrations/
 server/Xenova
 server/vespa/models/
 
+# cli
+server/vespa/vespa-cli_*
+
 # fe
 .mjs
 

--- a/deployment/Dockerfile-vespa-gpu
+++ b/deployment/Dockerfile-vespa-gpu
@@ -1,14 +1,9 @@
-FROM vespaengine/vespa:8.514.24
-# Switch to root to install packages
+FROM vespaengine/vespa:8.583.10
+
 USER root
-# Install CUDA-enabled ONNX runtime for Vespa
-# Using dnf directly as it's the package manager in the base image
-RUN dnf -y install dnf-plugins-core
-RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo \
- && dnf -y install cuda-libraries-12-2 \
- && dnf clean all
-RUN curl -1sLf 'https://dl.cloudsmith.io/public/vespa/open-source-rpms/setup.rpm.sh' | bash && \
-    dnf -y install vespa-onnxruntime-cuda-1.20.1 && \
-    dnf clean all
-# Switch back to vespa user (UID 1000 is typical for vespaengine/vespa)
-USER 1000
+
+RUN dnf -y install 'dnf-command(config-manager)'
+RUN dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+RUN dnf -y install $(rpm -q --queryformat '%{NAME}-cuda-%{VERSION}' vespa-onnxruntime)
+
+USER vespa

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -17,24 +17,20 @@ services:
   #   networks:
   #     - xyne
   #   restart: always
-  
+
   prometheus:
     image: "prom/prometheus"
     container_name: xyne-prometheus
     user: "65534:65534"
     volumes:
-      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-template.yml
+      - ./prometheus-selfhosted.yml:/etc/prometheus/prometheus-selfhosted.yml
       - ./prometheus/data:/prometheus
     ports:
     - "9090:9090"
     environment:
       - METRICS_PORT=${METRICS_PORT:-3001}
     command:
-      - sh
-      - -c
-      - |
-        envsubst < /etc/prometheus/prometheus-template.yml > /etc/prometheus/prometheus.yml
-        exec prometheus --config.file=/etc/prometheus/prometheus.yml
+      - "--config.file=/etc/prometheus/prometheus-selfhosted.yml"
     restart: always
     networks:
       - xyne
@@ -57,7 +53,7 @@ services:
       - POSTGRES_PASSWORD=xyne
 
   vespa:
-    image: vespaengine/vespa:8.503.27
+    image: xyne/vespa-gpu:8.583.10 # Uses the custom GPU-enabled Vespa image
     container_name: vespa
     hostname: vespa-container
     # sudo chown -R 1000:1000 ./server/vespa-data
@@ -96,8 +92,7 @@ services:
 
 
       # Main query container
-      - VESPA_CONTAINER_JVMARGS=-Xms6g -Xmx8g -XX:+UseG1GC
-      - VESPA_CONTAINER_MY_CONTAINER_JVMARGS=-Xms4g -Xmx6g -XX:+UseG1GC
+      - VESPA_CONTAINER_JVMARGS=-Xms8g -Xmx12g -XX:+UseG1GC -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/vespa/var/crash
 
       # Storage and search nodes
       - VESPA_CONTENT_JVMARGS=-Xms10g -Xmx14g -XX:+UseG1GC
@@ -144,5 +139,5 @@ networks:
 volumes:
   vespa-data:
     driver: local
-  grafana-storage:  
+  grafana-storage:
     driver: local

--- a/deployment/prometheus-selfhosted.yml
+++ b/deployment/prometheus-selfhosted.yml
@@ -4,12 +4,12 @@ scrape_configs:
     metrics_path: /prometheus/v1/values
     static_configs:
       - targets: ['vespa:8080']
-      
+
   - job_name: 'google_drive_ingestion'
     metrics_path: /metrics  # default path in your Hono app
     scrape_interval: 2s
     static_configs:
-      - targets: ['host.docker.internal:${METRICS_PORT:-3001}'] #replace  with your application's service name e.g. 'xyne-app:3000' or the host-name:port where your server is hosted
+      - targets: ['host.docker.internal:3001'] #replace  with your application's service name e.g. 'xyne-app:3000' or the host-name:port where your server is hosted
   # - job_name: 'pm2'
   #   metrics_path: /
   #   scrape_interval: 2s

--- a/server/config.ts
+++ b/server/config.ts
@@ -17,7 +17,6 @@ export const CLUSTER = "my_content"
 if (process.env.NODE_ENV === "production") {
   postgresBaseHost = process.env.DATABASE_HOST!
   vespaBaseHost = process.env.VESPA_HOST!
-  port = 80
   host = process.env.HOST!
   redirectUri = process.env.GOOGLE_PROD_REDIRECT_URI!
 }

--- a/server/vespa/deploy.sh
+++ b/server/vespa/deploy.sh
@@ -3,10 +3,13 @@
 #!/bin/sh
 set -e
 
+source ../.env
+
 mkdir -p models
 TOKENIZER_URL=""
 MODEL_URL=""
 DIMS=
+
 
 # URLs to download
 if [ "$EMBEDDING_MODEL" = "bge-small-en-v1.5" ] || [ -z "$EMBEDDING_MODEL" ]; then
@@ -52,7 +55,7 @@ else
 fi
 
 
-echo "Deploying vespa..."
+echo "Deploying vespa... $VESPA_CLI_PATH"
 ${VESPA_CLI_PATH:-vespa} deploy --wait 960
 echo "Restarting vespa...."
 docker restart vespa


### PR DESCRIPTION
- Replace Vespa image with 8.583.10 and custom GPU‑enabled build
- Install CUDA‑runtime libraries via vespa‑onnxruntime
- Switch Vespa process to run as `vespa` user for security
- Update production compose: use new image, configure Prometheus with pre‑generated YAML, increase JVM flags with heap‑dump options
- Remove hard‑coded port 80 in production and hardcode Prometheus metrics port
- Source `.env` to the deploy script

### Description

<!-- Summarize the changes in this PR. -->
<!-- Explain the purpose of the change (e.g., bug fix, feature, refactor). -->
<!-- Describe how this change affects the system or users. -->

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
