### PR TITLE
fix(drive-breadcrumb): fixed drive breadcrumb navigation

### DIFF
--- a/frontend/src/routes/_authenticated/agent.tsx
+++ b/frontend/src/routes/_authenticated/agent.tsx
@@ -379,10 +379,14 @@ function AgentComponent() {
     folderId: string,
     folderName: string,
   ) => {
+    
+    const isAlreadyInPath=navigationPath.some(item => item.id === folderId);
+    if(!isAlreadyInPath){
     setNavigationPath((prev) => [
       ...prev,
       { id: folderId, name: folderName, type: "drive-folder" },
     ])
+  }
     setIsLoadingItems(true)
     try {
       const response = await api.search.driveitem.$post({
@@ -3327,6 +3331,7 @@ function AgentComponent() {
                                   {(() => {
                                     // Show up to 3 items in the breadcrumb
                                     if (navigationPath.length > 0) {
+                                     
                                       // Get the last 3 items or all if less than 3
                                       const itemsToShow =
                                         navigationPath.length <= 3
@@ -3336,7 +3341,7 @@ function AgentComponent() {
                                             )
 
                                       return itemsToShow.map((item, index) => (
-                                        <React.Fragment key={item.id}>
+                                        <React.Fragment key={`${item.id}-${index}`}>
                                           <span className="mx-2 flex-shrink-0">
                                             /
                                           </span>
@@ -3344,15 +3349,18 @@ function AgentComponent() {
                                             className={`max-w-[60px] truncate ${index < itemsToShow.length - 1 ? "cursor-pointer hover:text-gray-800 dark:hover:text-gray-100" : "font-medium"}`}
                                             title={item.name}
                                             onClick={() => {
+                                              
                                               if (
                                                 index <
                                                 itemsToShow.length - 1
                                               ) {
+                                              
                                                 // Navigate to this item
                                                 const newPathIndex =
                                                   navigationPath.findIndex(
                                                     (p) => p.id === item.id,
                                                   )
+                                               
                                                 if (newPathIndex >= 0) {
                                                   const newPath =
                                                     navigationPath.slice(
@@ -3360,6 +3368,7 @@ function AgentComponent() {
                                                       newPathIndex + 1,
                                                     )
                                                   setNavigationPath(newPath)
+                                                 
 
                                                   if (
                                                     newPath.length === 1 &&
@@ -3368,7 +3377,7 @@ function AgentComponent() {
                                                   ) {
                                                     setCurrentItems([])
                                                   } else if (
-                                                    newPath.length > 1
+                                                    newPath.length > 1 && newPath[0].type==="cl-root"
                                                   ) {
                                                     const clId = newPath.find(
                                                       (item) =>
@@ -3419,6 +3428,17 @@ function AgentComponent() {
                                                             false,
                                                           ),
                                                         )
+                                                    }
+                                                  }
+                                                  else if(newPath.length === 1 && newPath[0].type === "drive-root"){
+                                                    
+                                                       navigateToGoogleDrive();
+                                                  }
+                                                  else if(newPath.length>1 && newPath[0].type === "drive-root"){
+                                                    if(newPath[newPath.length-1].type === "drive-folder"){
+                                                    const FolderId=newPath[newPath.length-1].id;
+                                                    const FolderName=newPath[newPath.length-1].name
+                                                    navigateToDriveFolder(FolderId,FolderName);
                                                     }
                                                   }
                                                 }

--- a/frontend/src/routes/_authenticated/agent.tsx
+++ b/frontend/src/routes/_authenticated/agent.tsx
@@ -380,13 +380,17 @@ function AgentComponent() {
     folderName: string,
   ) => {
     
-    const isAlreadyInPath=navigationPath.some(item => item.id === folderId);
-    if(!isAlreadyInPath){
-    setNavigationPath((prev) => [
-      ...prev,
-      { id: folderId, name: folderName, type: "drive-folder" },
-    ])
-  }
+    
+    setNavigationPath((prev) => {
+      if (prev.length > 0 && prev[prev.length - 1].id === folderId) {
+        return prev;
+      }
+      return [
+        ...prev,
+        { id: folderId, name: folderName, type: "drive-folder" },
+      ];
+    });
+  
     setIsLoadingItems(true)
     try {
       const response = await api.search.driveitem.$post({


### PR DESCRIPTION
### Description
fixed drive breadcrumb navigation

### Testing
tested locally



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate folders in the breadcrumb trail and navigation path.
  * Resolved breadcrumb rendering key conflicts when items share IDs.
  * Fixed breadcrumb clicks to correctly navigate between Google Drive root, specific folders, and CL root.
  * Ensured correct content is fetched when moving between Drive and CL paths.

* **Refactor**
  * Streamlined control flow and added guards for edge cases in breadcrumb-driven navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->