### PR TITLE
fix: keeping vespa optional in start/sh

### DIFF
--- a/server/health/index.ts
+++ b/server/health/index.ts
@@ -254,6 +254,8 @@ async function checkVespaContainerHealth(
 // Returns unhealthy if either container is unhealthy
 export async function checkVespaHealth(): Promise<HealthStatusResponse> {
   const startTime = Date.now()
+  const vespaRequired =
+    process.env.VESPA_REQUIRED === "true" || process.env.VESPA_REQUIRED === "1"
 
   try {
     const [feedHealth, queryHealth] = await Promise.all([
@@ -267,7 +269,9 @@ export async function checkVespaHealth(): Promise<HealthStatusResponse> {
       feedHealth.status === HealthStatusType.Unhealthy ||
       queryHealth.status === HealthStatusType.Unhealthy
     ) {
-      combinedStatus = HealthStatusType.Unhealthy
+      combinedStatus = vespaRequired
+        ? HealthStatusType.Unhealthy
+        : HealthStatusType.Degraded
     } else if (
       feedHealth.status === HealthStatusType.Degraded ||
       queryHealth.status === HealthStatusType.Degraded
@@ -284,6 +288,11 @@ export async function checkVespaHealth(): Promise<HealthStatusResponse> {
       serviceName: ServiceName.vespa,
       responseTime,
       details: {
+        optional: !vespaRequired,
+        message:
+          !vespaRequired && combinedStatus === HealthStatusType.Degraded
+            ? "Vespa is unavailable but optional; app remains healthy for deployment"
+            : undefined,
         feedContainer: {
           status: feedHealth.status,
           responseTime: feedHealth.responseTime,
@@ -299,10 +308,16 @@ export async function checkVespaHealth(): Promise<HealthStatusResponse> {
   } catch (error) {
     Logger.error(error, "Vespa health check failed")
     return {
-      status: HealthStatusType.Unhealthy,
+      status: vespaRequired
+        ? HealthStatusType.Unhealthy
+        : HealthStatusType.Degraded,
       serviceName: ServiceName.vespa,
       responseTime: Date.now() - startTime,
       details: {
+        optional: !vespaRequired,
+        message: vespaRequired
+          ? "Vespa health check failed"
+          : "Vespa health check failed, but Vespa is optional",
         error:
           error instanceof Error ? error.message : "Vespa health check failed",
       },

--- a/server/health/index.ts
+++ b/server/health/index.ts
@@ -255,7 +255,8 @@ async function checkVespaContainerHealth(
 export async function checkVespaHealth(): Promise<HealthStatusResponse> {
   const startTime = Date.now()
   const vespaRequired =
-    process.env.VESPA_REQUIRED === "true" || process.env.VESPA_REQUIRED === "1"
+    process.env.VESPA_REQUIRED?.toLowerCase() === "true" ||
+    process.env.VESPA_REQUIRED === "1"
 
   try {
     const [feedHealth, queryHealth] = await Promise.all([

--- a/start.sh
+++ b/start.sh
@@ -50,16 +50,37 @@ if [ $ATTEMPTS -ge $MAX_ATTEMPTS ]; then
   exit 1
 fi
 
-# Wait for Vespa to be ready
+# Wait for Vespa to be ready. Vespa is optional by default so a model download
+# or search deployment issue does not prevent the app from starting.
+VESPA_REQUIRED="${VESPA_REQUIRED:-false}"
+VESPA_ATTEMPTS=0
+VESPA_MAX_ATTEMPTS="${VESPA_WAIT_MAX_ATTEMPTS:-30}"
+VESPA_READY=false
+
 echo "Waiting for Vespa config server..."
-until curl -f http://${VESPA_HOST:-vespa}:19071/state/v1/health 2>/dev/null; do
-  echo "Vespa config server is unavailable - sleeping"
+while [ $VESPA_ATTEMPTS -lt $VESPA_MAX_ATTEMPTS ]; do
+  if curl -f http://${VESPA_HOST:-vespa}:19071/state/v1/health 2>/dev/null; then
+    VESPA_READY=true
+    echo "Vespa config server is ready!"
+    break
+  fi
+
+  VESPA_ATTEMPTS=$((VESPA_ATTEMPTS + 1))
+  echo "Vespa config server is unavailable - sleeping (attempt $VESPA_ATTEMPTS/$VESPA_MAX_ATTEMPTS)"
   sleep 2
 done
-echo "Vespa config server is ready!"
+
+if [ "$VESPA_READY" != "true" ]; then
+  if [ "$VESPA_REQUIRED" = "true" ] || [ "$VESPA_REQUIRED" = "1" ]; then
+    echo "ERROR: Failed to connect to Vespa after $VESPA_MAX_ATTEMPTS attempts"
+    exit 1
+  fi
+  echo "WARNING: Vespa is unavailable after $VESPA_MAX_ATTEMPTS attempts; continuing without Vespa"
+fi
 
 # Check if this is the first run (no init marker exists)
 INIT_MARKER_FILE="/usr/src/app/server/storage/.xyne_initialized"
+VESPA_INIT_MARKER_FILE="/usr/src/app/server/storage/.xyne_vespa_initialized"
 if [ ! -f "$INIT_MARKER_FILE" ]; then
   echo "First run detected, performing initial setup..."
   
@@ -71,18 +92,37 @@ if [ ! -f "$INIT_MARKER_FILE" ]; then
   # Try to run migrations, but don't fail if none exist
   bun run migrate || true
   
-  # Deploy Vespa schema and models
-  echo "Deploying Vespa..."
-  cd /usr/src/app/server/vespa
-  EMBEDDING_MODEL=${EMBEDDING_MODEL:-bge-small-en-v1.5} ./deploy-docker.sh
-  cd /usr/src/app/server
-  
   # Create marker file to indicate initialization is complete
   mkdir -p /usr/src/app/server/storage
   touch "$INIT_MARKER_FILE"
   echo "Initial setup completed"
 else
-  echo "Existing installation detected, skipping migrations and Vespa deployment"
+  echo "Existing installation detected, skipping migrations"
+fi
+
+# Deploy Vespa schema and models when Vespa is available. Keep the app bootable
+# if Hugging Face/model download or Vespa deployment fails, and retry on later
+# starts until deployment succeeds.
+if [ ! -f "$VESPA_INIT_MARKER_FILE" ]; then
+  if [ "$VESPA_READY" = "true" ]; then
+    echo "Deploying Vespa..."
+    cd /usr/src/app/server/vespa
+    if EMBEDDING_MODEL=${EMBEDDING_MODEL:-bge-small-en-v1.5} ./deploy-docker.sh; then
+      mkdir -p /usr/src/app/server/storage
+      touch "$VESPA_INIT_MARKER_FILE"
+    else
+      if [ "$VESPA_REQUIRED" = "true" ] || [ "$VESPA_REQUIRED" = "1" ]; then
+        echo "ERROR: Vespa deployment failed"
+        exit 1
+      fi
+      echo "WARNING: Vespa deployment failed; continuing without Vespa"
+    fi
+    cd /usr/src/app/server
+  else
+    echo "Skipping Vespa deployment because Vespa is unavailable"
+  fi
+else
+  echo "Vespa already initialized, skipping Vespa deployment"
 fi
 
 # Start the server

--- a/start.sh
+++ b/start.sh
@@ -53,13 +53,14 @@ fi
 # Wait for Vespa to be ready. Vespa is optional by default so a model download
 # or search deployment issue does not prevent the app from starting.
 VESPA_REQUIRED="${VESPA_REQUIRED:-false}"
+VESPA_REQUIRED_NORMALIZED="$(printf '%s' "$VESPA_REQUIRED" | tr '[:upper:]' '[:lower:]')"
 VESPA_ATTEMPTS=0
 VESPA_MAX_ATTEMPTS="${VESPA_WAIT_MAX_ATTEMPTS:-30}"
 VESPA_READY=false
 
 echo "Waiting for Vespa config server..."
-while [ $VESPA_ATTEMPTS -lt $VESPA_MAX_ATTEMPTS ]; do
-  if curl -f http://${VESPA_HOST:-vespa}:19071/state/v1/health 2>/dev/null; then
+while [ "$VESPA_ATTEMPTS" -lt "$VESPA_MAX_ATTEMPTS" ]; do
+  if curl --connect-timeout 2 --max-time 5 -f "http://${VESPA_HOST:-vespa}:19071/state/v1/health" 2>/dev/null; then
     VESPA_READY=true
     echo "Vespa config server is ready!"
     break
@@ -71,7 +72,7 @@ while [ $VESPA_ATTEMPTS -lt $VESPA_MAX_ATTEMPTS ]; do
 done
 
 if [ "$VESPA_READY" != "true" ]; then
-  if [ "$VESPA_REQUIRED" = "true" ] || [ "$VESPA_REQUIRED" = "1" ]; then
+  if [ "$VESPA_REQUIRED_NORMALIZED" = "true" ] || [ "$VESPA_REQUIRED" = "1" ]; then
     echo "ERROR: Failed to connect to Vespa after $VESPA_MAX_ATTEMPTS attempts"
     exit 1
   fi
@@ -111,7 +112,7 @@ if [ ! -f "$VESPA_INIT_MARKER_FILE" ]; then
       mkdir -p /usr/src/app/server/storage
       touch "$VESPA_INIT_MARKER_FILE"
     else
-      if [ "$VESPA_REQUIRED" = "true" ] || [ "$VESPA_REQUIRED" = "1" ]; then
+      if [ "$VESPA_REQUIRED_NORMALIZED" = "true" ] || [ "$VESPA_REQUIRED" = "1" ]; then
         echo "ERROR: Vespa deployment failed"
         exit 1
       fi


### PR DESCRIPTION
### Description

<!-- Summarize the changes in this PR. -->
<!-- Explain the purpose of the change (e.g., bug fix, feature, refactor). -->
<!-- Describe how this change affects the system or users. -->

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vespa can be configured as optional or required, with health reporting reflecting optional status (Degraded vs Unhealthy) and clearer messages.
  * Startup now uses bounded, configurable retry attempts for Vespa readiness and logs a warning instead of failing when Vespa is optional.
  * Vespa deployment runs only when needed and is retried across starts until successful, preventing repeated unnecessary deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->