### PR TITLE
fix: XYN-301 RAG on button for admins

### DIFF
--- a/frontend/src/routes/_authenticated/agent.tsx
+++ b/frontend/src/routes/_authenticated/agent.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
-// import { Switch } from "@/components/ui/switch"
+import { Switch } from "@/components/ui/switch"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,6 +31,7 @@ import {
   SlackEntity,
   AgentPromptPayload,
   DEFAULT_TEST_AGENT_ID,
+  UserRole,
 } from "shared/types"
 import {
   ChevronDown,
@@ -3129,16 +3130,19 @@ function AgentComponent() {
                         Select knowledge sources for your agent.
                       </p>
                     </div>
-                    {/* <div className="flex items-center gap-3">
-                      <Label className="text-sm font-medium text-gray-700 dark:text-gray-300">
-                        RAG
-                      </Label>
-                      <Switch
-                        checked={isRagOn}
-                        onCheckedChange={setIsRagOn}
-                        id="rag-toggle"
-                      />
-                    </div> */}
+                    {(user?.role === UserRole.Admin ||
+                      user?.role === UserRole.SuperAdmin) && (
+                      <div className="flex items-center gap-3">
+                        <Label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          RAG
+                        </Label>
+                        <Switch
+                          checked={isRagOn}
+                          onCheckedChange={setIsRagOn}
+                          id="rag-toggle"
+                        />
+                      </div>
+                    )}
                   </div>
                   <div className="flex flex-wrap items-center gap-2 p-3 border border-gray-300 dark:border-gray-600 rounded-lg min-h-[48px] bg-white dark:bg-slate-700">
                     {currentSelectedIntegrationObjects.length === 0 && (


### PR DESCRIPTION
### Description

quick fix to hide agent button

### Testing

tested locally.

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role-based control in the agent editor: the RAG toggle is now available only to Admin and SuperAdmin users.

* **Improvements**
  * Streamlined UI for non-admin users by hiding admin-only controls in the agent editor.
  * Clearer permissions experience, ensuring only authorized users can configure RAG settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->