### PR TITLE
fix(appExclusion):fetch user syncJobs based on session authType

### DIFF
--- a/server/api/search.ts
+++ b/server/api/search.ts
@@ -73,7 +73,7 @@ import type {
 } from "@xyne/vespa-ts/types"
 import { getConnectorByAppAndEmailId } from "@/db/connector"
 import { chunkDocument } from "@/chunks"
-import { getUserSyncJobsByEmail } from "@/db/syncJob"
+import { getAppSyncJobsByEmail } from "@/db/syncJob"
 import { getTracer } from "@/tracer"
 import { getDateForAI } from "@/utils/index"
 const loggerWithChild = getLoggerWithChild(Subsystem.Api)
@@ -461,9 +461,19 @@ export const SearchApi = async (c: Context) => {
     try {
       const [driveConnector, gmailConnector, calendarConnector] =
         await Promise.all([
-          getUserSyncJobsByEmail(db, Apps.GoogleDrive, email),
-          getUserSyncJobsByEmail(db, Apps.Gmail, email),
-          getUserSyncJobsByEmail(db, Apps.GoogleCalendar, email),
+          getAppSyncJobsByEmail(
+            db,
+            Apps.GoogleDrive,
+            config.CurrentAuthType,
+            email,
+          ),
+          getAppSyncJobsByEmail(db, Apps.Gmail, config.CurrentAuthType, email),
+          getAppSyncJobsByEmail(
+            db,
+            Apps.GoogleCalendar,
+            config.CurrentAuthType,
+            email,
+          ),
         ])
       isDriveConnected = Boolean(driveConnector && driveConnector.length > 0)
       isGmailConnected = Boolean(gmailConnector && gmailConnector.length > 0)

--- a/server/api/search.ts
+++ b/server/api/search.ts
@@ -73,7 +73,7 @@ import type {
 } from "@xyne/vespa-ts/types"
 import { getConnectorByAppAndEmailId } from "@/db/connector"
 import { chunkDocument } from "@/chunks"
-import { getAppSyncJobsByEmail } from "@/db/syncJob"
+import { getUserSyncJobsByEmail } from "@/db/syncJob"
 import { getTracer } from "@/tracer"
 import { getDateForAI } from "@/utils/index"
 const loggerWithChild = getLoggerWithChild(Subsystem.Api)
@@ -459,25 +459,11 @@ export const SearchApi = async (c: Context) => {
       )
     }
     try {
-      const authTypeForSyncJobs =
-        process.env.NODE_ENV !== "production"
-          ? AuthType.OAuth
-          : AuthType.ServiceAccount
       const [driveConnector, gmailConnector, calendarConnector] =
         await Promise.all([
-          getAppSyncJobsByEmail(
-            db,
-            Apps.GoogleDrive,
-            authTypeForSyncJobs,
-            email,
-          ),
-          getAppSyncJobsByEmail(db, Apps.Gmail, authTypeForSyncJobs, email),
-          getAppSyncJobsByEmail(
-            db,
-            Apps.GoogleCalendar,
-            authTypeForSyncJobs,
-            email,
-          ),
+          getUserSyncJobsByEmail(db, Apps.GoogleDrive, email),
+          getUserSyncJobsByEmail(db, Apps.Gmail, email),
+          getUserSyncJobsByEmail(db, Apps.GoogleCalendar, email),
         ])
       isDriveConnected = Boolean(driveConnector && driveConnector.length > 0)
       isGmailConnected = Boolean(gmailConnector && gmailConnector.length > 0)

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,5 +1,6 @@
 import { isURLValid } from "@/validate"
 import { Models } from "@/ai/types"
+import { AuthType } from "./shared/types"
 let vespaBaseHost = "0.0.0.0"
 let vespaPort = process.env.VESPA_PORT || 8080
 let postgresBaseHost = "0.0.0.0"
@@ -47,6 +48,8 @@ let fastModelReasoning = false
 let slackHost = process.env.SLACK_HOST
 let VESPA_NAMESPACE = "my_content"
 let ragOffFeature = true
+let CurrentAuthType: AuthType =
+  (process.env.AUTH_TYPE as AuthType) || AuthType.OAuth
 const MAX_IMAGE_SIZE_BYTES = 4 * 1024 * 1024
 const MAX_SERVICE_ACCOUNT_FILE_SIZE_BYTES = 3 * 1024 // 3KB - generous limit for service account JSON files
 
@@ -211,4 +214,5 @@ export default {
   MAX_SERVICE_ACCOUNT_FILE_SIZE_BYTES,
   vespaEndpoint: `http://${vespaBaseHost}:8080`,
   defaultRecencyDecayRate: 0.1, // Decay rate for recency scoring in Vespa searches
+  CurrentAuthType,
 }

--- a/server/db/syncJob.ts
+++ b/server/db/syncJob.ts
@@ -61,6 +61,17 @@ export const getAppSyncJobsByEmail = async (
     )
   return z.array(selectSyncJobSchema).parse(jobs)
 }
+export const getUserSyncJobsByEmail = async (
+  trx: TxnOrClient,
+  app: Apps,
+  email: string,
+): Promise<SelectSyncJob[]> => {
+  const jobs = await trx
+    .select()
+    .from(syncJobs)
+    .where(and(and(eq(syncJobs.app, app)), eq(syncJobs.email, email)))
+  return z.array(selectSyncJobSchema).parse(jobs)
+}
 
 export const updateSyncJob = async (
   trx: TxnOrClient,

--- a/server/db/syncJob.ts
+++ b/server/db/syncJob.ts
@@ -61,17 +61,6 @@ export const getAppSyncJobsByEmail = async (
     )
   return z.array(selectSyncJobSchema).parse(jobs)
 }
-export const getUserSyncJobsByEmail = async (
-  trx: TxnOrClient,
-  app: Apps,
-  email: string,
-): Promise<SelectSyncJob[]> => {
-  const jobs = await trx
-    .select()
-    .from(syncJobs)
-    .where(and(and(eq(syncJobs.app, app)), eq(syncJobs.email, email)))
-  return z.array(selectSyncJobSchema).parse(jobs)
-}
 
 export const updateSyncJob = async (
   trx: TxnOrClient,

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -24,7 +24,7 @@ import { db } from "@/db/client"
 import { getConnectorByAppAndEmailId } from "@/db/connector"
 import { AuthType, ConnectorStatus } from "@/shared/types"
 import { extractDriveIds, extractCollectionVespaIds } from "./utils"
-import { getAppSyncJobsByEmail } from "@/db/syncJob"
+import { getUserSyncJobsByEmail } from "@/db/syncJob"
 // Define your Vespa endpoint and schema name
 
 const Logger = getLogger(Subsystem.Vespa).child({ module: "vespa" })
@@ -93,20 +93,11 @@ export const searchVespa = async (
     Logger.error({ err: error, email }, "Error fetching Slack connector status")
   }
   try {
-    const authTypeForSyncJobs =
-      process.env.NODE_ENV !== "production"
-        ? AuthType.OAuth
-        : AuthType.ServiceAccount
     const [driveConnector, gmailConnector, calendarConnector] =
       await Promise.all([
-        getAppSyncJobsByEmail(db, Apps.GoogleDrive, authTypeForSyncJobs, email),
-        getAppSyncJobsByEmail(db, Apps.Gmail, authTypeForSyncJobs, email),
-        getAppSyncJobsByEmail(
-          db,
-          Apps.GoogleCalendar,
-          authTypeForSyncJobs,
-          email,
-        ),
+        getUserSyncJobsByEmail(db, Apps.GoogleDrive, email),
+        getUserSyncJobsByEmail(db, Apps.Gmail, email),
+        getUserSyncJobsByEmail(db, Apps.GoogleCalendar, email),
       ])
     isDriveConnected = Boolean(driveConnector && driveConnector.length > 0)
     isGmailConnected = Boolean(gmailConnector && gmailConnector.length > 0)

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -24,7 +24,7 @@ import { db } from "@/db/client"
 import { getConnectorByAppAndEmailId } from "@/db/connector"
 import { AuthType, ConnectorStatus } from "@/shared/types"
 import { extractDriveIds, extractCollectionVespaIds } from "./utils"
-import { getUserSyncJobsByEmail } from "@/db/syncJob"
+import { getAppSyncJobsByEmail } from "@/db/syncJob"
 // Define your Vespa endpoint and schema name
 
 const Logger = getLogger(Subsystem.Vespa).child({ module: "vespa" })
@@ -95,9 +95,19 @@ export const searchVespa = async (
   try {
     const [driveConnector, gmailConnector, calendarConnector] =
       await Promise.all([
-        getUserSyncJobsByEmail(db, Apps.GoogleDrive, email),
-        getUserSyncJobsByEmail(db, Apps.Gmail, email),
-        getUserSyncJobsByEmail(db, Apps.GoogleCalendar, email),
+        getAppSyncJobsByEmail(
+          db,
+          Apps.GoogleDrive,
+          config.CurrentAuthType,
+          email,
+        ),
+        getAppSyncJobsByEmail(db, Apps.Gmail, config.CurrentAuthType, email),
+        getAppSyncJobsByEmail(
+          db,
+          Apps.GoogleCalendar,
+          config.CurrentAuthType,
+          email,
+        ),
       ])
     isDriveConnected = Boolean(driveConnector && driveConnector.length > 0)
     isGmailConnected = Boolean(gmailConnector && gmailConnector.length > 0)


### PR DESCRIPTION
### Description

Previously, we differentiated between OAuth sync jobs and ServiceAccount sync jobs using an AuthType check tied to the environment:

Prod: only ServiceAccount sync jobs

Local: only OAuth sync jobs

However, in UAT, we run on a production-like environment but still have OAuth sync jobs. This caused issues due to the conditional check.
Added an env variable to capture the current session’s authType.
Now, user syncJobs are fetched based on this session-level authType instead of relying on environment-based checks.
This makes syncJobs selection consistent across local, UAT, and production environments.

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability when detecting connected Google Drive, Gmail, and Calendar accounts.
  - Reduced false “disconnected” states and related errors during global search.
  - Ensured consistent behavior across environments for Google integrations.

- Refactor
  - Unified the logic that checks Google service connections to use a single user-centric approach, simplifying how connectivity is determined across Drive, Gmail, and Calendar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->