### PR TITLE
fix(appExclusion):remove the authType check while fetching the user syncJobs

### DIFF
--- a/server/api/search.ts
+++ b/server/api/search.ts
@@ -68,7 +68,7 @@ import type {
 } from "@xyne/vespa-ts/types"
 import { getConnectorByAppAndEmailId } from "@/db/connector"
 import { chunkDocument } from "@/chunks"
-import { getAppSyncJobsByEmail } from "@/db/syncJob"
+import { getUserSyncJobsByEmail } from "@/db/syncJob"
 import { getTracer } from "@/tracer"
 import { getDateForAI } from "@/utils/index"
 const loggerWithChild = getLoggerWithChild(Subsystem.Api)
@@ -454,25 +454,11 @@ export const SearchApi = async (c: Context) => {
       )
     }
     try {
-      const authTypeForSyncJobs =
-        process.env.NODE_ENV !== "production"
-          ? AuthType.OAuth
-          : AuthType.ServiceAccount
       const [driveConnector, gmailConnector, calendarConnector] =
         await Promise.all([
-          getAppSyncJobsByEmail(
-            db,
-            Apps.GoogleDrive,
-            authTypeForSyncJobs,
-            email,
-          ),
-          getAppSyncJobsByEmail(db, Apps.Gmail, authTypeForSyncJobs, email),
-          getAppSyncJobsByEmail(
-            db,
-            Apps.GoogleCalendar,
-            authTypeForSyncJobs,
-            email,
-          ),
+          getUserSyncJobsByEmail(db, Apps.GoogleDrive, email),
+          getUserSyncJobsByEmail(db, Apps.Gmail, email),
+          getUserSyncJobsByEmail(db, Apps.GoogleCalendar, email),
         ])
       isDriveConnected = Boolean(driveConnector && driveConnector.length > 0)
       isGmailConnected = Boolean(gmailConnector && gmailConnector.length > 0)

--- a/server/db/syncJob.ts
+++ b/server/db/syncJob.ts
@@ -61,6 +61,17 @@ export const getAppSyncJobsByEmail = async (
     )
   return z.array(selectSyncJobSchema).parse(jobs)
 }
+export const getUserSyncJobsByEmail = async (
+  trx: TxnOrClient,
+  app: Apps,
+  email: string,
+): Promise<SelectSyncJob[]> => {
+  const jobs = await trx
+    .select()
+    .from(syncJobs)
+    .where(and(and(eq(syncJobs.app, app)), eq(syncJobs.email, email)))
+  return z.array(selectSyncJobSchema).parse(jobs)
+}
 
 export const updateSyncJob = async (
   trx: TxnOrClient,

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -24,7 +24,7 @@ import { db } from "@/db/client"
 import { getConnectorByAppAndEmailId } from "@/db/connector"
 import { AuthType, ConnectorStatus } from "@/shared/types"
 import { extractDriveIds, extractCollectionVespaIds } from "./utils"
-import { getAppSyncJobsByEmail } from "@/db/syncJob"
+import { getUserSyncJobsByEmail } from "@/db/syncJob"
 // Define your Vespa endpoint and schema name
 
 const Logger = getLogger(Subsystem.Vespa).child({ module: "vespa" })
@@ -93,20 +93,11 @@ export const searchVespa = async (
     Logger.error({ err: error, email }, "Error fetching Slack connector status")
   }
   try {
-    const authTypeForSyncJobs =
-      process.env.NODE_ENV !== "production"
-        ? AuthType.OAuth
-        : AuthType.ServiceAccount
     const [driveConnector, gmailConnector, calendarConnector] =
       await Promise.all([
-        getAppSyncJobsByEmail(db, Apps.GoogleDrive, authTypeForSyncJobs, email),
-        getAppSyncJobsByEmail(db, Apps.Gmail, authTypeForSyncJobs, email),
-        getAppSyncJobsByEmail(
-          db,
-          Apps.GoogleCalendar,
-          authTypeForSyncJobs,
-          email,
-        ),
+        getUserSyncJobsByEmail(db, Apps.GoogleDrive, email),
+        getUserSyncJobsByEmail(db, Apps.Gmail, email),
+        getUserSyncJobsByEmail(db, Apps.GoogleCalendar, email),
       ])
     isDriveConnected = Boolean(driveConnector && driveConnector.length > 0)
     isGmailConnected = Boolean(gmailConnector && gmailConnector.length > 0)


### PR DESCRIPTION
### Description

Earlier we have AuthType check to diff between oauth syncJobs and ServiceAccount sync job ,
 in prod we have all syncJobs of auth type serviceAccount , and on local we have oauth type syncJobs ,
 so we had conditional check based on env is of production or local
 but now in uat we are using production env but there we have authType of oauth , so 
 removed that auth type check,


### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
