### PR TITLE
fix(agentPathSupport): path referred folder considered as integration 

### DIFF
--- a/server/api/chat/agents.ts
+++ b/server/api/chat/agents.ts
@@ -121,6 +121,7 @@ import {
   convertReasoningStepToText,
   extractFileIdsFromMessage,
   extractImageFileNames,
+  extractItemIdsFromPath,
   getCitationToImage,
   handleError,
   isMessageWithContext,
@@ -3532,16 +3533,17 @@ export const AgentMessageApi = async (c: Context) => {
       }
     }
     const isMsgWithContext = isMessageWithContext(message)
-    const extractedInfo =
-      isMsgWithContext || (path && ids)
-        ? await extractFileIdsFromMessage(message, email, ids)
-        : {
-            totalValidFileIdsFromLinkCount: 0,
-            fileIds: [],
-            collectionFolderIds: [],
-          }
+    const extractedInfo = isMsgWithContext
+      ? await extractFileIdsFromMessage(message, email)
+      : {
+          totalValidFileIdsFromLinkCount: 0,
+          fileIds: [],
+          collectionFolderIds: [],
+        }
+    const pathExtractedInfo = isValidPath
+      ? await extractItemIdsFromPath(ids)
+      : { collectionFileIds: [], collectionFolderIds: [], collectionIds: [] }
     let fileIds = extractedInfo?.fileIds
-    let folderIds = extractedInfo?.collectionFolderIds
     if (nonImageAttachmentFileIds && nonImageAttachmentFileIds.length > 0) {
       fileIds = [...fileIds, ...nonImageAttachmentFileIds]
     }
@@ -3760,9 +3762,6 @@ export const AgentMessageApi = async (c: Context) => {
                 imageAttachmentFileIds,
                 agentPromptForLLM,
                 fileIds.length > 0,
-                actualModelId,
-                Boolean(isValidPath),
-                folderIds,
               )
               stream.writeSSE({
                 event: ChatSSEvents.Start,
@@ -4304,6 +4303,12 @@ export const AgentMessageApi = async (c: Context) => {
                   userRequestsReasoning,
                   understandSpan,
                   agentPromptForLLM,
+                  actualModelId,
+                  {
+                    collectionfileIds: pathExtractedInfo.collectionFileIds,
+                    collectionFolderIds: pathExtractedInfo.collectionFolderIds,
+                    collectionIds: pathExtractedInfo.collectionIds,
+                  },
                 )
                 stream.writeSSE({
                   event: ChatSSEvents.Start,

--- a/server/api/chat/agents.ts
+++ b/server/api/chat/agents.ts
@@ -3541,7 +3541,7 @@ export const AgentMessageApi = async (c: Context) => {
           collectionFolderIds: [],
         }
     const pathExtractedInfo = isValidPath
-      ? await extractItemIdsFromPath(ids)
+      ? await extractItemIdsFromPath(ids ?? "")
       : { collectionFileIds: [], collectionFolderIds: [], collectionIds: [] }
     let fileIds = extractedInfo?.fileIds
     if (nonImageAttachmentFileIds && nonImageAttachmentFileIds.length > 0) {

--- a/server/api/chat/agents.ts
+++ b/server/api/chat/agents.ts
@@ -4304,11 +4304,7 @@ export const AgentMessageApi = async (c: Context) => {
                   understandSpan,
                   agentPromptForLLM,
                   actualModelId,
-                  {
-                    collectionfileIds: pathExtractedInfo.collectionFileIds,
-                    collectionFolderIds: pathExtractedInfo.collectionFolderIds,
-                    collectionIds: pathExtractedInfo.collectionIds,
-                  },
+                  pathExtractedInfo,
                 )
                 stream.writeSSE({
                   event: ChatSSEvents.Start,

--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -1349,14 +1349,14 @@ async function* generateIterativeTimeFilterAndQueryRewrite(
         let source = []
         if (
           pathExtractedInfo &&
-          (pathExtractedInfo.collectionfileIds.length ||
+          (pathExtractedInfo.collectionFileIds.length ||
             pathExtractedInfo.collectionFolderIds.length ||
             pathExtractedInfo.collectionIds.length)
         ) {
           if (pathExtractedInfo.collectionFolderIds.length) {
             source = pathExtractedInfo.collectionFolderIds
-          } else if (pathExtractedInfo.collectionfileIds.length) {
-            source = pathExtractedInfo.collectionfileIds
+          } else if (pathExtractedInfo.collectionFileIds.length) {
+            source = pathExtractedInfo.collectionFileIds
           } else {
             source = pathExtractedInfo.collectionIds
           }
@@ -2622,14 +2622,14 @@ async function* generatePointQueryTimeExpansion(
         let source = []
         if (
           pathExtractedInfo &&
-          (pathExtractedInfo.collectionfileIds.length ||
+          (pathExtractedInfo.collectionFileIds.length ||
             pathExtractedInfo.collectionFolderIds.length ||
             pathExtractedInfo.collectionIds.length)
         ) {
           if (pathExtractedInfo.collectionFolderIds.length) {
             source = pathExtractedInfo.collectionFolderIds
-          } else if (pathExtractedInfo.collectionfileIds.length) {
-            source = pathExtractedInfo.collectionfileIds
+          } else if (pathExtractedInfo.collectionFileIds.length) {
+            source = pathExtractedInfo.collectionFileIds
           } else {
             source = pathExtractedInfo.collectionIds
           }
@@ -3202,14 +3202,14 @@ async function* generateMetadataQueryAnswer(
         let source = []
         if (
           pathExtractedInfo &&
-          (pathExtractedInfo.collectionfileIds.length ||
+          (pathExtractedInfo.collectionFileIds.length ||
             pathExtractedInfo.collectionFolderIds.length ||
             pathExtractedInfo.collectionIds.length)
         ) {
           if (pathExtractedInfo.collectionFolderIds?.length) {
             source = pathExtractedInfo.collectionFolderIds
-          } else if (pathExtractedInfo.collectionfileIds.length) {
-            source = pathExtractedInfo.collectionfileIds
+          } else if (pathExtractedInfo.collectionFileIds.length) {
+            source = pathExtractedInfo.collectionFileIds
           } else {
             source = pathExtractedInfo.collectionIds
           }
@@ -3830,7 +3830,7 @@ const fallbackText = (classification: QueryRouterLLMResponse): string => {
 }
 
 export type pathExtractedInfo = {
-  collectionfileIds: string[]
+  collectionFileIds: string[]
   collectionFolderIds: string[]
   collectionIds: string[]
 }

--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -1222,7 +1222,7 @@ async function* generateIterativeTimeFilterAndQueryRewrite(
   userRequestsReasoning?: boolean,
   queryRagSpan?: Span,
   agentPrompt?: string,
-  pathExtractedInfo?: pathExtractedInfo,
+  pathExtractedInfo?: PathExtractedInfo,
 ): AsyncIterableIterator<
   ConverseResponse & {
     citation?: { index: number; item: any }
@@ -1346,23 +1346,7 @@ async function* generateIterativeTimeFilterAndQueryRewrite(
         const collectionIds: string[] = []
         const collectionFolderIds: string[] = []
         const collectionFileIds: string[] = []
-        let source = []
-        if (
-          pathExtractedInfo &&
-          (pathExtractedInfo.collectionFileIds.length ||
-            pathExtractedInfo.collectionFolderIds.length ||
-            pathExtractedInfo.collectionIds.length)
-        ) {
-          if (pathExtractedInfo.collectionFolderIds.length) {
-            source = pathExtractedInfo.collectionFolderIds
-          } else if (pathExtractedInfo.collectionFileIds.length) {
-            source = pathExtractedInfo.collectionFileIds
-          } else {
-            source = pathExtractedInfo.collectionIds
-          }
-        } else {
-          source = selectedItems[Apps.KnowledgeBase]
-        }
+        const source = getCollectionSource(pathExtractedInfo, selectedItems)
 
         for (const itemId of source) {
           if (itemId.startsWith("cl-")) {
@@ -2501,7 +2485,7 @@ async function* generatePointQueryTimeExpansion(
   userRequestsReasoning: boolean,
   eventRagSpan?: Span,
   agentPrompt?: string,
-  pathExtractedInfo?: pathExtractedInfo,
+  pathExtractedInfo?: PathExtractedInfo,
 ): AsyncIterableIterator<
   ConverseResponse & {
     citation?: { index: number; item: any }
@@ -2619,23 +2603,7 @@ async function* generatePointQueryTimeExpansion(
         const collectionIds: string[] = []
         const collectionFolderIds: string[] = []
         const collectionFileIds: string[] = []
-        let source = []
-        if (
-          pathExtractedInfo &&
-          (pathExtractedInfo.collectionFileIds.length ||
-            pathExtractedInfo.collectionFolderIds.length ||
-            pathExtractedInfo.collectionIds.length)
-        ) {
-          if (pathExtractedInfo.collectionFolderIds.length) {
-            source = pathExtractedInfo.collectionFolderIds
-          } else if (pathExtractedInfo.collectionFileIds.length) {
-            source = pathExtractedInfo.collectionFileIds
-          } else {
-            source = pathExtractedInfo.collectionIds
-          }
-        } else {
-          source = selectedItems[Apps.KnowledgeBase]
-        }
+        const source = getCollectionSource(pathExtractedInfo, selectedItems)
         for (const itemId of source) {
           if (itemId.startsWith("cl-")) {
             // Entire collection - remove cl- prefix
@@ -3082,7 +3050,7 @@ async function* generateMetadataQueryAnswer(
   agentPrompt?: string,
   maxIterations = 5,
   modelId?: string,
-  pathExtractedInfo?: pathExtractedInfo,
+  pathExtractedInfo?: PathExtractedInfo,
 ): AsyncIterableIterator<
   ConverseResponse & {
     citation?: { index: number; item: any }
@@ -3199,23 +3167,7 @@ async function* generateMetadataQueryAnswer(
         const collectionIds: string[] = []
         const collectionFolderIds: string[] = []
         const collectionFileIds: string[] = []
-        let source = []
-        if (
-          pathExtractedInfo &&
-          (pathExtractedInfo.collectionFileIds.length ||
-            pathExtractedInfo.collectionFolderIds.length ||
-            pathExtractedInfo.collectionIds.length)
-        ) {
-          if (pathExtractedInfo.collectionFolderIds?.length) {
-            source = pathExtractedInfo.collectionFolderIds
-          } else if (pathExtractedInfo.collectionFileIds.length) {
-            source = pathExtractedInfo.collectionFileIds
-          } else {
-            source = pathExtractedInfo.collectionIds
-          }
-        } else {
-          source = selectedItems[Apps.KnowledgeBase]
-        }
+        const source = getCollectionSource(pathExtractedInfo, selectedItems)
         for (const itemId of source) {
           if (itemId.startsWith("cl-")) {
             // Entire collection - remove cl- prefix
@@ -3829,10 +3781,32 @@ const fallbackText = (classification: QueryRouterLLMResponse): string => {
   return `${searchDescription}${timeDescription}`
 }
 
-export type pathExtractedInfo = {
+export type PathExtractedInfo = {
   collectionFileIds: string[]
   collectionFolderIds: string[]
   collectionIds: string[]
+}
+
+export function getCollectionSource(
+  pathExtractedInfo: PathExtractedInfo | undefined,
+  selectedItems: Record<string, any>,
+): string[] {
+  if (
+    pathExtractedInfo &&
+    (pathExtractedInfo.collectionFileIds.length ||
+      pathExtractedInfo.collectionFolderIds.length ||
+      pathExtractedInfo.collectionIds.length)
+  ) {
+    if (pathExtractedInfo.collectionFolderIds.length) {
+      return pathExtractedInfo.collectionFolderIds
+    } else if (pathExtractedInfo.collectionFileIds.length) {
+      return pathExtractedInfo.collectionFileIds
+    } else {
+      return pathExtractedInfo.collectionIds
+    }
+  } else {
+    return selectedItems[Apps.KnowledgeBase] || []
+  }
 }
 
 export async function* UnderstandMessageAndAnswer(
@@ -3847,7 +3821,7 @@ export async function* UnderstandMessageAndAnswer(
   passedSpan?: Span,
   agentPrompt?: string,
   modelId?: string,
-  pathExtractedInfo?: pathExtractedInfo,
+  pathExtractedInfo?: PathExtractedInfo,
 ): AsyncIterableIterator<
   ConverseResponse & {
     citation?: { index: number; item: any }

--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -1222,6 +1222,7 @@ async function* generateIterativeTimeFilterAndQueryRewrite(
   userRequestsReasoning?: boolean,
   queryRagSpan?: Span,
   agentPrompt?: string,
+  pathExtractedInfo?: pathExtractedInfo,
 ): AsyncIterableIterator<
   ConverseResponse & {
     citation?: { index: number; item: any }
@@ -1345,8 +1346,25 @@ async function* generateIterativeTimeFilterAndQueryRewrite(
         const collectionIds: string[] = []
         const collectionFolderIds: string[] = []
         const collectionFileIds: string[] = []
+        let source = []
+        if (
+          pathExtractedInfo &&
+          (pathExtractedInfo.collectionfileIds.length ||
+            pathExtractedInfo.collectionFolderIds.length ||
+            pathExtractedInfo.collectionIds.length)
+        ) {
+          if (pathExtractedInfo.collectionFolderIds.length) {
+            source = pathExtractedInfo.collectionFolderIds
+          } else if (pathExtractedInfo.collectionfileIds.length) {
+            source = pathExtractedInfo.collectionfileIds
+          } else {
+            source = pathExtractedInfo.collectionIds
+          }
+        } else {
+          source = selectedItems[Apps.KnowledgeBase]
+        }
 
-        for (const itemId of selectedItems[Apps.KnowledgeBase]) {
+        for (const itemId of source) {
           if (itemId.startsWith("cl-")) {
             // Entire collection - remove cl- prefix
             collectionIds.push(itemId.replace(/^cl[-_]/, ""))
@@ -2483,6 +2501,7 @@ async function* generatePointQueryTimeExpansion(
   userRequestsReasoning: boolean,
   eventRagSpan?: Span,
   agentPrompt?: string,
+  pathExtractedInfo?: pathExtractedInfo,
 ): AsyncIterableIterator<
   ConverseResponse & {
     citation?: { index: number; item: any }
@@ -2600,8 +2619,24 @@ async function* generatePointQueryTimeExpansion(
         const collectionIds: string[] = []
         const collectionFolderIds: string[] = []
         const collectionFileIds: string[] = []
-
-        for (const itemId of selectedItems[Apps.KnowledgeBase]) {
+        let source = []
+        if (
+          pathExtractedInfo &&
+          (pathExtractedInfo.collectionfileIds.length ||
+            pathExtractedInfo.collectionFolderIds.length ||
+            pathExtractedInfo.collectionIds.length)
+        ) {
+          if (pathExtractedInfo.collectionFolderIds.length) {
+            source = pathExtractedInfo.collectionFolderIds
+          } else if (pathExtractedInfo.collectionfileIds.length) {
+            source = pathExtractedInfo.collectionfileIds
+          } else {
+            source = pathExtractedInfo.collectionIds
+          }
+        } else {
+          source = selectedItems[Apps.KnowledgeBase]
+        }
+        for (const itemId of source) {
           if (itemId.startsWith("cl-")) {
             // Entire collection - remove cl- prefix
             collectionIds.push(itemId.replace(/^cl[-_]/, ""))
@@ -3047,6 +3082,7 @@ async function* generateMetadataQueryAnswer(
   agentPrompt?: string,
   maxIterations = 5,
   modelId?: string,
+  pathExtractedInfo?: pathExtractedInfo,
 ): AsyncIterableIterator<
   ConverseResponse & {
     citation?: { index: number; item: any }
@@ -3163,8 +3199,24 @@ async function* generateMetadataQueryAnswer(
         const collectionIds: string[] = []
         const collectionFolderIds: string[] = []
         const collectionFileIds: string[] = []
-
-        for (const itemId of selectedItems[Apps.KnowledgeBase]) {
+        let source = []
+        if (
+          pathExtractedInfo &&
+          (pathExtractedInfo.collectionfileIds.length ||
+            pathExtractedInfo.collectionFolderIds.length ||
+            pathExtractedInfo.collectionIds.length)
+        ) {
+          if (pathExtractedInfo.collectionFolderIds?.length) {
+            source = pathExtractedInfo.collectionFolderIds
+          } else if (pathExtractedInfo.collectionfileIds.length) {
+            source = pathExtractedInfo.collectionfileIds
+          } else {
+            source = pathExtractedInfo.collectionIds
+          }
+        } else {
+          source = selectedItems[Apps.KnowledgeBase]
+        }
+        for (const itemId of source) {
           if (itemId.startsWith("cl-")) {
             // Entire collection - remove cl- prefix
             collectionIds.push(itemId.replace(/^cl[-_]/, ""))
@@ -3777,6 +3829,12 @@ const fallbackText = (classification: QueryRouterLLMResponse): string => {
   return `${searchDescription}${timeDescription}`
 }
 
+export type pathExtractedInfo = {
+  collectionfileIds: string[]
+  collectionFolderIds: string[]
+  collectionIds: string[]
+}
+
 export async function* UnderstandMessageAndAnswer(
   email: string,
   userCtx: string,
@@ -3789,6 +3847,7 @@ export async function* UnderstandMessageAndAnswer(
   passedSpan?: Span,
   agentPrompt?: string,
   modelId?: string,
+  pathExtractedInfo?: pathExtractedInfo,
 ): AsyncIterableIterator<
   ConverseResponse & {
     citation?: { index: number; item: any }
@@ -3836,6 +3895,7 @@ export async function* UnderstandMessageAndAnswer(
       agentPrompt,
       5,
       modelId,
+      pathExtractedInfo,
     )
 
     let hasYieldedAnswer = false
@@ -3884,6 +3944,7 @@ export async function* UnderstandMessageAndAnswer(
       userRequestsReasoning,
       eventRagSpan,
       agentPrompt,
+      pathExtractedInfo,
     )
   } else {
     loggerWithChild({ email: email }).info(
@@ -3906,6 +3967,7 @@ export async function* UnderstandMessageAndAnswer(
       userRequestsReasoning,
       ragSpan,
       agentPrompt, // Pass agentPrompt to generateIterativeTimeFilterAndQueryRewrite
+      pathExtractedInfo,
     )
   }
 }

--- a/server/api/chat/utils.ts
+++ b/server/api/chat/utils.ts
@@ -694,7 +694,7 @@ export const extractFileIdsFromMessage = async (
   }
 }
 export const extractItemIdsFromPath = async (
-  pathRefId: any,
+  pathRefId: string,
 ): Promise<{
   collectionFileIds: string[]
   collectionFolderIds: string[]


### PR DESCRIPTION
### Description
if the path is passed to AgentMessageApi , while doing the vespa call we replace the kb integration with the path referenced folder or file


### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Answers now use collection/folder/file context derived from the current path, improving relevance.
  - Path-based context applied consistently for both streamed and non-streamed responses.
  - Model selection now receives explicit model info for more accurate results.

- Bug Fixes
  - More resilient handling of missing or invalid path context, gracefully falling back to previous behavior.
  - Reduced edge-case inconsistencies when selecting knowledge-base items from navigation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->