### PR TITLE
fix(userRelevanceScore): removed the vector score from user.sd

### DIFF
--- a/server/vespa/schemas/user.sd
+++ b/server/vespa/schemas/user.sd
@@ -139,12 +139,7 @@ schema user {
         }
     }
 
-    field chunk_embeddings type tensor<bfloat16>(v[DIMS])  {
-        indexing: (input name || "") . " " .(input email || "") | embed | attribute | index
-        attribute {
-            distance-metric: angular
-        }
-    }
+    
 
     # Fuzzy matching for the 'name' field
     field name_fuzzy type string {
@@ -221,9 +216,6 @@ schema user {
             expression: (nativeRank(name) +  nativeRank(email)) / if(matchedFieldCount == 0, 1, matchedFieldCount)
         }
 
-        function vector_score() {
-            expression: closeness(field, chunk_embeddings)
-        }
     }
 
     rank-profile default_native inherits initial {
@@ -239,22 +231,19 @@ schema user {
         }
     }
 rank-profile title_boosted_hybrid inherits initial {
-  first-phase {
-    expression: (query(alpha) * vector_score) + ((1 - query(alpha)) * (3 * nativeRank(name)))
-  }
+ 
   
   global-phase {
     expression {
-      1.2 * (
-        (query(alpha) * vector_score) + 
-        ((1 - query(alpha)) * (3 * nativeRank(name)))
-      )
+      (3 * combined_nativeRank)
     }
     rerank-count: 1000
   }
 
   match-features {
+    matchedFieldCount
     nativeRank(name)
+    nativeRank(email)
   }
 }
 
@@ -292,7 +281,7 @@ rank-profile title_boosted_hybrid inherits initial {
 
         # Calculate the hybrid relevance score (combining vector and lexical search)
         function hybrid_relevance_score() {
-          expression: (query(alpha) * vector_score()) + ((1 - query(alpha)) * combined_nativeRank)
+          expression:  2 * (combined_nativeRank)
         }
 
         # --- Ranking Expression ---
@@ -304,7 +293,6 @@ rank-profile title_boosted_hybrid inherits initial {
         # Include all relevant features for debugging/monitoring
         match-features {
           query(alpha)
-          vector_score
           combined_nativeRank
           matchedFieldCount # Make sure matchedFieldCount is defined in 'initial' or here if used
           # Specific nativeRank fields for user
@@ -351,7 +339,6 @@ rank-profile title_boosted_hybrid inherits initial {
             matchedFieldCount
             nativeRank(name)
             nativeRank(email)
-            vector_score
         }
     }
 

--- a/server/vespa/schemas/user.sd
+++ b/server/vespa/schemas/user.sd
@@ -229,14 +229,13 @@ schema user {
     rank-profile default_native inherits initial {
         # slight boost for people
         global-phase {
-            expression: 1.2 * ((query(alpha) * vector_score) + ((1 - query(alpha)) *  combined_nativeRank))
+            expression: 2 * (combined_nativeRank)
         }
 
         match-features {
             matchedFieldCount
             nativeRank(name)
             nativeRank(email)
-            vector_score
         }
     }
 rank-profile title_boosted_hybrid inherits initial {


### PR DESCRIPTION


### Description

removed the vector score in default native profile of user.sd , boosted the nativeRank score  to support the exact match of contacts

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified ranking to rely on a single combined relevance signal, removing the separate vector-based component for scoring.
  * Results ranking is more consistent and may be faster under load; no UI changes.

* **New Features**
  * Added a recency-aware global sorting option that bins by document age and applies hybrid scoring within bins to boost recent, relevant results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->