### PR TITLE
fix(clfileupload) : XYNE-101 added file picker and show correct supported files

### DIFF
--- a/frontend/src/components/ClFileUpload.tsx
+++ b/frontend/src/components/ClFileUpload.tsx
@@ -219,6 +219,9 @@ const CollectionFileUpload = ({
     }
   }
 
+  // Calculate supported files count 
+  const supportedFilesCount = selectedFiles.filter(f => isValidFile(f.file)).length
+
   // Show skeleton loader when uploading
   if (isUploading && batchProgress && batchProgress.total > 0) {
     return (
@@ -269,6 +272,7 @@ const CollectionFileUpload = ({
           onDragLeave={handleDragLeave}
           onDragOver={handleDragOver}
           onDrop={handleDrop}
+          onClick={handleFileClick}
         >
           <div
             className={`border-2 border-dashed border-gray-200 dark:border-gray-600 rounded-lg p-8 w-full mx-auto h-80 min-h-80 flex flex-col items-center justify-center transition-colors relative bg-gray-50 dark:bg-slate-800 ${
@@ -276,7 +280,7 @@ const CollectionFileUpload = ({
                 ? "border-blue-500 bg-blue-50 dark:bg-blue-900/10"
                 : isUploading
                   ? "cursor-not-allowed"
-                  : "hover:border-gray-400 dark:hover:border-gray-500"
+                  : "hover:border-gray-400 dark:hover:border-gray-500 cursor-pointer"
             }`}
           >
             <div className="flex flex-col items-center justify-center w-full h-full">
@@ -325,7 +329,7 @@ const CollectionFileUpload = ({
                 UPLOAD QUEUE
               </h3>
               <span className="text-xs text-gray-500 dark:text-gray-400">
-                {selectedFiles.length} file{selectedFiles.length !== 1 ? "s" : ""}
+                {supportedFilesCount} supported file{supportedFilesCount !== 1 ? "s" : ""}
               </span>
               <Button
                 onClick={onRemoveAllFiles}

--- a/frontend/src/routes/_authenticated/knowledgeManagement.tsx
+++ b/frontend/src/routes/_authenticated/knowledgeManagement.tsx
@@ -752,7 +752,7 @@ function KnowledgeManagementContent() {
         id: updatedCl.id,
         name: updatedCl.name,
         description: updatedCl.description,
-        files: updatedCl.totalCount || selectedFiles.length,
+        files: updatedCl.totalCount || validFiles.length,
         lastUpdated: new Date(updatedCl.updatedAt).toLocaleString("en-GB", {
           day: "numeric",
           month: "short",


### PR DESCRIPTION
### Description

- instead of showing x files, showing x supported files
- added file picker
### Testing

- tested locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Upload area is now clickable, allowing users to open the file picker directly.
* Bug Fixes
  * File counts now reflect only supported/validated files across the upload queue and collection views.
  * Upload queue header displays the correct count with proper pluralization.
* Style
  * Added a pointer cursor to the upload area when it’s clickable (not uploading, dragging, or disabled).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->