### PR TITLE
fix(drive-item): fixed drive item sort and select issue

### DIFF
--- a/frontend/src/components/GoogleDriveNavigation.tsx
+++ b/frontend/src/components/GoogleDriveNavigation.tsx
@@ -230,7 +230,7 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
               </div>
             ) : searchResults.length > 0 ? (
               searchResults.map((result: any) => {
-                const itemId = result.docId
+                const itemDocId = result.docId
                 const itemEntity = result.entity
                 const itemTitle = result.title || result.name || "Untitled"
                 const isFolder = itemEntity === DriveEntity.Folder
@@ -245,7 +245,7 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
 
                 return (
                   <div
-                    key={itemId}
+                    key={itemDocId}
                     className="flex items-center px-4 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800"
                   >
                     <input
@@ -254,12 +254,12 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
                         e.stopPropagation()
 
                         handleGoogleDriveItemSelection(
-                          itemId,
+                          itemDocId,
                           // Normalize the data structure for search results
                           {
                             ...result,
                             fields: {
-                              docId: result.docId || itemId,
+                              docId: itemDocId,
                               title: result.title || result.name || itemTitle,
                               name: result.name || result.title || itemTitle,
                               entity: result.entity || itemEntity,
@@ -305,7 +305,7 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
               </div>
             ) : sortedItems.length > 0 ? (
               sortedItems.map((item: any) => {
-                const itemId = item.id || item.fields?.docId
+               
                 const itemDocId = item.fields?.docId
                 const itemEntity = item.fields?.entity
                 const itemTitle =
@@ -314,7 +314,7 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
 
                 // Check if this item is inherited from a selected parent folder
                 const isDirectlySelected =
-                  selectedItemsInGoogleDrive.has(itemId)
+                  selectedItemsInGoogleDrive.has(itemDocId)
                 const isInheritedFromParent = isItemSelectedWithInheritance(
                   item,
                   selectedItemsInGoogleDrive,
@@ -329,7 +329,7 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
 
                 return (
                   <div
-                    key={itemId}
+                    key={itemDocId}
                     className="flex items-center px-4 py-2 text-sm cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
                     onClick={() => {
                       if (isFolder && itemDocId) {
@@ -346,7 +346,7 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
                         if (isDisabled) return // Prevent changes if inherited from parent
 
                         handleGoogleDriveItemSelection(
-                          itemDocId || itemId,
+                          itemDocId,
                           item,
                           selectedItemsInGoogleDrive,
                           setSelectedItemsInGoogleDrive,

--- a/frontend/src/components/GoogleDriveNavigation.tsx
+++ b/frontend/src/components/GoogleDriveNavigation.tsx
@@ -143,8 +143,8 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
   setSelectedIntegrations,
   selectedIntegrations,
 }) => {
-  useMemo(() => {
-    sortDriveItems(currentItems)
+  const sortedItems= useMemo(() => {
+    return sortDriveItems(currentItems)
   }, [currentItems])
 
   // Function to get icon for Google Drive entity
@@ -322,8 +322,8 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
               <div className="px-4 py-8 text-sm text-gray-500 dark:text-gray-400 text-center">
                 Loading...
               </div>
-            ) : currentItems.length > 0 ? (
-              currentItems.map((item: any) => {
+            ) : sortedItems.length > 0 ? (
+              sortedItems.map((item: any) => {
                 const itemId = item.id || item.fields?.docId
                 const itemDocId = item.fields?.docId
                 const itemEntity = item.fields?.entity

--- a/frontend/src/components/GoogleDriveNavigation.tsx
+++ b/frontend/src/components/GoogleDriveNavigation.tsx
@@ -101,8 +101,8 @@ const sortDriveItems = (item: DriveItem[]): DriveItem[] => {
     const isBFolder = b.fields.entity === DriveEntity.Folder
     if (isAFolder && !isBFolder) return -1
     if (!isAFolder && isBFolder) return 1
-    const aName = a.fields.title.toLowerCase()
-    const bName = b.fields.title.toLowerCase()
+    const aName = (a.fields.title || "").toLowerCase()
+    const bName = (b.fields.title || "").toLowerCase()
     return aName.localeCompare(bName)
   })
 }

--- a/frontend/src/components/GoogleDriveNavigation.tsx
+++ b/frontend/src/components/GoogleDriveNavigation.tsx
@@ -3,11 +3,11 @@ import { ChevronRight } from "lucide-react"
 import { Apps, DriveEntity } from "shared/types"
 import { getIcon } from "@/lib/common"
 import { api } from "@/api"
-import {FileSchema} from "shared/types"
+import {VespaFile} from "shared/types"
 
 // Utility function to check if an item is selected either directly or through parent inheritance
 function isItemSelectedWithInheritance(
-  item: any,
+  itemId: string,
   selectedItemsInGoogleDrive: Set<string>,
   selectedItemDetailsInGoogleDrive: Record<string, any>,
   navigationPath: Array<{
@@ -17,9 +17,8 @@ function isItemSelectedWithInheritance(
   }>,
   selectedIntegrations: Record<string, boolean>,
 ): boolean {
-  const itemId = item.id || item.fields?.docId
+  
 
-  // Check if item is directly selected
   if (selectedItemsInGoogleDrive.has(itemId)) {
     return true
   }
@@ -28,14 +27,14 @@ function isItemSelectedWithInheritance(
     hasGoogleDriveSelected && selectedItemsInGoogleDrive.size === 0
 
   if (isGoogleDriveSelectAll) return true
-  // Check if any parent folder in the current navigation path is selected
+ 
   const parentFolders = navigationPath
     .filter((pathItem) => pathItem.type === "drive-folder")
     .map((pathItem) => pathItem.id)
 
-  // Check if any parent folder is selected
+ 
   for (const parentFolderId of parentFolders) {
-    // Find the parent folder in selected items
+
     for (const selectedItemId of selectedItemsInGoogleDrive) {
       const selectedItemDetail =
         selectedItemDetailsInGoogleDrive[selectedItemId]
@@ -43,7 +42,7 @@ function isItemSelectedWithInheritance(
         const selectedDocId =
           selectedItemDetail.fields?.docId || selectedItemDetail.docId
         if (selectedDocId === parentFolderId) {
-          // This item is inside a selected folder
+         
           return true
         }
       }
@@ -90,7 +89,7 @@ interface GoogleDriveNavigationProps {
   selectedIntegrations: Record<string, boolean>
 }
 interface DriveItem {
-  fields: FileSchema
+  fields: VespaFile
   id: string
   relevance: number
   source: string
@@ -347,7 +346,7 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
                         if (isDisabled) return // Prevent changes if inherited from parent
 
                         handleGoogleDriveItemSelection(
-                          itemId,
+                          itemDocId || itemId,
                           item,
                           selectedItemsInGoogleDrive,
                           setSelectedItemsInGoogleDrive,

--- a/frontend/src/components/GoogleDriveNavigation.tsx
+++ b/frontend/src/components/GoogleDriveNavigation.tsx
@@ -3,6 +3,7 @@ import { ChevronRight } from "lucide-react"
 import { Apps, DriveEntity } from "shared/types"
 import { getIcon } from "@/lib/common"
 import { api } from "@/api"
+import {FileSchema} from "shared/types"
 
 // Utility function to check if an item is selected either directly or through parent inheritance
 function isItemSelectedWithInheritance(
@@ -88,27 +89,8 @@ interface GoogleDriveNavigationProps {
   >
   selectedIntegrations: Record<string, boolean>
 }
-interface DriveItemFields {
-  app: "google-drive"
-  createdAt: number
-  docId: string
-  documentid: string
-  entity: DriveEntity
-  metadata?: string | ""
-  mimeType: string
-  owner: string
-  ownerEmail: string
-  parentId: string
-  permissions: string[]
-  photoLink: string
-  sddocname: string
-  title: string
-  updatedAt: number
-  url: string
-}
-
 interface DriveItem {
-  fields: DriveItemFields
+  fields: FileSchema
   id: string
   relevance: number
   source: string

--- a/frontend/src/components/GoogleDriveNavigation.tsx
+++ b/frontend/src/components/GoogleDriveNavigation.tsx
@@ -1,9 +1,8 @@
-import React from "react"
+import React, { useMemo } from "react"
 import { ChevronRight } from "lucide-react"
 import { Apps, DriveEntity } from "shared/types"
 import { getIcon } from "@/lib/common"
 import { api } from "@/api"
-
 
 // Utility function to check if an item is selected either directly or through parent inheritance
 function isItemSelectedWithInheritance(
@@ -15,7 +14,7 @@ function isItemSelectedWithInheritance(
     name: string
     type: "cl-root" | "cl" | "folder" | "drive-root" | "drive-folder"
   }>,
-  selectedIntegrations: Record<string, boolean>
+  selectedIntegrations: Record<string, boolean>,
 ): boolean {
   const itemId = item.id || item.fields?.docId
 
@@ -23,10 +22,11 @@ function isItemSelectedWithInheritance(
   if (selectedItemsInGoogleDrive.has(itemId)) {
     return true
   }
-    const hasGoogleDriveSelected = !!selectedIntegrations["googledrive"]
-  const isGoogleDriveSelectAll = hasGoogleDriveSelected && selectedItemsInGoogleDrive.size === 0
+  const hasGoogleDriveSelected = !!selectedIntegrations["googledrive"]
+  const isGoogleDriveSelectAll =
+    hasGoogleDriveSelected && selectedItemsInGoogleDrive.size === 0
 
-  if(isGoogleDriveSelectAll) return true
+  if (isGoogleDriveSelectAll) return true
   // Check if any parent folder in the current navigation path is selected
   const parentFolders = navigationPath
     .filter((pathItem) => pathItem.type === "drive-folder")
@@ -94,7 +94,7 @@ interface DriveItemFields {
   docId: string
   documentid: string
   entity: DriveEntity
-  metadata?: string | "" 
+  metadata?: string | ""
   mimeType: string
   owner: string
   ownerEmail: string
@@ -113,18 +113,17 @@ interface DriveItem {
   relevance: number
   source: string
 }
-const sortDriveItems=(item:DriveItem[]):DriveItem[]=>{
-       return item.sort((a:DriveItem,b:DriveItem)=>{
-        const isAFolder= a.fields.entity=== DriveEntity.Folder
-        const isBFolder= b.fields.entity === DriveEntity.Folder
-        if(isAFolder && !isBFolder) return -1
-        if(!isAFolder && isBFolder) return 1
-        const aName=a.fields.title.toLowerCase();
-        const bName=b.fields.title.toLowerCase();
-        return aName.localeCompare(bName);
-       })
-
-   }
+const sortDriveItems = (item: DriveItem[]): DriveItem[] => {
+  return [...item].sort((a: DriveItem, b: DriveItem) => {
+    const isAFolder = a.fields.entity === DriveEntity.Folder
+    const isBFolder = b.fields.entity === DriveEntity.Folder
+    if (isAFolder && !isBFolder) return -1
+    if (!isAFolder && isBFolder) return 1
+    const aName = a.fields.title.toLowerCase()
+    const bName = b.fields.title.toLowerCase()
+    return aName.localeCompare(bName)
+  })
+}
 
 export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
   navigationPath,
@@ -142,11 +141,12 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
   selectedItemDetailsInGoogleDrive,
   setSelectedItemDetailsInGoogleDrive,
   setSelectedIntegrations,
-  selectedIntegrations
+  selectedIntegrations,
 }) => {
- 
-  sortDriveItems(currentItems)
-  
+  useMemo(() => {
+    sortDriveItems(currentItems)
+  }, [currentItems])
+
   // Function to get icon for Google Drive entity
   const getDriveEntityIcon = (entity: string) => {
     return getIcon(Apps.GoogleDrive, entity as any, { w: 16, h: 16, mr: 8 })
@@ -177,7 +177,6 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
       setIsLoadingItems(false)
     }
   }
- 
 
   // Helper function for Google Drive item selection
   function handleGoogleDriveItemSelection(
@@ -236,7 +235,6 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
   if (!isShowingDriveContents) {
     return null
   }
-  
 
   return (
     <>
@@ -255,7 +253,7 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
                 const itemEntity = result.entity
                 const itemTitle = result.title || result.name || "Untitled"
                 const isFolder = itemEntity === DriveEntity.Folder
-           
+
                 const handleFolderNavigation = () => {
                   if (isFolder && result.fields?.docId) {
                     // Clear search query and results when navigating
@@ -271,10 +269,9 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
                   >
                     <input
                       type="checkbox"
-                    
                       onChange={(e) => {
                         e.stopPropagation()
-                        
+
                         handleGoogleDriveItemSelection(
                           itemId,
                           // Normalize the data structure for search results
@@ -292,8 +289,7 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
                           setSelectedItemDetailsInGoogleDrive,
                           setSelectedIntegrations,
                         )
-                      }
-                      }
+                      }}
                       className="mr-3 h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
                     />
                     {getDriveEntityIcon(itemEntity)}
@@ -343,10 +339,9 @@ export const GoogleDriveNavigation: React.FC<GoogleDriveNavigationProps> = ({
                   selectedItemsInGoogleDrive,
                   selectedItemDetailsInGoogleDrive,
                   navigationPath,
-                  selectedIntegrations
-                ) 
-                
-                
+                  selectedIntegrations,
+                )
+
                 const finalIsSelected =
                   isDirectlySelected || isInheritedFromParent
                 const isDisabled = isInheritedFromParent && !isDirectlySelected

--- a/frontend/src/routes/_authenticated/agent.tsx
+++ b/frontend/src/routes/_authenticated/agent.tsx
@@ -108,6 +108,7 @@ interface FetchedDataSource {
   entity: string
 }
 
+
 const CustomBadge: React.FC<CustomBadgeProps> = ({ text, onRemove, icon }) => {
   return (
     <div className="flex items-center justify-center bg-slate-100 dark:bg-slate-600 text-slate-700 dark:text-slate-200 text-xs font-medium pl-2 pr-1 py-1 rounded-md border border-slate-200 dark:border-slate-500">
@@ -326,6 +327,7 @@ function isItemSelectedWithInheritance(
 
   return false
 }
+ 
 
 function AgentComponent() {
   const { agentId } = Route.useSearch()
@@ -418,7 +420,7 @@ function AgentComponent() {
   const getDriveEntityIcon = (entity: string) => {
     return getIcon(Apps.GoogleDrive, entity as any, { w: 16, h: 16, mr: 8 })
   }
-
+  
   // Google Drive navigation functions
   const navigateToGoogleDrive = async () => {
     setNavigationPath([
@@ -434,6 +436,8 @@ function AgentComponent() {
         const data = await response.json()
         // Extract the actual items from the Vespa response structure
         const items = data?.root?.children || []
+        
+     
         setCurrentItems(items)
       }
     } catch (error) {
@@ -463,6 +467,8 @@ function AgentComponent() {
         const data = await response.json()
         // Extract the actual items from the Vespa response structure
         const items = data?.root?.children || []
+       
+     
         setCurrentItems(items)
       }
     } catch (error) {
@@ -1890,7 +1896,10 @@ function AgentComponent() {
   const toggleIntegrationSelection = (integrationId: string) => {
     setSelectedIntegrations((prev) => {
       const newValue = !prev[integrationId]
-
+      if(integrationId === "googledrive" && !newValue ){
+         setSelectedItemsInGoogleDrive(new Set())
+          setSelectedItemDetailsInGoogleDrive({})
+      }
       // If it's a collection integration and we're deselecting it, clear its items
       if (integrationId.startsWith("cl_") && !newValue) {
         const clId = integrationId.replace("cl_", "")
@@ -2063,9 +2072,22 @@ function AgentComponent() {
 
     // Handle Google Drive items
     if (
-      selectedIntegrations["googledrive"] &&
-      selectedItemsInGoogleDrive.size > 0
+      selectedIntegrations["googledrive"] 
     ) {
+      if(selectedItemsInGoogleDrive.size === 0){
+        const googleDriveIntegration = allAvailableIntegrations.find(
+          (int) => int.id === "googledrive",
+        )
+        if (googleDriveIntegration) {
+          result.push({
+            ...googleDriveIntegration,
+            type: "integration",
+          })
+        }
+      }
+      else{
+
+      
       // If specific Google Drive items are selected, show individual file/folder pills
       for (const itemId of selectedItemsInGoogleDrive) {
         const item = selectedItemDetailsInGoogleDrive[itemId]
@@ -2088,18 +2110,8 @@ function AgentComponent() {
           })
         }
       }
-    } else if (selectedIntegrations["googledrive"]) {
-      // If no specific items are selected but Google Drive is checked, show the main Google Drive pill
-      const googleDriveIntegration = allAvailableIntegrations.find(
-        (int) => int.id === "googledrive",
-      )
-      if (googleDriveIntegration) {
-        result.push({
-          ...googleDriveIntegration,
-          type: "integration",
-        })
-      }
     }
+    } 
 
     allAvailableIntegrations.forEach((integration) => {
       if (
@@ -3333,6 +3345,8 @@ function AgentComponent() {
                                                     // Extract the actual items from the Vespa response structure
                                                     const items =
                                                       data?.root?.children || []
+                                                    
+                                                    
                                                     setCurrentItems(items)
                                                     setIsLoadingItems(false)
                                                   })
@@ -3540,17 +3554,46 @@ function AgentComponent() {
 
                                 return (
                                   <>
-                                    {/* Regular integrations */}
+                                      {collections.length > 0 && (
+                                      <DropdownMenuItem
+                                        onSelect={(e) => {
+                                          e.preventDefault()
+                                          setNavigationPath([
+                                            {
+                                              id: "cl-root",
+                                              name: "Collections",
+                                              type: "cl-root",
+                                            },
+                                          ])
+                                          setDropdownSearchQuery("")
+                                        }}
+                                        className="flex items-center justify-between cursor-pointer text-sm py-2.5 px-4 hover:!bg-transparent focus:!bg-transparent data-[highlighted]:!bg-transparent"
+                                      >
+                                        <div className="flex items-center">
+                                          <div className="w-4 h-4 mr-3">  </div>
+                                          <span className="mr-2 flex items-center">
+                                          <BookOpen className="w-4 h-4 mr-2 text-blue-600" />
+                                          </span>
+                                          <span className="text-gray-700 dark:text-gray-200">
+                                            Collections
+                                          </span>
+                                        </div>
+                                        <ChevronRight className="h-4 w-4 text-gray-400" />
+                                      </DropdownMenuItem>
+                                    )}
+                                   
                                     {otherIntegrations.map((integration) => {
                                       const isGoogleDrive =
                                         integration.app === Apps.GoogleDrive &&
                                         integration.entity === "file"
                                       const showChevron = isGoogleDrive
+                                      
 
                                       return (
                                         <DropdownMenuItem
                                           key={integration.id}
                                           onSelect={(e) => {
+                                           
                                             e.preventDefault()
                                             toggleIntegrationSelection(
                                               integration.id,
@@ -3594,31 +3637,7 @@ function AgentComponent() {
                                       )
                                     })}
 
-                                    {/* Collections item */}
-                                    {collections.length > 0 && (
-                                      <DropdownMenuItem
-                                        onSelect={(e) => {
-                                          e.preventDefault()
-                                          setNavigationPath([
-                                            {
-                                              id: "cl-root",
-                                              name: "Collections",
-                                              type: "cl-root",
-                                            },
-                                          ])
-                                          setDropdownSearchQuery("")
-                                        }}
-                                        className="flex items-center justify-between cursor-pointer text-sm py-2.5 px-4 hover:!bg-transparent focus:!bg-transparent data-[highlighted]:!bg-transparent"
-                                      >
-                                        <div className="flex items-center">
-                                          <BookOpen className="w-4 h-4 mr-2 text-blue-600" />
-                                          <span className="text-gray-700 dark:text-gray-200">
-                                            Collections
-                                          </span>
-                                        </div>
-                                        <ChevronRight className="h-4 w-4 text-gray-400" />
-                                      </DropdownMenuItem>
-                                    )}
+
                                   </>
                                 )
                               })()
@@ -4224,6 +4243,7 @@ function AgentComponent() {
                                             setSelectedIntegrations={
                                               setSelectedIntegrations
                                             }
+                                            selectedIntegrations={selectedIntegrations}
                                           />
                                         )
                                       } else {

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -27,6 +27,7 @@ import {
   GooglePeopleEntity,
   SlackEntity,
   MicrosoftPeopleEntity,
+  
 } from "@xyne/vespa-ts/types"
 export {
   GooglePeopleEntity,
@@ -52,6 +53,7 @@ export type {
   SearchResultsSchema,
   SearchResponse,
   SearchResultDiscriminatedUnion,
+  FileSchema
 } from "@xyne/vespa-ts/types"
 
 export const FileEntitySchema = z.nativeEnum(DriveEntity)

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -53,9 +53,10 @@ export type {
   SearchResultsSchema,
   SearchResponse,
   SearchResultDiscriminatedUnion,
-  FileSchema
+  
 } from "@xyne/vespa-ts/types"
 
+export type VespaFile = z.infer<typeof VespaFileSchema>
 export const FileEntitySchema = z.nativeEnum(DriveEntity)
 export const MailEntitySchema = z.nativeEnum(MailEntity)
 export const MailAttachmentEntitySchema = z.nativeEnum(MailAttachmentEntity)


### PR DESCRIPTION
### Description
fixed the item select in drive,sorted the drive item based on folder and item name.

### Testing
tested locally



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Google Drive selection UI: shows a main Drive pill when integration selected with no items, and per-item removable badges when items are chosen.
  * Integration-aware select-all and selection syncing across navigation; selection state now respects active integrations.
  * Folder-first, stable client-side sorting for clearer Drive browsing.
  * Collections entry and root navigation added to integrations dropdown.
  * New exported type: VespaFile available for integrations.

* **Bug Fixes**
  * Deselecting Google Drive now clears related item selections and details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->