### PR TITLE
feat(citations): precise per-paragraph + cited-substring PDF highlighting

### DIFF
--- a/frontend/src/components/DocumentChat.tsx
+++ b/frontend/src/components/DocumentChat.tsx
@@ -54,9 +54,14 @@ interface DocumentChatProps {
   documentName: string
   initialChatId?: string | null
   onChatCreated?: (chatId: string) => void
-  onChunkIndexChange?: (chunkIndex: number | null, itemId: string, docId: string) => void
+  onChunkIndexChange?: (
+    chunkIndex: number | null,
+    itemId: string,
+    docId: string,
+    answerText?: string,
+  ) => void
   uploadStatus?: UploadStatus
-  isKnowledgeBaseChat?: boolean 
+  isKnowledgeBaseChat?: boolean
 }
 
 const ChatMessage = React.memo(
@@ -801,7 +806,40 @@ export const DocumentChat: React.FC<DocumentChatProps> = ({
   }
 
   const handleCitationClick = (citation: Citation, chunkIndex?: number) => {
-    onChunkIndexChange?.(chunkIndex ?? null, citation.itemId ?? documentId, citation.docId)
+    // Resolve the answer text that owns this citation so the upstream
+    // handler can highlight the substring it actually came from.  The
+    // most-recent assistant message that lists this citation wins.
+    let answerText: string | undefined
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i] as SelectPublicMessage
+      if (m.messageRole !== "assistant") continue
+      const sources = (m as any).sources as Citation[] | undefined
+      const matches = sources?.some(
+        (c) =>
+          c.docId === citation.docId ||
+          (c.itemId && c.itemId === citation.itemId),
+      )
+      if (matches) {
+        answerText = cleanCitationsFromResponse(m.message || "")
+        break
+      }
+    }
+    // Fallback: use the latest assistant message if we couldn't match by source.
+    if (!answerText) {
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const m = messages[i] as SelectPublicMessage
+        if (m.messageRole === "assistant" && m.message) {
+          answerText = cleanCitationsFromResponse(m.message)
+          break
+        }
+      }
+    }
+    onChunkIndexChange?.(
+      chunkIndex ?? null,
+      citation.itemId ?? documentId,
+      citation.docId,
+      answerText,
+    )
   }
 
   // Populate feedbackMap from loaded messages

--- a/frontend/src/components/PdfViewer.tsx
+++ b/frontend/src/components/PdfViewer.tsx
@@ -559,11 +559,7 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
           attempts++
         }
         // Two frames after DOM + layers agree — layout/transform often settles here.
-        if (
-          isMountedRef.current &&
-          pageNode() &&
-          isFullyReady(pageNum)
-        ) {
+        if (isMountedRef.current && pageNode() && isFullyReady(pageNum)) {
           await new Promise<void>((resolve) => {
             requestAnimationFrame(() => {
               requestAnimationFrame(() => resolve())
@@ -571,110 +567,194 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
           })
         }
       }
-
+      ;(window as any).__docOpsLastSet = Date.now()
       documentOperationsRef.current.highlightBbox = async (
-        bbox: { l: number; t: number; r: number; b: number },
+        bboxOrList:
+          | { l: number; t: number; r: number; b: number }
+          | Array<{
+              l: number
+              t: number
+              r: number
+              b: number
+              page_no?: number | null
+            }>,
         pageIndex: number,
       ): Promise<boolean> => {
         if (!isMountedRef.current || pageIndex < 0) {
           return false
         }
 
-        const pageNum = pageIndex + 1
+        // Normalise to a list of {bbox, pageIndex}.  When per-fragment bboxes
+        // carry their own page_no (1-based, Docling convention), use it; else
+        // fall back to the explicit pageIndex argument.
+        type Frag = {
+          l: number
+          t: number
+          r: number
+          b: number
+          pageIdx: number
+        }
+        const frags: Frag[] = (
+          Array.isArray(bboxOrList) ? bboxOrList : [bboxOrList]
+        )
+          .filter((b) => b && typeof b.l === "number")
+          .map((b: any) => ({
+            l: b.l,
+            t: b.t,
+            r: b.r,
+            b: b.b,
+            pageIdx:
+              typeof b.page_no === "number" && b.page_no > 0
+                ? b.page_no - 1
+                : pageIndex,
+          }))
 
-        // Navigate to page — do NOT delete pageReadyRef here.
-        // Deleting it would invalidate already-rendered pages whose callbacks will
-        // never re-fire, causing the canvas-poll below to wait 300× unnecessarily.
-        goToPage(pageNum)
+        if (frags.length === 0) return false
+
+        // Group fragments by their target page so we only poll once per page
+        const byPage = new Map<number, Frag[]>()
+        for (const f of frags) {
+          if (!byPage.has(f.pageIdx)) byPage.set(f.pageIdx, [])
+          byPage.get(f.pageIdx)!.push(f)
+        }
+
+        // Navigate to the FIRST fragment's page (typically all on the same page)
+        const firstPageIdx = frags[0].pageIdx
+        goToPage(firstPageIdx + 1)
         if (displayMode === "continuous") {
           rowVirtualizer.measure()
         }
-        // For bbox we only need the canvas element (not text/annotation layers).
-        // Poll until the canvas is present inside the target page element AND
-        // has sensible dimensions (> 200px tall). react-pdf may briefly create a
-        // small placeholder canvas before the real render completes.
-        const getCanvas = () => {
-          const c = containerRef.current?.querySelector<HTMLCanvasElement>(
+
+        const getCanvas = (pageNum: number) => {
+          const root: ParentNode = containerRef.current ?? document
+          const c = root.querySelector<HTMLCanvasElement>(
             `[data-page-number="${pageNum}"] canvas`,
           )
-          // Reject canvas that still has placeholder dimensions
-          return c && c.offsetHeight > 200 ? c : null
+          return c && c.offsetHeight >= 100 ? c : null
         }
 
-        let attempts = 0
-        const maxAttempts = 300
-        while (isMountedRef.current && attempts < maxAttempts) {
-          if (getCanvas()) break
-          await new Promise((r) => setTimeout(r, 16))
-          attempts++
+        // Wait until the canvas's offsetHeight has been stable across two
+        // consecutive samples.  react-pdf re-renders the canvas at the final
+        // fit-to-width size after an initial smaller render; reading the
+        // mid-flight size would give a wrong scale and overlays land off-page.
+        const waitForCanvasStable = async (pageNum: number) => {
+          let prevH = -1
+          let stableCount = 0
+          const maxFrames = 60 // ~1s at 16ms
+          for (let i = 0; i < maxFrames; i++) {
+            const c = getCanvas(pageNum)
+            const h = c?.offsetHeight ?? -1
+            if (h > 0 && h === prevH) {
+              stableCount++
+              if (stableCount >= 2) return c
+            } else {
+              stableCount = 0
+            }
+            prevH = h
+            await new Promise((r) => setTimeout(r, 16))
+          }
+          return getCanvas(pageNum)
         }
-        if (!isMountedRef.current) return false
 
-        const canvas = getCanvas()
-        if (!canvas) return false
-
-        // Use closest() so the overlay's position: absolute is anchored to the
-        // exact element the canvas lives in, regardless of DOM nesting changes.
-        const pageEl = canvas.closest<HTMLElement>('[data-page-number]')
-        if (!pageEl) return false
-
-        // Clear any existing bbox overlays from the entire viewer
-        containerRef.current
-          ?.querySelectorAll("[data-bbox-overlay]")
+        // Clear any existing bbox overlays from the entire viewer (do this once,
+        // up front, not per-fragment, to avoid wiping our own overlays mid-loop)
+        const cleanupRoot: ParentNode = containerRef.current ?? document
+        cleanupRoot
+          .querySelectorAll("[data-bbox-overlay]")
           .forEach((el) => el.remove())
 
-        // canvas.offsetHeight is the CSS pixel height = pageHeightPts * scale
-        // So pageHeightPts = canvas.offsetHeight / scale
-        const pageHeightPts = canvas.offsetHeight / scale
+        let firstOverlay: HTMLDivElement | null = null
+        let drewAny = false
 
-        // Docling uses PDF coordinate system: origin (0,0) at bottom-left, y increases upward.
-        // bbox.t = top of box (larger y, farther from bottom in PDF space)
-        // bbox.b = bottom of box (smaller y, closer to bottom in PDF space)
-        // Convert to CSS (top-left origin, y increases downward):
-        //   css_top  = (pageHeightPts - bbox.t) * scale
-        //   css_left = bbox.l * scale
-        const cssLeft = bbox.l * scale
-        const cssTop = (pageHeightPts - bbox.t) * scale
-        const cssWidth = (bbox.r - bbox.l) * scale
-        const cssHeight = Math.max((bbox.t - bbox.b) * scale, 4)
+        for (const [pageIdx, pageFrags] of byPage) {
+          const pageNum = pageIdx + 1
 
-        // Ensure the page element is positioned so we can place an absolute child
-        const pageStyle = window.getComputedStyle(pageEl)
-        if (pageStyle.position === "static") {
-          pageEl.style.position = "relative"
+          // Poll for canvas readiness on this page
+          let attempts = 0
+          const maxAttempts = 300
+          while (isMountedRef.current && attempts < maxAttempts) {
+            if (getCanvas(pageNum)) break
+            await new Promise((r) => setTimeout(r, 16))
+            attempts++
+          }
+          if (!isMountedRef.current) return drewAny
+
+          // After the canvas appears, react-pdf may re-render it at a different
+          // (typically larger) size on the next paint.  Wait for the height to
+          // stabilise before reading offsetHeight, otherwise our scale
+          // calculation is based on the placeholder size and overlays land far
+          // outside the page.
+          const canvas = await waitForCanvasStable(pageNum)
+          if (!isMountedRef.current) return drewAny
+          if (!canvas) {
+            console.warn("[highlightBbox] canvas not found after polling", {
+              pageNum,
+              attempts,
+            })
+            continue
+          }
+
+          const pageEl = canvas.closest<HTMLElement>("[data-page-number]")
+          if (!pageEl) {
+            console.warn("[highlightBbox] no page element ancestor for canvas")
+            continue
+          }
+
+          // Ensure the page element is positioned so absolute children anchor
+          if (window.getComputedStyle(pageEl).position === "static") {
+            pageEl.style.position = "relative"
+          }
+
+          // canvas.offsetHeight is the CSS pixel height = pageHeightPts * scale
+          const pageHeightPts = canvas.offsetHeight / scale
+
+          for (const f of pageFrags) {
+            // PDF coords: origin (0,0) at bottom-left, y grows upward
+            //   css_top  = (pageHeightPts - f.t) * scale
+            //   css_left = f.l * scale
+            const cssLeft = f.l * scale
+            const cssTop = (pageHeightPts - f.t) * scale
+            const cssWidth = (f.r - f.l) * scale
+            const cssHeight = Math.max((f.t - f.b) * scale, 4)
+
+            const overlay = document.createElement("div")
+            overlay.setAttribute("data-bbox-overlay", "true")
+            overlay.style.cssText = `
+              position: absolute;
+              left: ${cssLeft}px;
+              top: ${cssTop}px;
+              width: ${cssWidth}px;
+              height: ${cssHeight}px;
+              background-color: rgba(250, 204, 21, 0.35);
+              border: 1px solid rgba(234, 179, 8, 0.85);
+              border-radius: 3px;
+              pointer-events: none;
+              z-index: 100;
+              box-sizing: border-box;
+            `
+            pageEl.appendChild(overlay)
+            if (!firstOverlay) firstOverlay = overlay
+            drewAny = true
+          }
         }
 
-        const overlay = document.createElement("div")
-        overlay.setAttribute("data-bbox-overlay", "true")
-        overlay.style.cssText = `
-          position: absolute;
-          left: ${cssLeft}px;
-          top: ${cssTop}px;
-          width: ${cssWidth}px;
-          height: ${cssHeight}px;
-          background-color: rgba(250, 204, 21, 0.35);
-          border: 1px solid rgba(234, 179, 8, 0.85);
-          border-radius: 3px;
-          pointer-events: none;
-          z-index: 100;
-          box-sizing: border-box;
-        `
-        pageEl.appendChild(overlay)
-
-        // Scroll the overlay into view inside the scrollable container
+        // Scroll the FIRST overlay into view inside the scrollable container
         const scrollEl = containerRef.current
-        if (scrollEl) {
+        if (scrollEl && firstOverlay) {
           const containerRect = scrollEl.getBoundingClientRect()
-          const overlayRect = overlay.getBoundingClientRect()
+          const overlayRect = firstOverlay.getBoundingClientRect()
           const targetScrollTop =
             scrollEl.scrollTop +
             (overlayRect.top - containerRect.top) -
             scrollEl.clientHeight / 2 +
             overlayRect.height / 2
-          scrollEl.scrollTo({ top: Math.max(0, targetScrollTop), behavior: "smooth" })
+          scrollEl.scrollTo({
+            top: Math.max(0, targetScrollTop),
+            behavior: "smooth",
+          })
         }
 
-        return true
+        return drewAny
       }
 
       documentOperationsRef.current.clearHighlights = () => {

--- a/frontend/src/components/PdfViewer.tsx
+++ b/frontend/src/components/PdfViewer.tsx
@@ -625,8 +625,14 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
           rowVirtualizer.measure()
         }
 
+        // Look up canvas inside this viewer's containerRef only, never the
+        // whole document.  If multiple PdfViewer instances are mounted (e.g.
+        // chat panel + KM viewer), a global lookup could pick a canvas from a
+        // different viewer.  Returning null while the ref is still attaching
+        // is fine — the poll loop below retries.
         const getCanvas = (pageNum: number) => {
-          const root: ParentNode = containerRef.current ?? document
+          const root = containerRef.current
+          if (!root) return null
           const c = root.querySelector<HTMLCanvasElement>(
             `[data-page-number="${pageNum}"] canvas`,
           )
@@ -656,12 +662,14 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
           return getCanvas(pageNum)
         }
 
-        // Clear any existing bbox overlays from the entire viewer (do this once,
-        // up front, not per-fragment, to avoid wiping our own overlays mid-loop)
-        const cleanupRoot: ParentNode = containerRef.current ?? document
-        cleanupRoot
-          .querySelectorAll("[data-bbox-overlay]")
-          .forEach((el) => el.remove())
+        // Clear any existing bbox overlays from THIS viewer only (do this once,
+        // up front, not per-fragment, to avoid wiping our own overlays mid-loop).
+        // Scoped to containerRef so other PdfViewer instances are untouched.
+        if (containerRef.current) {
+          containerRef.current
+            .querySelectorAll("[data-bbox-overlay]")
+            .forEach((el) => el.remove())
+        }
 
         let firstOverlay: HTMLDivElement | null = null
         let drewAny = false

--- a/frontend/src/contexts/DocumentOperationsContext.tsx
+++ b/frontend/src/contexts/DocumentOperationsContext.tsx
@@ -114,7 +114,15 @@ export const withDocumentOperations = <P extends object>(
           return false
         },
         highlightBbox: async (
-          bbox: { l: number; t: number; r: number; b: number },
+          bbox:
+            | { l: number; t: number; r: number; b: number }
+            | Array<{
+                l: number
+                t: number
+                r: number
+                b: number
+                page_no?: number | null
+              }>,
           pageIndex: number,
         ) => {
           if (documentOperationsRef.current?.highlightBbox) {

--- a/frontend/src/contexts/DocumentOperationsContext.tsx
+++ b/frontend/src/contexts/DocumentOperationsContext.tsx
@@ -14,9 +14,22 @@ export interface DocumentOperations {
     pageIndex?: number,
     waitForTextLayer?: boolean,
   ) => Promise<boolean>
-  /** PDF viewer: highlight exact bbox coordinates with a yellow overlay box. */
+  /** PDF viewer: highlight exact bbox coordinates with a yellow overlay box.
+   *
+   *  Pass a single bbox to draw one rectangle, or a non-empty array to draw
+   *  one rectangle per fragment (e.g. one per paragraph in a multi-paragraph
+   *  chunk). Each fragment may carry its own `page_no` (1-based, Docling
+   *  convention); if absent, falls back to the `pageIndex` argument. */
   highlightBbox?: (
-    bbox: { l: number; t: number; r: number; b: number },
+    bbox:
+      | { l: number; t: number; r: number; b: number }
+      | Array<{
+          l: number
+          t: number
+          r: number
+          b: number
+          page_no?: number | null
+        }>,
     pageIndex: number,
   ) => Promise<boolean>
   clearHighlights?: () => void

--- a/frontend/src/hooks/useScopedFind.ts
+++ b/frontend/src/hooks/useScopedFind.ts
@@ -28,9 +28,9 @@ type HighlightCache = {
 const isScrollable = (element: HTMLElement): boolean => {
   const style = window.getComputedStyle(element)
   return (
-    (style.overflowY === "auto" || 
-     style.overflowY === "scroll" || 
-     style.overflowY === "overlay") &&
+    (style.overflowY === "auto" ||
+      style.overflowY === "scroll" ||
+      style.overflowY === "overlay") &&
     element.scrollHeight > element.clientHeight
   )
 }
@@ -468,8 +468,11 @@ export function useScopedFind(
       overlay.remove()
     })
 
-    // Clear bbox-based highlights
-    root.querySelectorAll("[data-bbox-overlay]").forEach((el) => el.remove())
+    // NOTE: bbox-based highlights ([data-bbox-overlay]) are intentionally
+    // NOT cleared here.  They are managed by PdfViewer.highlightBbox, which
+    // clears its own previous overlays at the start of each draw.  Wiping
+    // them from this hook would erase a layered highlight added on top of
+    // the bbox (used to darken the cited substring).
   }, [])
 
   // Exported function: increments token to cancel pending work, clears DOM, resets state
@@ -632,7 +635,9 @@ export function useScopedFind(
 
             if (waitForPageReadyFn) {
               if (debug) {
-                console.log("Waiting for page ready (canvas + text + annotations)...")
+                console.log(
+                  "Waiting for page ready (canvas + text + annotations)...",
+                )
               }
               await waitForPageReadyFn(pageIndex)
             }
@@ -647,7 +652,9 @@ export function useScopedFind(
               const pageRoot = findPdfPageRoot(root, pageIndex)
               if (!pageRoot) {
                 if (debug) {
-                  console.log(`PDF page ${pageIndex} not found, skipping highlight`)
+                  console.log(
+                    `PDF page ${pageIndex} not found, skipping highlight`,
+                  )
                 }
                 return false
               }
@@ -666,10 +673,14 @@ export function useScopedFind(
               if (debug) {
                 console.log("Waiting for text layer (non-PDF readiness)...")
               }
-              containerText = await waitForTextLayerReady(highlightScope, 5000, {
-                searchPhrase: text,
-                caseSensitive,
-              })
+              containerText = await waitForTextLayerReady(
+                highlightScope,
+                5000,
+                {
+                  searchPhrase: text,
+                  caseSensitive,
+                },
+              )
               if (debug) {
                 console.log("Text layer ready, proceeding with highlighting")
               }
@@ -749,7 +760,7 @@ export function useScopedFind(
           if (debug) {
             console.log("Using cached result for key:", cacheKey)
           }
-          
+
           // Check if this call is still the latest before using cached results
           if (currentToken !== callTokenRef.current) {
             if (debug) {
@@ -757,7 +768,7 @@ export function useScopedFind(
             }
             return false
           }
-          
+
           matches = cachedEntry.matches
         } else {
           if (debug) {
@@ -794,7 +805,9 @@ export function useScopedFind(
           // Check if this call is still the latest before processing results
           if (currentToken !== callTokenRef.current) {
             if (debug) {
-              console.log("Stale call detected after computing matches, aborting")
+              console.log(
+                "Stale call detected after computing matches, aborting",
+              )
             }
             return false
           }
@@ -819,7 +832,9 @@ export function useScopedFind(
         // Check if this call is still the latest before creating DOM highlights
         if (currentToken !== callTokenRef.current) {
           if (debug) {
-            console.log("Stale call detected before creating highlights, aborting")
+            console.log(
+              "Stale call detected before creating highlights, aborting",
+            )
           }
           return false
         }
@@ -859,7 +874,9 @@ export function useScopedFind(
         // Final check before updating state
         if (currentToken !== callTokenRef.current) {
           if (debug) {
-            console.log("Stale call detected before state update, aborting and cleaning up DOM")
+            console.log(
+              "Stale call detected before state update, aborting and cleaning up DOM",
+            )
           }
           allMarks.forEach((mark) => {
             if (mark.parentNode) {
@@ -921,7 +938,7 @@ export function useScopedFind(
       // Check if container is scrollable, if not find the scrollable parent
 
       let scrollParent: HTMLElement = container
-      
+
       if (!isScrollable(container)) {
         // Container is not scrollable, find the scrollable parent
         let parent = container.parentElement
@@ -932,7 +949,7 @@ export function useScopedFind(
           }
           parent = parent.parentElement
         }
-        
+
         // If no scrollable parent found, use document element
         if (!parent) {
           scrollParent = document.documentElement
@@ -979,7 +996,7 @@ export function useScopedFind(
       const timeoutId = setTimeout(() => {
         scrollToMatch(index)
       }, 50)
-      
+
       return () => clearTimeout(timeoutId)
     }
   }, [matches, index, scrollToMatch])

--- a/frontend/src/hooks/useScopedFind.ts
+++ b/frontend/src/hooks/useScopedFind.ts
@@ -71,12 +71,24 @@ export function useScopedFind(
   const [index, setIndex] = useState(0)
   const [isLoading, setIsLoading] = useState(false)
 
-  // Generate cache key based on document ID, chunk index, page (PDF scope), and options
+  // Quick non-cryptographic hash so the search phrase fits in the cache key
+  const hashText = (s: string): string => {
+    let h = 5381
+    for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0
+    return (h >>> 0).toString(36)
+  }
+
+  // Generate cache key based on document ID, chunk index, page (PDF scope),
+  // and the search phrase.  The phrase MUST be in the key — the same
+  // chunk/page is now searched with multiple substrings (full chunk text vs.
+  // a Smith-Waterman matched span), and re-using cached match offsets across
+  // them would highlight the wrong text on layered citation clicks.
   const generateCacheKey = useCallback(
     (
       docId: string | undefined,
       chunkIdx: number | null | undefined,
-      pageIdx?: number,
+      pageIdx: number | undefined,
+      text: string,
     ): string => {
       const keyComponents = [
         docId || "no-doc-id",
@@ -84,6 +96,7 @@ export function useScopedFind(
           ? chunkIdx.toString()
           : "no-chunk-idx",
         pageIdx !== undefined && pageIdx >= 0 ? `p${pageIdx}` : "p-na",
+        `t${hashText(text || "")}`,
       ]
       return keyComponents.join("|")
     },
@@ -746,7 +759,7 @@ export function useScopedFind(
         // Generate cache key (include page so PDF page-scoped offsets stay valid)
         const canUseCache = !!documentId
         const cacheKey = canUseCache
-          ? generateCacheKey(documentId, chunkIndex, pageIndex)
+          ? generateCacheKey(documentId, chunkIndex, pageIndex, text)
           : ""
 
         // Check cache first (only if safe)

--- a/frontend/src/lib/textMatch.ts
+++ b/frontend/src/lib/textMatch.ts
@@ -1,0 +1,236 @@
+/**
+ * Find the best contiguous span inside a chunk that "comes from" the answer.
+ *
+ * Uses token-level Smith-Waterman local alignment.  The chunk is the
+ * reference text (haystack), the answer is the query (needle).  The
+ * returned span is in CHARACTER offsets of the original chunk string,
+ * trimmed to the boundaries of real tokens.
+ *
+ * Returns null when the alignment score is too low to be meaningful
+ * (caller should treat as "no useful match — draw nothing extra").
+ */
+
+export interface MatchSpan {
+  /** inclusive start char offset in the chunk */
+  start: number
+  /** exclusive end char offset in the chunk */
+  end: number
+  /** alignment score (higher is better) */
+  score: number
+}
+
+interface Token {
+  /** lowercased, punctuation-stripped form used for matching */
+  norm: string
+  /** char offset of the first character of the original token */
+  start: number
+  /** char offset just past the last character of the original token */
+  end: number
+}
+
+const STOPWORDS = new Set([
+  "the",
+  "a",
+  "an",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "being",
+  "of",
+  "in",
+  "on",
+  "at",
+  "to",
+  "for",
+  "by",
+  "with",
+  "as",
+  "from",
+  "or",
+  "and",
+  "but",
+  "if",
+  "it",
+  "this",
+  "that",
+  "these",
+  "those",
+  "i",
+  "you",
+  "we",
+  "they",
+  "he",
+  "she",
+  "his",
+  "her",
+  "its",
+  "their",
+  "our",
+])
+
+const MATCH = 2
+const MISMATCH = -1
+const GAP = -1
+
+/** Normalize a token: lowercased, alphanumeric only.  Empty if all punctuation. */
+function normalize(raw: string): string {
+  let out = ""
+  for (let i = 0; i < raw.length; i++) {
+    const c = raw.charCodeAt(i)
+    // a-z, A-Z, 0-9
+    if ((c >= 97 && c <= 122) || (c >= 48 && c <= 57)) {
+      out += raw[i]
+    } else if (c >= 65 && c <= 90) {
+      out += String.fromCharCode(c + 32)
+    }
+  }
+  return out
+}
+
+/** Tokenize on whitespace.  Each token records its char span in the original string. */
+function tokenize(text: string): Token[] {
+  const tokens: Token[] = []
+  const re = /\S+/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text)) !== null) {
+    const norm = normalize(m[0])
+    if (!norm) continue
+    tokens.push({ norm, start: m.index, end: m.index + m[0].length })
+  }
+  return tokens
+}
+
+/** Score a single token match.  Stopwords are worth less than content words. */
+function tokenScore(t: string): number {
+  return STOPWORDS.has(t) ? 1 : MATCH
+}
+
+/**
+ * Smith-Waterman local alignment between two token sequences.
+ * Returns the best-scoring contiguous run on the chunk side.
+ */
+function alignTokens(
+  query: Token[],
+  haystack: Token[],
+): { startTok: number; endTok: number; score: number } | null {
+  if (query.length === 0 || haystack.length === 0) return null
+
+  const Q = query.length
+  const H = haystack.length
+  // dp[i][j] = best local-alignment score ending at query[i-1], haystack[j-1]
+  const dp: Int32Array[] = new Array(Q + 1)
+  for (let i = 0; i <= Q; i++) dp[i] = new Int32Array(H + 1)
+
+  let bestScore = 0
+  let bestI = 0
+  let bestJ = 0
+  // Trace bookkeeping: record which (i,j) each cell came from so we can walk back
+  // 0 = stop, 1 = diag, 2 = up (gap in haystack), 3 = left (gap in query)
+  const trace: Uint8Array[] = new Array(Q + 1)
+  for (let i = 0; i <= Q; i++) trace[i] = new Uint8Array(H + 1)
+
+  for (let i = 1; i <= Q; i++) {
+    const qi = query[i - 1].norm
+    const qScore = tokenScore(qi)
+    for (let j = 1; j <= H; j++) {
+      const hj = haystack[j - 1].norm
+      const diag = dp[i - 1][j - 1] + (qi === hj ? qScore : MISMATCH)
+      const up = dp[i - 1][j] + GAP
+      const left = dp[i][j - 1] + GAP
+      let v = 0
+      let t: 0 | 1 | 2 | 3 = 0
+      if (diag > v) {
+        v = diag
+        t = 1
+      }
+      if (up > v) {
+        v = up
+        t = 2
+      }
+      if (left > v) {
+        v = left
+        t = 3
+      }
+      dp[i][j] = v
+      trace[i][j] = t
+      if (v > bestScore) {
+        bestScore = v
+        bestI = i
+        bestJ = j
+      }
+    }
+  }
+
+  if (bestScore === 0) return null
+
+  // Walk back from (bestI, bestJ) until we hit a 0 cell to find the start on the haystack side
+  let i = bestI
+  let j = bestJ
+  let endTok = bestJ // exclusive on haystack tokens
+  let startTok = bestJ - 1
+  while (i > 0 && j > 0 && trace[i][j] !== 0) {
+    const t = trace[i][j]
+    if (t === 1) {
+      startTok = j - 1
+      i--
+      j--
+    } else if (t === 2) {
+      i--
+    } else if (t === 3) {
+      startTok = j - 1
+      j--
+    } else break
+  }
+
+  return { startTok, endTok, score: bestScore }
+}
+
+/**
+ * Find the best matching span of `chunk` for the given `answer`.
+ *
+ * Returns null when the score is too small to be trustworthy.  The
+ * threshold scales with the answer length: requiring at least ~half
+ * of the answer's content tokens to land in the alignment.
+ */
+export function findBestMatchSpan(
+  answer: string,
+  chunk: string,
+): MatchSpan | null {
+  if (!answer || !chunk) return null
+
+  const queryToks = tokenize(answer)
+  const hayToks = tokenize(chunk)
+  if (queryToks.length === 0 || hayToks.length === 0) return null
+
+  // Skip the alignment entirely when the answer has no content words
+  // (e.g. "yes", "ok") — there is nothing meaningful to highlight.
+  const contentWords = queryToks.filter((t) => !STOPWORDS.has(t.norm)).length
+  if (contentWords === 0) return null
+
+  const aligned = alignTokens(queryToks, hayToks)
+  if (!aligned) return null
+
+  // Reject very weak matches: require enough score that at least a couple
+  // of content tokens hit.  We deliberately do NOT scale this with answer
+  // length — a long paraphrased answer can still legitimately point to a
+  // short snippet in the chunk (the SW algorithm finds the LOCAL best
+  // alignment regardless of how much surrounding answer text is irrelevant).
+  const MIN_CONTENT_MATCHES = 2
+  const minScore = MATCH * MIN_CONTENT_MATCHES
+  if (aligned.score < minScore) return null
+
+  const startTok = Math.max(0, Math.min(aligned.startTok, hayToks.length - 1))
+  const endTok = Math.max(
+    startTok + 1,
+    Math.min(aligned.endTok, hayToks.length),
+  )
+
+  return {
+    start: hayToks[startTok].start,
+    end: hayToks[endTok - 1].end,
+    score: aligned.score,
+  }
+}

--- a/frontend/src/routes/_authenticated/chat.tsx
+++ b/frontend/src/routes/_authenticated/chat.tsx
@@ -2,6 +2,7 @@ import MarkdownPreview from "@uiw/react-markdown-preview"
 import DOMPurify from "dompurify"
 import { api } from "@/api"
 import { Sidebar } from "@/components/Sidebar"
+import { findBestMatchSpan } from "@/lib/textMatch"
 import {
   createFileRoute,
   useLoaderData,
@@ -450,6 +451,13 @@ export const ChatPage = ({
     chunkContent: string
     pageIndex: number
     bbox: { l: number; t: number; r: number; b: number } | null
+    bboxes: Array<{
+      l: number
+      t: number
+      r: number
+      b: number
+      page_no?: number | null
+    }> | null
   } | null>(null)
   /** Token to invalidate in-flight prefetch/chunk handlers so a slower call cannot overwrite newer citation state. */
   const latestPrefetchTokenRef = useRef<symbol>(Symbol())
@@ -1230,10 +1238,9 @@ export const ChatPage = ({
   // Handle chunk index changes from CitationPreview
   const handleChunkIndexChange = useCallback(
     async (newChunkIndex: number | null, docId: string) => {
-      
       const expectedCitationId = selectedCitation?.docId ?? null
       if (!expectedCitationId) {
-        return;
+        return
       }
 
       if (newChunkIndex === null) {
@@ -1249,6 +1256,13 @@ export const ChatPage = ({
           let chunkContent: string
           let pageIndex: number
           let bbox: { l: number; t: number; r: number; b: number } | null = null
+          let bboxes: Array<{
+            l: number
+            t: number
+            r: number
+            b: number
+            page_no?: number | null
+          }> | null = null
 
           const prefetched = prefetchedChunkRef.current
           if (
@@ -1259,6 +1273,7 @@ export const ChatPage = ({
             chunkContent = prefetched.chunkContent
             pageIndex = prefetched.pageIndex
             bbox = prefetched.bbox
+            bboxes = (prefetched as any).bboxes ?? null
             prefetchedChunkRef.current = null
           } else {
             const chunkContentResponse = await api.chunk[":cId"].files[
@@ -1288,6 +1303,7 @@ export const ChatPage = ({
             pageIndex =
               typeof data?.pageIndex === "number" ? data.pageIndex : -1
             bbox = (data as any)?.bbox ?? null
+            bboxes = (data as any)?.bboxes ?? null
           }
 
           if (latestPrefetchTokenRef.current !== chunkToken) return
@@ -1302,24 +1318,104 @@ export const ChatPage = ({
             documentOperationsRef.current.clearHighlights()
           }
 
-          // Use precise bbox highlighting when available (PDF only), fall back to text search
-          if (bbox && pageIndex >= 0 && documentOperationsRef?.current?.highlightBbox) {
+          // Resolve the answer text that owns this citation so we can darken
+          // the substring it actually came from.  Most-recent assistant message
+          // whose `sources` includes this docId/itemId wins; fall back to the
+          // most recent assistant message overall.
+          let answerText: string | undefined
+          for (let i = messages.length - 1; i >= 0; i--) {
+            const m = messages[i] as SelectPublicMessage
+            if (m.messageRole !== "assistant") continue
+            const sources = (m as any).sources as Citation[] | undefined
+            const matches = sources?.some(
+              (c) =>
+                c.docId === expectedCitationId ||
+                (c.itemId &&
+                  selectedCitation?.itemId &&
+                  c.itemId === selectedCitation.itemId),
+            )
+            if (matches) {
+              answerText = cleanCitationsFromResponse(m.message || "")
+              break
+            }
+          }
+          if (!answerText) {
+            for (let i = messages.length - 1; i >= 0; i--) {
+              const m = messages[i] as SelectPublicMessage
+              if (m.messageRole === "assistant" && m.message) {
+                answerText = cleanCitationsFromResponse(m.message)
+                break
+              }
+            }
+          }
+
+          // Use precise bbox highlighting when available (PDF only), fall back to text search.
+          // Pass per-fragment bboxes when present (one rectangle per paragraph),
+          // else the union bbox.
+          const bboxArg =
+            Array.isArray(bboxes) && bboxes.length > 0 ? bboxes : bbox
+          if (
+            bboxArg &&
+            pageIndex >= 0 &&
+            documentOperationsRef?.current?.highlightBbox
+          ) {
+            let bboxOk = false
             try {
-              await documentOperationsRef.current.highlightBbox(bbox, pageIndex)
+              bboxOk = await documentOperationsRef.current.highlightBbox(
+                bboxArg,
+                pageIndex,
+              )
             } catch (error) {
               console.error("Error highlighting chunk bbox:", error)
-              // Fall back to text highlighting
-              if (chunkContent && documentOperationsRef?.current?.highlightText) {
-                try {
-                  await documentOperationsRef.current.highlightText(
-                    chunkContent,
-                    newChunkIndex,
-                    pageIndex,
-                    true,
-                  )
-                } catch (textError) {
-                  console.error("Error highlighting chunk text (fallback):", textError)
+              bboxOk = false
+            }
+            if (latestPrefetchTokenRef.current !== chunkToken) return
+            // Fall back to text highlighting if bbox draw failed (returned false or threw)
+            if (
+              !bboxOk &&
+              chunkContent &&
+              documentOperationsRef?.current?.highlightText
+            ) {
+              console.warn(
+                "highlightBbox failed; falling back to text highlight",
+              )
+              try {
+                await documentOperationsRef.current.highlightText(
+                  chunkContent,
+                  newChunkIndex,
+                  pageIndex,
+                  true,
+                )
+              } catch (textError) {
+                console.error(
+                  "Error highlighting chunk text (fallback):",
+                  textError,
+                )
+              }
+            }
+            // Layer 2: when bbox succeeded AND we have the answer text, darken
+            // the matched substring on top of the bbox using Smith-Waterman.
+            if (
+              bboxOk &&
+              answerText &&
+              chunkContent &&
+              documentOperationsRef?.current?.highlightText
+            ) {
+              try {
+                const span = findBestMatchSpan(answerText, chunkContent)
+                if (span) {
+                  const matched = chunkContent.slice(span.start, span.end)
+                  if (matched.trim().length > 0) {
+                    await documentOperationsRef.current.highlightText(
+                      matched,
+                      newChunkIndex,
+                      pageIndex,
+                      true,
+                    )
+                  }
                 }
+              } catch (error) {
+                console.error("Error layering substring highlight:", error)
               }
             }
             if (latestPrefetchTokenRef.current !== chunkToken) return
@@ -1352,15 +1448,12 @@ export const ChatPage = ({
         }
       }
     },
-    [selectedCitation, toast, documentOperationsRef],
+    [selectedCitation, toast, documentOperationsRef, messages],
   )
 
   useEffect(() => {
     if (selectedCitation && isDocumentLoaded) {
-      handleChunkIndexChange(
-        selectedChunkIndex,
-        selectedCitation?.docId ?? "",
-      )
+      handleChunkIndexChange(selectedChunkIndex, selectedCitation?.docId ?? "")
     }
   }, [
     selectedChunkIndex,
@@ -1377,14 +1470,12 @@ export const ChatPage = ({
       fromSources: boolean = false,
     ) => {
       const delegatedAgent =
-        citation.docId.startsWith("delegated_agent:") &&
-        citation.url
+        citation.docId.startsWith("delegated_agent:") && citation.url
 
       if (delegatedAgent && citation.url) {
         const sameDoc =
           selectedCitation && selectedCitation.docId === citation.docId
-        const previewAlreadyOpenWithSameDoc =
-          isCitationPreviewOpen && sameDoc
+        const previewAlreadyOpenWithSameDoc = isCitationPreviewOpen && sameDoc
         if (previewAlreadyOpenWithSameDoc) {
           setShowSources(false)
           if (!fromSources) {
@@ -1418,11 +1509,11 @@ export const ChatPage = ({
       }
 
       const sameDoc =
-      selectedCitation &&
-      citation &&
-      selectedCitation.docId === citation.docId
+        selectedCitation &&
+        citation &&
+        selectedCitation.docId === citation.docId
       const previewAlreadyOpenWithSameDoc = isCitationPreviewOpen && sameDoc
-      
+
       // Same document already open: only change chunk; handleChunkIndexChange will fetch and goToPage (no full reload)
       if (previewAlreadyOpenWithSameDoc) {
         if (delegatedAgent) {
@@ -1473,12 +1564,14 @@ export const ChatPage = ({
             pageIndex =
               typeof data.pageIndex === "number" ? data.pageIndex : null
             const bboxPrefetch = (data as any)?.bbox ?? null
+            const bboxesPrefetch = (data as any)?.bboxes ?? null
             prefetchedChunkRef.current = {
               documentId: docId,
               chunkIndex,
               chunkContent: content,
               pageIndex: pageIndex ?? -1,
               bbox: bboxPrefetch,
+              bboxes: bboxesPrefetch,
             }
           }
         } catch {
@@ -1620,10 +1713,7 @@ export const ChatPage = ({
   if ((data?.error || historyLoading) && !isSharedChat) {
     return (
       <div className="h-full w-full flex flex-col bg-white">
-        <Sidebar 
-          isAgentMode={agentWhiteList}
-          isEmbedded={isEmbedded}
-        />
+        <Sidebar isAgentMode={agentWhiteList} isEmbedded={isEmbedded} />
         {/* <div className="ml-[120px]">Error: Could not get data</div> */}
       </div>
     )
@@ -2686,7 +2776,7 @@ const VirtualizedMessages = React.forwardRef<
                       timeTakenMs={
                         message.externalId === "current-resp"
                           ? streamTimeTakenMs
-                          : message.timeTakenMs ?? undefined
+                          : (message.timeTakenMs ?? undefined)
                       }
                     />
 
@@ -2950,7 +3040,12 @@ export const ChatMessage = ({
                 ) : message !== "" ? (
                   <MarkdownPreview
                     key={`markdown-${messageId || "unknown"}`}
-                      source={processMessage(message, citationMap, citationUrls, citations)}
+                    source={processMessage(
+                      message,
+                      citationMap,
+                      citationUrls,
+                      citations,
+                    )}
                     wrapperElement={{
                       "data-color-mode": theme,
                     }}

--- a/frontend/src/routes/_authenticated/knowledgeManagement.tsx
+++ b/frontend/src/routes/_authenticated/knowledgeManagement.tsx
@@ -13,6 +13,7 @@ import {
   ChevronDown,
 } from "lucide-react"
 import { Sidebar } from "@/components/Sidebar"
+import { findBestMatchSpan } from "@/lib/textMatch"
 import { useState, useCallback, useEffect, memo, useRef, useMemo } from "react"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
@@ -1302,8 +1303,8 @@ function KnowledgeManagementContent() {
         !fileName.endsWith(".xls") &&
         !fileName.endsWith(".text") &&
         !fileName.endsWith(".txt") &&
-        !fileName.endsWith(".tsv")) &&
-        !fileName.endsWith(".json")
+        !fileName.endsWith(".tsv") &&
+        !fileName.endsWith(".json"))
     ) {
       toast.warning({
         title: "Preview Not Available",
@@ -1503,6 +1504,7 @@ function KnowledgeManagementContent() {
     newChunkIndex: number | null,
     documentId: string,
     docId: string,
+    answerText?: string,
   ) => {
     if (!documentId) {
       console.error("handleChunkIndexChange called without documentId")
@@ -1541,7 +1543,69 @@ function KnowledgeManagementContent() {
             documentOperationsRef.current.clearHighlights()
           }
 
-          if (documentOperationsRef?.current?.highlightText) {
+          const bboxes = (chunkContent as any)?.bboxes ?? null
+          const bbox = (chunkContent as any)?.bbox ?? null
+          const pageIdx =
+            typeof chunkContent.pageIndex === "number"
+              ? chunkContent.pageIndex
+              : -1
+
+          // Prefer precise bbox highlighting (PDF only); fall back to text search.
+          // Pass per-fragment bboxes when available (one rectangle per paragraph),
+          // else the union bbox.
+          let bboxOk = false
+          const bboxArg =
+            Array.isArray(bboxes) && bboxes.length > 0 ? bboxes : bbox
+          if (
+            bboxArg &&
+            pageIdx >= 0 &&
+            documentOperationsRef?.current?.highlightBbox
+          ) {
+            try {
+              bboxOk = await documentOperationsRef.current.highlightBbox(
+                bboxArg,
+                pageIdx,
+              )
+            } catch (error) {
+              console.error("Error highlighting chunk bbox:", error)
+              bboxOk = false
+            }
+          }
+
+          // Layer 2: when bbox succeeded AND we have the answer text, find the
+          // best matching span of the chunk (Smith-Waterman on tokens) and add
+          // a tighter text-layer highlight on top of the bbox.  The text-layer
+          // overlay paints on the existing yellow rectangle, producing a
+          // visibly darker band on the actual cited sentence(s).
+          if (
+            bboxOk &&
+            answerText &&
+            documentOperationsRef?.current?.highlightText
+          ) {
+            try {
+              const span = findBestMatchSpan(
+                answerText,
+                chunkContent.chunkContent,
+              )
+              if (span) {
+                const matched = chunkContent.chunkContent.slice(
+                  span.start,
+                  span.end,
+                )
+                if (matched.trim().length > 0) {
+                  await documentOperationsRef.current.highlightText(
+                    matched,
+                    newChunkIndex,
+                    chunkContent.pageIndex,
+                  )
+                }
+              }
+            } catch (error) {
+              console.error("Error layering substring highlight:", error)
+            }
+          }
+
+          if (!bboxOk && documentOperationsRef?.current?.highlightText) {
             try {
               await documentOperationsRef.current.highlightText(
                 chunkContent.chunkContent,
@@ -2418,7 +2482,8 @@ function KnowledgeManagementContent() {
                     />
                   </div>
                   <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                    When enabled, PDFs will be processed using OCR for better text extraction from scanned documents
+                    When enabled, PDFs will be processed using OCR for better
+                    text extraction from scanned documents
                   </p>
                 </div>
                 <CollectionFileUpload

--- a/server/api/knowledgeBase.ts
+++ b/server/api/knowledgeBase.ts
@@ -40,7 +40,11 @@ import {
   markParentAsProcessing,
   // Legacy aliases for backward compatibility
 } from "@/db/knowledgeBase"
-import { cleanUpAgentDb, getAgentByExternalId, getAgentCollections } from "@/db/agent"
+import {
+  cleanUpAgentDb,
+  getAgentByExternalId,
+  getAgentCollections,
+} from "@/db/agent"
 import type { Collection, CollectionItem, File as DbFile } from "@/db/schema"
 import { collectionItems, collections } from "@/db/schema"
 import { and, eq, isNull, sql } from "drizzle-orm"
@@ -96,7 +100,7 @@ const EXTENSION_MIME_MAP: Record<string, string> = {
   ".webp": "image/webp",
   ".svg": "image/svg+xml",
   ".ico": "image/x-icon",
-  ".md": "text/markdown",     
+  ".md": "text/markdown",
   ".markdown": "text/markdown",
 }
 
@@ -167,27 +171,27 @@ function calculateChecksum(buffer: ArrayBuffer): string {
  */
 export function sanitizeFileName(fileName: string): string {
   // Handle empty or whitespace-only filenames
-  if (!fileName || typeof fileName !== 'string') {
-    return 'unnamed_file'
+  if (!fileName || typeof fileName !== "string") {
+    return "unnamed_file"
   }
 
   // Normalize unicode to NFC form
-  let sanitized = fileName.normalize('NFC')
+  let sanitized = fileName.normalize("NFC")
 
   // Remove any path separators (forward and backslash)
-  sanitized = sanitized.replace(/[/\\]/g, '_')
+  sanitized = sanitized.replace(/[/\\]/g, "_")
 
   // Remove control characters (0x00-0x1F)
-  sanitized = sanitized.replace(/[\x00-\x1F]/g, '')
+  sanitized = sanitized.replace(/[\x00-\x1F]/g, "")
 
   // Remove leading dots (hidden files) and spaces
-  sanitized = sanitized.replace(/^[\s.]+/, '')
+  sanitized = sanitized.replace(/^[\s.]+/, "")
 
   // Replace multiple consecutive dots with single dot (prevent .. traversal)
-  sanitized = sanitized.replace(/\.{2,}/g, '.')
+  sanitized = sanitized.replace(/\.{2,}/g, ".")
 
   // Remove trailing dots and spaces (Windows compatibility)
-  sanitized = sanitized.replace(/[\s.]+$/, '')
+  sanitized = sanitized.replace(/[\s.]+$/, "")
 
   // Limit filename length to 255 characters (preserve extension if possible)
   if (sanitized.length > 255) {
@@ -197,8 +201,8 @@ export function sanitizeFileName(fileName: string): string {
   }
 
   // If filename becomes empty after sanitization, use a default
-  if (!sanitized || sanitized.trim() === '') {
-    return 'unnamed_file'
+  if (!sanitized || sanitized.trim() === "") {
+    return "unnamed_file"
   }
 
   return sanitized
@@ -484,13 +488,19 @@ export const ListCollectionsApi = async (c: Context) => {
     let collections = showOnlyOwn
       ? await getCollectionsByOwner(db, user.id)
       : await getAccessibleCollections(db, user.id)
-    
+
     if (agentId) {
-      const agentCollections = await getAgentCollections(db, agentId, user.id, user.workspaceId)
+      const agentCollections = await getAgentCollections(
+        db,
+        agentId,
+        user.id,
+        user.workspaceId,
+      )
       // Merge and deduplicate based on collection id
       const allCollections = [...collections, ...agentCollections]
-      const uniqueCollections = allCollections.filter((collection, index, self) => 
-        index === self.findIndex(c => c.id === collection.id)
+      const uniqueCollections = allCollections.filter(
+        (collection, index, self) =>
+          index === self.findIndex((c) => c.id === collection.id),
       )
       collections = uniqueCollections
     }
@@ -726,7 +736,16 @@ export const UpdateCollectionApi = async (c: Context) => {
 }
 
 // Helper function to delete a Collection (only owner of the collection can delete it)
-export const deleteCollection = async (db: TxnOrClient, collectionId: string, userEmail: string): Promise<{ success: boolean, deletedCount: number, deletedFiles: number, deletedFolders: number }> => {
+export const deleteCollection = async (
+  db: TxnOrClient,
+  collectionId: string,
+  userEmail: string,
+): Promise<{
+  success: boolean
+  deletedCount: number
+  deletedFiles: number
+  deletedFolders: number
+}> => {
   if (!collectionId) {
     throw new HTTPException(400, { message: "Collection ID is required" })
   }
@@ -904,8 +923,8 @@ export const DeleteCollectionApi = async (c: Context) => {
   const collectionId = c.req.param("clId")
 
   try {
-
-    const { success, deletedCount, deletedFiles, deletedFolders } = await deleteCollection(db, collectionId, userEmail)
+    const { success, deletedCount, deletedFiles, deletedFolders } =
+      await deleteCollection(db, collectionId, userEmail)
     if (!success) {
       throw new HTTPException(500, {
         message: "Failed to delete Collection",
@@ -959,17 +978,22 @@ export const ListCollectionItemsApi = async (c: Context) => {
 
     // If agentId is provided, check if the collection belongs to that agent
     if (agentId) {
-      const agentCollections = await getAgentCollections(db, agentId, user.id, user.workspaceId)
-      const collectionBelongsToAgent = agentCollections.some(
-        (agentCollection) => agentCollection.id === collectionId
+      const agentCollections = await getAgentCollections(
+        db,
+        agentId,
+        user.id,
+        user.workspaceId,
       )
-      
+      const collectionBelongsToAgent = agentCollections.some(
+        (agentCollection) => agentCollection.id === collectionId,
+      )
+
       if (!collectionBelongsToAgent && collection.ownerId !== user.id) {
         throw new HTTPException(403, {
           message: "Collection does not belong to the specified agent",
         })
       }
-      
+
       // Skip the normal ownership/privacy check since the collection belongs to the agent
     } else {
       // Owner can edit, permission users can view, and public collections are viewable by all.
@@ -1661,8 +1685,8 @@ export const UploadFilesApi = async (c: Context) => {
             : FileProcessingQueue
         await boss.send(
           queueName,
-          { 
-            fileId: item.id, 
+          {
+            fileId: item.id,
             type: ProcessingJobType.FILE,
             useOCR: useOCR, // Pass OCR option to the processing job
           },
@@ -2011,7 +2035,7 @@ export const GetFilePreviewApi = async (c: Context) => {
   }
 }
 
-// Get chunk content for a file 
+// Get chunk content for a file
 // for collection items (all users in permissions including owner can get chunk content or if collection is public)
 // for attachments (only owner of the file can get chunk content)
 export const GetChunkContentApi = async (c: Context) => {
@@ -2028,7 +2052,10 @@ export const GetChunkContentApi = async (c: Context) => {
   const user = users[0]
 
   try {
-    const resp = await GetDocument(isAttachment ? fileSchema : KbItemsSchema, docId)
+    const resp = await GetDocument(
+      isAttachment ? fileSchema : KbItemsSchema,
+      docId,
+    )
 
     if (!resp || !resp.fields) {
       throw new HTTPException(404, {
@@ -2040,7 +2067,7 @@ export const GetChunkContentApi = async (c: Context) => {
       throw new HTTPException(404, { message: "Document missing chunk data" })
     }
 
-    if(!isAttachment) {
+    if (!isAttachment) {
       const collectionId = (resp.fields as any).clId
       const collection = await getCollectionById(db, collectionId)
       if (!collection) {
@@ -2052,7 +2079,7 @@ export const GetChunkContentApi = async (c: Context) => {
     } else {
       const ownerId = Number((resp.fields as any).owner)
       const email = (resp.fields as any).ownerEmail
-      if(ownerId !== user.id && email !== userEmail) {
+      if (ownerId !== user.id && email !== userEmail) {
         throw new HTTPException(403, {
           message: "You don't have access to this file",
         })
@@ -2087,28 +2114,28 @@ export const GetChunkContentApi = async (c: Context) => {
     // Build chunk content with bounds checking
     const chunksArray = resp.fields.chunks as string[]
     const chunkParts: string[] = []
-    
+
     // Add previous chunk if it exists (for context)
     if (index > 0 && chunksArray[index - 1]) {
       chunkParts.push(chunksArray[index - 1])
     }
-    
+
     // Add the main chunk (always required)
     if (chunksArray[index]) {
       chunkParts.push(chunksArray[index])
     }
-    
+
     // Add next chunk if it exists (for context)
     if (index < chunksArray.length - 1 && chunksArray[index + 1]) {
       chunkParts.push(chunksArray[index + 1])
     }
-    
+
     let chunkContent = chunkParts.join("")
     let pageIndex: number | undefined
     let fileName: string | undefined
-    if(("title" in resp.fields) && resp.fields.title) {
+    if ("title" in resp.fields && resp.fields.title) {
       fileName = resp.fields.title
-    } else if(("fileName" in resp.fields) && resp.fields.fileName) {
+    } else if ("fileName" in resp.fields && resp.fields.fileName) {
       fileName = resp.fields.fileName
     }
 
@@ -2125,9 +2152,13 @@ export const GetChunkContentApi = async (c: Context) => {
         pageIndex = 0
       }
       // Remove header row (first line) and column header (first tab-delimited value) from each remaining line
-      chunkContent = chunkContent.split("\n").slice(1).map((line) => {
-        return line.split("\t").slice(1).join("\t")
-      }).join("\n")
+      chunkContent = chunkContent
+        .split("\n")
+        .slice(1)
+        .map((line) => {
+          return line.split("\t").slice(1).join("\t")
+        })
+        .join("\n")
     } else {
       const pageNums = (resp.fields as any).chunks_map?.[index]?.page_numbers
       // All chunk sources (Docling, PDF.js, OCR) now use 0-based page numbers
@@ -2141,20 +2172,58 @@ export const GetChunkContentApi = async (c: Context) => {
       throw new HTTPException(404, { message: "Chunk content not found" })
     }
 
-    // Get bbox from chunks_map if available
+    // Get bbox + per-fragment bboxes from chunks_map if available
     const chunkMeta = (resp.fields as any).chunks_map?.[index]
-    const bbox = chunkMeta?.bbox_l !== undefined ? {
-      l: chunkMeta.bbox_l,
-      t: chunkMeta.bbox_t,
-      r: chunkMeta.bbox_r,
-      b: chunkMeta.bbox_b,
-    } : null
+    const bbox =
+      chunkMeta?.bbox_l !== undefined
+        ? {
+            l: chunkMeta.bbox_l,
+            t: chunkMeta.bbox_t,
+            r: chunkMeta.bbox_r,
+            b: chunkMeta.bbox_b,
+          }
+        : null
+
+    let bboxes: Array<{
+      l: number
+      t: number
+      r: number
+      b: number
+      page_no?: number | null
+    }> | null = null
+    const bboxesJson = chunkMeta?.bboxes_json
+    if (typeof bboxesJson === "string" && bboxesJson.length > 0) {
+      try {
+        const parsed = JSON.parse(bboxesJson)
+        if (Array.isArray(parsed)) {
+          bboxes = parsed
+            .filter(
+              (b: any) =>
+                b &&
+                typeof b.l === "number" &&
+                typeof b.t === "number" &&
+                typeof b.r === "number" &&
+                typeof b.b === "number",
+            )
+            .map((b: any) => ({
+              l: b.l,
+              t: b.t,
+              r: b.r,
+              b: b.b,
+              page_no: typeof b.page_no === "number" ? b.page_no : null,
+            }))
+          if (bboxes.length === 0) bboxes = null
+        }
+      } catch {
+        bboxes = null
+      }
+    }
 
     return c.json({
       chunkContent: chunkContent,
       pageIndex: pageIndex,
       bbox: bbox,
-
+      bboxes: bboxes,
     })
   } catch (error) {
     if (error instanceof HTTPException) throw error

--- a/server/lib/chunkByDocling.ts
+++ b/server/lib/chunkByDocling.ts
@@ -38,11 +38,16 @@ interface DoclingTocEntry {
   parent_index?: number | null
 }
 
+interface DoclingBboxFragment extends DoclingBbox {
+  page_no?: number | null
+}
+
 interface DoclingChunk {
   text: string
   headings: string[]
   page_numbers: number[]
   bbox?: DoclingBbox
+  bboxes?: DoclingBboxFragment[]
 }
 
 interface DoclingImageChunk {
@@ -91,11 +96,11 @@ interface DoclingResponse {
 // Extended ChunkMetadata with docling-specific fields
 interface DoclingChunkMetadata extends ChunkMetadata {
   bbox?: DoclingBbox
+  bboxes?: DoclingBboxFragment[]
   width?: number
   height?: number
   headings?: string[]
 }
-
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
@@ -106,7 +111,10 @@ function sleep(ms: number): Promise<void> {
  */
 function detectImageExtension(base64Data: string): string {
   // Check for data URL prefix
-  if (base64Data.startsWith("data:image/jpeg") || base64Data.startsWith("data:image/jpg")) {
+  if (
+    base64Data.startsWith("data:image/jpeg") ||
+    base64Data.startsWith("data:image/jpg")
+  ) {
     return "jpg"
   }
   if (base64Data.startsWith("data:image/png")) {
@@ -168,7 +176,9 @@ async function callDoclingService(
 
   const formData = new FormData()
   // Create blob from buffer bytes - use type assertion to bypass strict typing
-  const blob = new Blob([buffer as unknown as BlobPart], { type: "application/pdf" })
+  const blob = new Blob([buffer as unknown as BlobPart], {
+    type: "application/pdf",
+  })
   formData.append("file", blob, fileName)
   formData.append("doc_id", docId)
 
@@ -179,12 +189,15 @@ async function callDoclingService(
     const timer = setTimeout(() => controller.abort(), DOCLING_TIMEOUT_MS)
 
     try {
-      Logger.info(`Calling docling service (attempt ${attempt}/${MAX_RETRIES})`, {
-        fileName,
-        docId,
-        fileSize: buffer.length,
-        url: apiUrl,
-      })
+      Logger.info(
+        `Calling docling service (attempt ${attempt}/${MAX_RETRIES})`,
+        {
+          fileName,
+          docId,
+          fileSize: buffer.length,
+          url: apiUrl,
+        },
+      )
 
       const response = await fetch(apiUrl, {
         method: "POST",
@@ -303,9 +316,7 @@ async function saveImages(
 /**
  * Transform docling chunks to xyne format
  */
-function transformChunks(
-  doclingChunks: DoclingChunk[],
-): {
+function transformChunks(doclingChunks: DoclingChunk[]): {
   chunks: string[]
   chunks_map: DoclingChunkMetadata[]
 } {
@@ -328,13 +339,14 @@ function transformChunks(
 
     // Docling returns 1-based page numbers (first page = 1)
     // Normalize to 0-based to match PDF.js/OCR convention
-    const pageNumbers = (chunk.page_numbers || []).map(p => p - 1)
+    const pageNumbers = (chunk.page_numbers || []).map((p) => p - 1)
 
     chunks_map.push({
       chunk_index: index,
       page_numbers: pageNumbers,
       block_labels: blockLabels,
       bbox: chunk.bbox,
+      bboxes: chunk.bboxes,
       headings: chunk.headings,
     })
   }
@@ -345,9 +357,7 @@ function transformChunks(
 /**
  * Transform docling image chunks to xyne format
  */
-function transformImageChunks(
-  doclingImageChunks: DoclingImageChunk[],
-): {
+function transformImageChunks(doclingImageChunks: DoclingImageChunk[]): {
   image_chunks: string[]
   image_chunks_map: DoclingChunkMetadata[]
 } {
@@ -363,7 +373,9 @@ function transformImageChunks(
     image_chunks.push(description)
     // Docling returns 1-based page numbers (first page = 1)
     // Normalize to 0-based to match PDF.js/OCR convention
-    const pageNumber = imgChunk.page_number ? imgChunk.page_number - 1 : undefined
+    const pageNumber = imgChunk.page_number
+      ? imgChunk.page_number - 1
+      : undefined
     image_chunks_map.push({
       chunk_index: index,
       page_numbers: pageNumber !== undefined ? [pageNumber] : [],

--- a/server/lib/pdfProcessor.ts
+++ b/server/lib/pdfProcessor.ts
@@ -17,7 +17,8 @@ export const PDF_PROCESSING_METHOD = {
   PDFJS: "pdfjs",
 } as const
 
-export type PdfProcessingMethod = typeof PDF_PROCESSING_METHOD[keyof typeof PDF_PROCESSING_METHOD]
+export type PdfProcessingMethod =
+  (typeof PDF_PROCESSING_METHOD)[keyof typeof PDF_PROCESSING_METHOD]
 
 const PDF_GEMINI_PAGE_THRESHOLD = 40
 
@@ -53,9 +54,10 @@ export class PdfProcessor {
     // not the position in this specific array
     if (Array.isArray(metadata) && metadata.length === totalCount) {
       return metadata.map((entry, index) => ({
-        chunk_index: typeof entry?.chunk_index === "number" && entry.chunk_index >= 0
-          ? entry.chunk_index
-          : index,
+        chunk_index:
+          typeof entry?.chunk_index === "number" && entry.chunk_index >= 0
+            ? entry.chunk_index
+            : index,
         page_numbers: Array.isArray(entry?.page_numbers)
           ? entry.page_numbers
           : [],
@@ -63,6 +65,7 @@ export class PdfProcessor {
           ? entry.block_labels
           : [],
         bbox: entry?.bbox,
+        bboxes: (entry as any)?.bboxes,
         width: entry?.width,
         height: entry?.height,
         headings: entry?.headings,
@@ -199,7 +202,11 @@ export class PdfProcessor {
     fileName: string,
     vespaDocId: string,
   ): Promise<ProcessingResult> {
-    const doclingResult = await chunkByDoclingFromBuffer(buffer, fileName, vespaDocId)
+    const doclingResult = await chunkByDoclingFromBuffer(
+      buffer,
+      fileName,
+      vespaDocId,
+    )
     return this.finalizeProcessingResult(
       {
         chunks: doclingResult.chunks,
@@ -214,113 +221,123 @@ export class PdfProcessor {
     )
   }
 
-    /**
-    * Processes a PDF using the fallback logic:
-    * 1. Try OCR first (if enabled via useOCR)
-    *    - If DOCLING_ENABLED is true, use Docling
-    *    - Otherwise, use Paddle OCR (if OCR_PROVIDERS configured)
-    * 2. If OCR fails and PDF < 40 pages, try Gemini
-    * 3. If all above fail or PDF >= 40 pages, use PDF.js
-    *
-    * @param buffer - PDF file buffer
-    * @param fileName - Name of the PDF file
-    * @param vespaDocId - Vespa document ID
-    * @param extractImages - Whether to extract images (only applies to the PDF.js fallback).
-    * @param describeImages - Whether to describe images (only applies to the PDF.js fallback).
-    * @param useOCR - Whether to use OCR for processing (default: true)
-    * @returns PDF processing result with method used
-    */
-   static async processWithFallback(
-     buffer: Buffer,
-     fileName: string,
-     vespaDocId: string,
-     extractImages: boolean = false,
-     describeImages: boolean = false,
-     useOCR: boolean = true,
-   ): Promise<ProcessingResult> {
-     // Step 1: Try OCR first (if enabled)
-     if (useOCR) {
-       try {
-         Logger.info(`Attempting OCR processing for ${fileName}`)
-         
-         // Check if Docling is enabled in config, otherwise use Paddle OCR
-         const doclingEnabled = process.env.DOCLING_ENABLED === "true"
-         
-         if (doclingEnabled) {
-           Logger.info(`Using Docling for OCR processing of ${fileName}`)
-           const doclingResult = await this.processWithDocling(buffer, fileName, vespaDocId)
-           Logger.info(`Docling processing successful for ${fileName}`)
-           return doclingResult
-         } else {
-           Logger.info(`Using Paddle OCR for processing of ${fileName}`)
-           const ocrResult = await chunkByOCRFromBuffer(buffer, fileName, vespaDocId)
-           Logger.info(`OCR processing successful for ${fileName}`)
-           return this.finalizeProcessingResult(
-             {
-               chunks: ocrResult.chunks,
-               chunks_pos: ocrResult.chunks_pos,
-               image_chunks: ocrResult.image_chunks,
-               image_chunks_pos: ocrResult.image_chunks_pos,
-               chunks_map: ocrResult.chunks_map,
-               image_chunks_map: ocrResult.image_chunks_map,
-             },
-             PDF_PROCESSING_METHOD.OCR,
-           )
-         }
-       } catch (error) {
-         Logger.warn(
-           `OCR PDF processing failed for ${fileName}, attempting fallbacks. error: ${JSON.stringify(error)}`,
-         )
-       }
-     } else {
-       Logger.info(`OCR disabled for ${fileName}, skipping OCR processing`)
-     }
+  /**
+   * Processes a PDF using the fallback logic:
+   * 1. Try OCR first (if enabled via useOCR)
+   *    - If DOCLING_ENABLED is true, use Docling
+   *    - Otherwise, use Paddle OCR (if OCR_PROVIDERS configured)
+   * 2. If OCR fails and PDF < 40 pages, try Gemini
+   * 3. If all above fail or PDF >= 40 pages, use PDF.js
+   *
+   * @param buffer - PDF file buffer
+   * @param fileName - Name of the PDF file
+   * @param vespaDocId - Vespa document ID
+   * @param extractImages - Whether to extract images (only applies to the PDF.js fallback).
+   * @param describeImages - Whether to describe images (only applies to the PDF.js fallback).
+   * @param useOCR - Whether to use OCR for processing (default: true)
+   * @returns PDF processing result with method used
+   */
+  static async processWithFallback(
+    buffer: Buffer,
+    fileName: string,
+    vespaDocId: string,
+    extractImages: boolean = false,
+    describeImages: boolean = false,
+    useOCR: boolean = true,
+  ): Promise<ProcessingResult> {
+    // Step 1: Try OCR first (if enabled)
+    if (useOCR) {
+      try {
+        Logger.info(`Attempting OCR processing for ${fileName}`)
 
-     // Step 2: Determine if we should try Gemini based on page count
-     const pageCount = await this.getPdfPageCount(buffer)
-     const shouldTryGemini =
-       pageCount !== null && pageCount < PDF_GEMINI_PAGE_THRESHOLD
+        // Check if Docling is enabled in config, otherwise use Paddle OCR
+        const doclingEnabled = process.env.DOCLING_ENABLED === "true"
 
-     if (shouldTryGemini) {
-       try {
-         Logger.info(`Attempting Gemini processing for ${fileName} (${pageCount} pages)`)
-         const result = await this.processWithGemini(buffer, vespaDocId)
-         Logger.info(`Gemini processing successful for ${fileName}`)
-         return result
-       } catch (error) {
-         Logger.warn(
-           `Gemini PDF processing failed for ${fileName}, falling back to PDF.js. error: ${JSON.stringify(error)}`,
-         )
-       }
-     } else if (pageCount !== null) {
-       Logger.debug(
-         {
-           fileName,
-           pageCount,
-           threshold: PDF_GEMINI_PAGE_THRESHOLD,
-         },
-         "Skipping Gemini fallback due to page count threshold",
-       )
-     }
+        if (doclingEnabled) {
+          Logger.info(`Using Docling for OCR processing of ${fileName}`)
+          const doclingResult = await this.processWithDocling(
+            buffer,
+            fileName,
+            vespaDocId,
+          )
+          Logger.info(`Docling processing successful for ${fileName}`)
+          return doclingResult
+        } else {
+          Logger.info(`Using Paddle OCR for processing of ${fileName}`)
+          const ocrResult = await chunkByOCRFromBuffer(
+            buffer,
+            fileName,
+            vespaDocId,
+          )
+          Logger.info(`OCR processing successful for ${fileName}`)
+          return this.finalizeProcessingResult(
+            {
+              chunks: ocrResult.chunks,
+              chunks_pos: ocrResult.chunks_pos,
+              image_chunks: ocrResult.image_chunks,
+              image_chunks_pos: ocrResult.image_chunks_pos,
+              chunks_map: ocrResult.chunks_map,
+              image_chunks_map: ocrResult.image_chunks_map,
+            },
+            PDF_PROCESSING_METHOD.OCR,
+          )
+        }
+      } catch (error) {
+        Logger.warn(
+          `OCR PDF processing failed for ${fileName}, attempting fallbacks. error: ${JSON.stringify(error)}`,
+        )
+      }
+    } else {
+      Logger.info(`OCR disabled for ${fileName}, skipping OCR processing`)
+    }
 
-     // Step 3: Final fallback to PDF.js
-     try {
-       Logger.info(`Attempting PDF.js processing for ${fileName}`)
-       const result = await this.processWithPdfJs(
-         buffer,
-         vespaDocId,
-         extractImages,
-         describeImages,
-       )
-       Logger.info(`PDF.js processing successful for ${fileName}`)
-       return result
-     } catch (error) {
-       Logger.error(
-         `All PDF processing strategies failed for ${fileName}. error: ${JSON.stringify(error)}`,
-       )
-       throw error
-     }
-   }
+    // Step 2: Determine if we should try Gemini based on page count
+    const pageCount = await this.getPdfPageCount(buffer)
+    const shouldTryGemini =
+      pageCount !== null && pageCount < PDF_GEMINI_PAGE_THRESHOLD
+
+    if (shouldTryGemini) {
+      try {
+        Logger.info(
+          `Attempting Gemini processing for ${fileName} (${pageCount} pages)`,
+        )
+        const result = await this.processWithGemini(buffer, vespaDocId)
+        Logger.info(`Gemini processing successful for ${fileName}`)
+        return result
+      } catch (error) {
+        Logger.warn(
+          `Gemini PDF processing failed for ${fileName}, falling back to PDF.js. error: ${JSON.stringify(error)}`,
+        )
+      }
+    } else if (pageCount !== null) {
+      Logger.debug(
+        {
+          fileName,
+          pageCount,
+          threshold: PDF_GEMINI_PAGE_THRESHOLD,
+        },
+        "Skipping Gemini fallback due to page count threshold",
+      )
+    }
+
+    // Step 3: Final fallback to PDF.js
+    try {
+      Logger.info(`Attempting PDF.js processing for ${fileName}`)
+      const result = await this.processWithPdfJs(
+        buffer,
+        vespaDocId,
+        extractImages,
+        describeImages,
+      )
+      Logger.info(`PDF.js processing successful for ${fileName}`)
+      return result
+    } catch (error) {
+      Logger.error(
+        `All PDF processing strategies failed for ${fileName}. error: ${JSON.stringify(error)}`,
+      )
+      throw error
+    }
+  }
 
   /**
    * Get the page count of a PDF without processing it

--- a/server/queue/fileProcessor.ts
+++ b/server/queue/fileProcessor.ts
@@ -190,10 +190,14 @@ type MappedChunkMeta = {
   bbox_t: number | null
   bbox_r: number | null
   bbox_b: number | null
+  bboxes_json: string | null
   headings?: string[]
 }
 
-const mapChunkMeta = (meta: ChunkMetadata, includeHeadings = false): MappedChunkMeta => {
+const mapChunkMeta = (
+  meta: ChunkMetadata,
+  includeHeadings = false,
+): MappedChunkMeta => {
   const result: MappedChunkMeta = {
     chunk_index: meta.chunk_index,
     page_numbers: meta.page_numbers || [],
@@ -204,17 +208,28 @@ const mapChunkMeta = (meta: ChunkMetadata, includeHeadings = false): MappedChunk
     bbox_t: null,
     bbox_r: null,
     bbox_b: null,
+    bboxes_json: null,
   }
 
-  if (meta.bbox && 
-      typeof meta.bbox.l === 'number' && 
-      typeof meta.bbox.t === 'number' && 
-      typeof meta.bbox.r === 'number' && 
-      typeof meta.bbox.b === 'number') {
+  if (
+    meta.bbox &&
+    typeof meta.bbox.l === "number" &&
+    typeof meta.bbox.t === "number" &&
+    typeof meta.bbox.r === "number" &&
+    typeof meta.bbox.b === "number"
+  ) {
     result.bbox_l = meta.bbox.l
     result.bbox_t = meta.bbox.t
     result.bbox_r = meta.bbox.r
     result.bbox_b = meta.bbox.b
+  }
+
+  if (Array.isArray((meta as any).bboxes) && (meta as any).bboxes.length > 0) {
+    try {
+      result.bboxes_json = JSON.stringify((meta as any).bboxes)
+    } catch {
+      result.bboxes_json = null
+    }
   }
 
   if (includeHeadings) {
@@ -370,7 +385,7 @@ async function processFileJob(jobData: FileProcessingJob, startTime: number) {
         vespaFileName = `${vespaFileName} (${resultIndex + 1})`
         docId = `${file.vespaDocId}_${resultIndex}`
       }
-      
+
       const vespaDoc = {
         docId: docId,
         clId: file.collectionId,
@@ -385,8 +400,12 @@ async function processFileJob(jobData: FileProcessingJob, startTime: number) {
         image_chunks: processingResult.image_chunks,
         image_chunks_pos: processingResult.image_chunks_pos,
         toc_chunks: processingResult.toc_chunks || [],
-        chunks_map: processingResult.chunks_map?.map(meta => mapChunkMeta(meta, true)),
-        image_chunks_map: processingResult.image_chunks_map?.map(meta => mapChunkMeta(meta, false)),
+        chunks_map: processingResult.chunks_map?.map((meta) =>
+          mapChunkMeta(meta, true),
+        ),
+        image_chunks_map: processingResult.image_chunks_map?.map((meta) =>
+          mapChunkMeta(meta, false),
+        ),
         pageTitle: pageTitle,
         metadata: JSON.stringify(
           mergeCollectionItemMetadata(file.metadata, {

--- a/server/types.ts
+++ b/server/types.ts
@@ -708,6 +708,15 @@ export type ChunkMetadata = {
     r: number
     b: number
   }
+  /** Per-fragment bboxes when a chunk merges multiple document items.
+   *  `bbox` above is the union; `bboxes` lists each underlying rectangle. */
+  bboxes?: Array<{
+    l: number
+    t: number
+    r: number
+    b: number
+    page_no?: number | null
+  }>
   width?: number
   height?: number
   headings?: string[]

--- a/server/vespa/schemas/kb_items.sd
+++ b/server/vespa/schemas/kb_items.sd
@@ -9,6 +9,7 @@ schema kb_items {
     field bbox_t type double {}
     field bbox_r type double {}
     field bbox_b type double {}
+    field bboxes_json type string {}
     field width type int {}
     field height type int {}
     field headings type array<string> {}
@@ -103,6 +104,7 @@ schema kb_items {
       struct-field bbox_t { indexing: attribute | summary }
       struct-field bbox_r { indexing: attribute | summary }
       struct-field bbox_b { indexing: attribute | summary }
+      struct-field bboxes_json { indexing: summary }
       struct-field width { indexing: attribute | summary }
       struct-field height { indexing: attribute | summary }
     }
@@ -115,6 +117,7 @@ schema kb_items {
       struct-field bbox_t { indexing: attribute | summary }
       struct-field bbox_r { indexing: attribute | summary }
       struct-field bbox_b { indexing: attribute | summary }
+      struct-field bboxes_json { indexing: summary }
       struct-field width { indexing: attribute | summary }
       struct-field height { indexing: attribute | summary }
       # Array fields are stored in summary only (not as attributes)
@@ -153,12 +156,12 @@ schema kb_items {
   }
 
   # Vector embeddings
-  field chunk_embeddings type tensor<bfloat16>(p{}, v[384]) {
+  field chunk_embeddings type tensor<bfloat16>(p{}, v[768]) {
     indexing: input chunks | embed | attribute | index
     attribute { distance-metric: angular }
   }
 
-  field image_chunk_embeddings type tensor<bfloat16>(p{}, v[384]) {
+  field image_chunk_embeddings type tensor<bfloat16>(p{}, v[768]) {
     indexing: input image_chunks | embed | attribute | index
     attribute { distance-metric: angular }
   }
@@ -177,7 +180,7 @@ schema kb_items {
   rank-profile initial {
     # Inputs for the query vector and alpha for hybrid search
     inputs {
-      query(e) tensor<bfloat16>(v[384])  # Query embedding
+      query(e) tensor<bfloat16>(v[768])  # Query embedding
       query(alpha) double  # Alpha parameter for hybrid weight
       query(recency_decay_rate) double
     }


### PR DESCRIPTION
## Summary

When a user clicks a citation in the chat or knowledge-management view, the PDF panel now shows **two layers** of highlighting that pinpoint where the answer came from:

1. **Per-fragment chunk highlighting (light yellow)** — one yellow rectangle per merged document item (paragraph, heading, table cell). Previously the chunk's bbox was just the *first* item's *first* prov bbox, covering only a fraction of the chunk's content; citations landed in the wrong area.
2. **Cited-substring highlighting (darker yellow on top)** — Smith-Waterman local alignment between the answer text and the chunk text picks the best contiguous span; that substring is painted on top of the bbox using the existing `highlightText` infrastructure, producing a visibly darker band on the actual cited sentence(s).

## What's wired

### Per-fragment bboxes (end-to-end)
- `server/lib/chunkByDocling.ts` — forwards Docling's per-element `bboxes`
- `server/lib/pdfProcessor.ts` — `normalizeChunkMetadata` preserves them
- `server/queue/fileProcessor.ts` — `mapChunkMeta` JSON-encodes them as `bboxes_json` on each `chunks_map` entry
- `server/vespa/schemas/kb_items.sd` — declares the new `bboxes_json` struct field
- `server/api/knowledgeBase.ts` — `GetChunkContentApi` decodes `bboxes_json` → `bboxes[]`
- `frontend/.../PdfViewer.tsx` — `highlightBbox` accepts `bbox | bbox[]`, draws one overlay per element, scrolls the first into view, multi-page aware via `page_no`
- `frontend/.../DocumentOperationsContext.tsx` — type signature widened
- `frontend/.../knowledgeManagement.tsx` and `chat.tsx` — pass `bboxes` if present, else `bbox`

### Substring highlighting
- `frontend/src/lib/textMatch.ts` *(new)* — token-level Smith-Waterman with stopword down-weighting, fixed minimum-score threshold so paraphrased answers still find their source snippet
- `frontend/.../DocumentChat.tsx` — `handleCitationClick` looks up the assistant message that owns the cited source and forwards its plaintext through `onChunkIndexChange` (signature gained `answerText?`)
- `frontend/.../knowledgeManagement.tsx` and `chat.tsx` — after a successful bbox draw, run `findBestMatchSpan(answerText, chunkContent)` and feed the matched substring into `highlightText` for the second layer

### Robustness fixes shipped alongside
- `PdfViewer.highlightBbox` — replaced single canvas-poll with a `waitForCanvasStable` poll (offsetHeight unchanged for 2 consecutive 16ms samples). react-pdf re-renders the canvas at the final fit-to-width size after an initial smaller render; reading the mid-flight size gave a wrong scale and overlays landed off-page.
- `chat.tsx` — fall back to text-search when `highlightBbox` returns `false` (was only catching thrown errors).
- `useScopedFind.clearHighlightsFromDOM` — no longer wipes `[data-bbox-overlay]`. With the layered design, text-layer cleanup must not erase the bbox underneath; bbox cleanup remains in `PdfViewer.highlightBbox` where each draw clears its own predecessors.

## Backward compatibility

Older chunks ingested before this change have no `bboxes_json` field. The API returns `bboxes: null` in that case and the frontend silently degrades to the single union `bbox` rectangle. No schema migration or data backfill is required for existing data to keep working.

## Upstream dependency

This PR makes the most of the Docling sidecar emitting `bboxes` per chunk in its `/process` response. The upstream change is in [MukherjeeSourish/paddle PR #1](https://github.com/MukherjeeSourish/paddle/pull/1). With the unmodified upstream Docling (only `bbox`), the bbox layer still works (single rectangle) and the substring layer still works — you just don't get per-paragraph multi-rectangles.

## Test plan
- [ ] Re-ingest a multi-paragraph PDF after deploying the Vespa schema; verify `bboxes_json` is populated in `chunks_map`
- [ ] Click a citation in `/knowledgeManagement` chat with a chunked PDF — confirm one rectangle per paragraph + a darker band on the cited substring
- [ ] Click a citation in `/chat/:id` (regular chat) on the same doc — confirm parity
- [ ] Click a citation on a chunk that spans multiple pages — confirm rectangles light up on every page they span
- [ ] Click a citation on a chunk that pre-dates this PR (no `bboxes_json` in Vespa) — confirm the union bbox renders as a single rectangle and the substring layer still works
- [ ] Resize the citation panel mid-click — confirm bbox positions follow the canvas (the stability poll waits for layout to settle before measuring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More precise citation highlighting: bbox-first plus substring matching to pinpoint answer text
  * Support for multiple bounding boxes/fragments per chunk and multi-page navigation
  * PDF viewer now reliably scrolls and highlights multiple fragments smoothly

* **Bug Fixes**
  * More reliable answer-text resolution when jumping to citations
  * Highlighting no longer unintentionally clears bbox overlays
  * Search/highlight matching improved to avoid stale or incorrect matches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->