### PR TITLE
fix(appExclusion):fetch user syncJobs based on session authType (#958)

### DIFF
--- a/server/api/search.ts
+++ b/server/api/search.ts
@@ -454,23 +454,19 @@ export const SearchApi = async (c: Context) => {
       )
     }
     try {
-      const authTypeForSyncJobs =
-        process.env.NODE_ENV !== "production"
-          ? AuthType.OAuth
-          : AuthType.ServiceAccount
       const [driveConnector, gmailConnector, calendarConnector] =
         await Promise.all([
           getAppSyncJobsByEmail(
             db,
             Apps.GoogleDrive,
-            authTypeForSyncJobs,
+            config.CurrentAuthType,
             email,
           ),
-          getAppSyncJobsByEmail(db, Apps.Gmail, authTypeForSyncJobs, email),
+          getAppSyncJobsByEmail(db, Apps.Gmail, config.CurrentAuthType, email),
           getAppSyncJobsByEmail(
             db,
             Apps.GoogleCalendar,
-            authTypeForSyncJobs,
+            config.CurrentAuthType,
             email,
           ),
         ])

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,5 +1,6 @@
 import { isURLValid } from "@/validate"
 import { Models } from "@/ai/types"
+import { AuthType } from "./shared/types"
 let vespaBaseHost = "0.0.0.0"
 let vespaPort = process.env.VESPA_PORT || 8080
 let postgresBaseHost = "0.0.0.0"
@@ -46,6 +47,8 @@ let fastModelReasoning = false
 let slackHost = process.env.SLACK_HOST
 let VESPA_NAMESPACE = "my_content"
 let ragOffFeature = true
+let CurrentAuthType: AuthType =
+  (process.env.AUTH_TYPE as AuthType) || AuthType.OAuth
 const MAX_IMAGE_SIZE_BYTES = 4 * 1024 * 1024
 const MAX_SERVICE_ACCOUNT_FILE_SIZE_BYTES = 3 * 1024 // 3KB - generous limit for service account JSON files
 
@@ -210,4 +213,5 @@ export default {
   MAX_SERVICE_ACCOUNT_FILE_SIZE_BYTES,
   vespaEndpoint: `http://${vespaBaseHost}:8080`,
   defaultRecencyDecayRate: 0.1, // Decay rate for recency scoring in Vespa searches
+  CurrentAuthType,
 }

--- a/server/search/vespa.ts
+++ b/server/search/vespa.ts
@@ -93,18 +93,19 @@ export const searchVespa = async (
     Logger.error({ err: error, email }, "Error fetching Slack connector status")
   }
   try {
-    const authTypeForSyncJobs =
-      process.env.NODE_ENV !== "production"
-        ? AuthType.OAuth
-        : AuthType.ServiceAccount
     const [driveConnector, gmailConnector, calendarConnector] =
       await Promise.all([
-        getAppSyncJobsByEmail(db, Apps.GoogleDrive, authTypeForSyncJobs, email),
-        getAppSyncJobsByEmail(db, Apps.Gmail, authTypeForSyncJobs, email),
+        getAppSyncJobsByEmail(
+          db,
+          Apps.GoogleDrive,
+          config.CurrentAuthType,
+          email,
+        ),
+        getAppSyncJobsByEmail(db, Apps.Gmail, config.CurrentAuthType, email),
         getAppSyncJobsByEmail(
           db,
           Apps.GoogleCalendar,
-          authTypeForSyncJobs,
+          config.CurrentAuthType,
           email,
         ),
       ])


### PR DESCRIPTION
### Description

Previously, we differentiated between OAuth sync jobs and ServiceAccount sync jobs using an AuthType check tied to the environment:

Prod: only ServiceAccount sync jobs

Local: only OAuth sync jobs

However, in UAT, we run on a production-like environment but still have OAuth sync jobs. This caused issues due to the conditional check.
Added an env variable to capture the current session’s authType.
Now, user syncJobs are fetched based on this session-level authType instead of relying on environment-based checks.
This makes syncJobs selection consistent across local, UAT, and production environments.

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
