### PR TITLE
fix(copy-file-vespa): added a feature to copy vespa data for docs in kb

### DIFF
--- a/frontend/src/components/DebugDocModal.tsx
+++ b/frontend/src/components/DebugDocModal.tsx
@@ -5,8 +5,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
 import { useToast } from "@/hooks/use-toast"
 import { authFetch } from "@/utils/authFetch"
+import { Copy } from "lucide-react"
 import ReactJsonView from "react-json-view"
 
 interface DebugDocModalProps {
@@ -51,6 +53,31 @@ export function DebugDocModal({
   const { toast } = useToast()
   const [vespaData, setVespaData] = useState<KnowledgeBaseFile | null>(null)
   const [loadingVespaData, setLoadingVespaData] = useState(false)
+
+  const handleCopyToClipboard = async () => {
+    if (!vespaData) {
+      toast.error({
+        title: "Error",
+        description: "No data available to copy",
+      })
+      return
+    }
+
+    try {
+      const formattedData = JSON.stringify(vespaData, null, 2)
+      await navigator.clipboard.writeText(formattedData)
+      toast.success({
+        title: "Success",
+        description: "Vespa data copied to clipboard",
+      })
+    } catch (error) {
+      console.error("Error copying to clipboard:", error)
+      toast.error({
+        title: "Error",
+        description: "Failed to copy data to clipboard",
+      })
+    }
+  }
 
   const handleFetchVespaData = async () => {
     if (!documentId) {
@@ -122,9 +149,21 @@ export function DebugDocModal({
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-[60vw] w-full max-h-[95vh] overflow-hidden flex flex-col">
         <DialogHeader>
-          <DialogTitle className="text-lg font-semibold">
-            Vespa Document Data - {documentName}
-          </DialogTitle>
+          <div className="flex items-center justify-between">
+            <DialogTitle className="text-lg font-semibold">
+              Vespa Document Data - {documentName}
+            </DialogTitle>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleCopyToClipboard}
+              disabled={!vespaData || loadingVespaData}
+              className="flex items-center gap-2 mr-8"
+            >
+              <Copy className="h-4 w-4" />
+              Copy Data
+            </Button>
+          </div>
         </DialogHeader>
         <div className="flex-1 overflow-auto p-4">
           {loadingVespaData ? (

--- a/frontend/src/routes/_authenticated/knowledgeManagement.tsx
+++ b/frontend/src/routes/_authenticated/knowledgeManagement.tsx
@@ -1475,9 +1475,9 @@ function KnowledgeManagementContent() {
                         onClick={handleViewVespaData}
                         variant="ghost"
                         size="sm"
-                        className="flex items-center gap-2 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 px-2 py-1 h-auto"
+                        className="flex items-center gap-6 text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 px-2 py-1 h-auto border-2"
                       >
-                        View
+                        Raw view
                       </Button>
                     )}
                     <Button


### PR DESCRIPTION
### Description
- added a feature to copy vespa data of a knowledge base file 

### Testing
- tested locally 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Copy Data” button in the debug document modal to copy Vespa data to the clipboard, with success/error toasts. Button is disabled when data is unavailable or loading.
* **Style**
  * Updated knowledge management header button label to “Raw view.”
  * Increased spacing and added a border for improved visual clarity.
  * Aligned the modal title and action button on a single row for a cleaner header layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->