### PR TITLE
fix(agentApiPathSupport): integrate RAG for path-based source passing

### DIFF
--- a/server/ai/context.ts
+++ b/server/ai/context.ts
@@ -575,13 +575,19 @@ const constructCollectionFileContext = (
   if ((!maxSummaryChunks && !isSelectedFiles) || isMsgWithSources) {
     maxSummaryChunks = fields.chunks_summary?.length
   }
-
   let chunks: ScoredChunk[] = []
   if (fields.matchfeatures && fields.chunks_summary) {
     const summaryStrings = fields.chunks_summary.map((c) =>
       typeof c === "string" ? c : c.chunk,
     )
-    chunks = getSortedScoredChunks(fields.matchfeatures, summaryStrings)
+    if (!maxSummaryChunks) {
+      maxSummaryChunks = 10
+    }
+    chunks = getSortedScoredChunks(
+      fields.matchfeatures,
+      summaryStrings,
+      maxSummaryChunks,
+    )
   } else if (fields.chunks_summary) {
     chunks =
       fields.chunks_summary?.map((chunk, idx) => ({

--- a/server/api/chat/agents.ts
+++ b/server/api/chat/agents.ts
@@ -3714,8 +3714,12 @@ export const AgentMessageApi = async (c: Context) => {
     message = decodeURIComponent(message)
     rootSpan.setAttribute("message", message)
     let ids
+    let isValidPath: boolean = false
     if (path) {
       ids = await getRecordBypath(path, db)
+      if (ids != null) {
+        isValidPath = Boolean(true)
+      }
     }
     const isMsgWithContext = isMessageWithContext(message)
     const extractedInfo =
@@ -3724,8 +3728,10 @@ export const AgentMessageApi = async (c: Context) => {
         : {
             totalValidFileIdsFromLinkCount: 0,
             fileIds: [],
+            collectionFolderIds: [],
           }
     let fileIds = extractedInfo?.fileIds
+    let folderIds = extractedInfo?.collectionFolderIds
     if (nonImageAttachmentFileIds && nonImageAttachmentFileIds.length > 0) {
       fileIds = [...fileIds, ...nonImageAttachmentFileIds]
     }
@@ -3943,6 +3949,10 @@ export const AgentMessageApi = async (c: Context) => {
                 [],
                 imageAttachmentFileIds,
                 agentPromptForLLM,
+                fileIds.length > 0,
+                "",
+                Boolean(isValidPath),
+                folderIds,
               )
               stream.writeSSE({
                 event: ChatSSEvents.Start,

--- a/server/db/knowledgeBase.ts
+++ b/server/db/knowledgeBase.ts
@@ -574,7 +574,8 @@ export const getAllCollectionAndFolderItems = async (
   parentIds: string[],
   trx: TxnOrClient,
 ) => {
-  const result: string[] = []
+  const fileIds: string[] = []
+  const folderIds: string[] = []
   type Q = { itemId: string }
   const queue: Q[] = []
 
@@ -611,7 +612,10 @@ export const getAllCollectionAndFolderItems = async (
             isNull(collectionItems.deletedAt),
           ),
         )
-      if (folder) queue.push({ itemId: folder.id })
+      if (folder) {
+        queue.push({ itemId: folder.id })
+        folderIds.push(folder.id)
+      }
     } else if (input.startsWith("clf-")) {
       const fileid = await trx
         .select({ id: collectionItems.id })
@@ -622,7 +626,7 @@ export const getAllCollectionAndFolderItems = async (
             isNull(collectionItems.deletedAt),
           ),
         )
-      if (fileid.length) result.push(fileid[0].id)
+      if (fileid.length) fileIds.push(fileid[0].id)
     } else {
       // Assume it's a DB item id (UUID)
       queue.push({ itemId: input })
@@ -644,18 +648,19 @@ export const getAllCollectionAndFolderItems = async (
     if (children.length === 0) {
       // If no children: either this is a file leaf or an invalid id; only push if it's a file
       const node = await getCollectionItemById(trx, itemId)
-      if (node && node.type === "file") result.push(itemId)
+      if (node && node.type === "file") fileIds.push(itemId)
       continue
     }
     for (const child of children) {
       if (child.type === "folder") {
+        folderIds.push(child.id)
         queue.push({ itemId: child.id })
       } else if (child.type === "file") {
-        result.push(child.id)
+        fileIds.push(child.id)
       }
     }
   }
-  return result
+  return { fileIds, folderIds }
 }
 
 // Keep the old function for backward compatibility
@@ -664,7 +669,7 @@ export const getAllFolderItems = async (
   trx: TxnOrClient,
 ) => {
   const res = []
-  let queue = [...parentIds];
+  let queue = [...parentIds]
   while (queue.length > 0) {
     const curr = queue.shift()!
 
@@ -690,15 +695,15 @@ export const getAllFolderIds = async (
   trx: TxnOrClient,
 ) => {
   const res = []
-  let queue = [...parentIds];
+  let queue = [...parentIds]
   while (queue.length > 0) {
     const curr = queue.shift()!
 
     const resp = await getParentItems(curr, trx)
     for (const item of resp) {
       if (item.type == "folder") {
-        res.push(item.id) 
-        queue.push(item.id) 
+        res.push(item.id)
+        queue.push(item.id)
       }
     }
   }
@@ -722,6 +727,30 @@ export const getCollectionFilesVespaIds = async (
       and(
         inArray(collectionItems.id, collectionFileIds),
         eq(collectionItems.type, "file"),
+        isNull(collectionItems.deletedAt),
+      ),
+    )
+
+  return resp
+}
+
+export const getCollectionFoldersItemIds = async (
+  collectionFoldersIds: string[],
+  trx: TxnOrClient,
+) => {
+  const resp = await trx
+    .select({
+      id: collectionItems.id,
+      vespaDocId: collectionItems.vespaDocId,
+      originalName: collectionItems.originalName,
+      mimeType: collectionItems.mimeType,
+      fileSize: collectionItems.fileSize,
+    })
+    .from(collectionItems)
+    .where(
+      and(
+        inArray(collectionItems.id, collectionFoldersIds),
+        eq(collectionItems.type, "folder"),
         isNull(collectionItems.deletedAt),
       ),
     )

--- a/server/db/schema/chats.ts
+++ b/server/db/schema/chats.ts
@@ -24,7 +24,7 @@ export const platformEnum = pgEnum(
 
 // Chat type enum for better scalability
 export enum ChatType {
-  Default  = "default",
+  Default = "default",
   KbChat = "kb_chat",
 }
 

--- a/server/package.json
+++ b/server/package.json
@@ -65,7 +65,7 @@
     "@slack/web-api": "^7.8.0",
     "@types/jszip": "^3.4.1",
     "@types/node": "^24.3.0",
-    "@xyne/vespa-ts": "^1.0.6",
+    "@xyne/vespa-ts": "^1.0.7",
     "@xynehq/jaf": "^0.1.4",
     "arctic": "^3.3.0",
     "async-mutex": "^0.5.0",

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -65,7 +65,7 @@ export const GetDocument = vespa.GetDocument.bind(vespa)
 export const getDocumentOrNull = vespa.getDocumentOrNull.bind(vespa)
 export const UpdateDocument = vespa.UpdateDocument.bind(vespa)
 export const DeleteDocument = vespa.DeleteDocument.bind(vespa)
-
+export const searchCollectionRAG = vespa.searchCollectionRAG.bind(vespa)
 export const searchVespa = async (
   query: string,
   email: string,


### PR DESCRIPTION
### Description
Enhance documents retrieval by integrating RAG support in agentMessageApi. Instead of sending the entire files to the LLM, fetch only the most relevant documents from the Knowledgebase collection based on the path passed.


### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
