### PR TITLE
fix: adding envs to db connections and docling retries

### DIFF
--- a/server/db/client.ts
+++ b/server/db/client.ts
@@ -10,7 +10,11 @@ const Logger = getLogger(Subsystem.Db).child({ module: "client" })
 const url = config.getDatabaseUrl()
 
 const queryClient = postgres(url, {
-  idle_timeout: 0,
+  max: Number(process.env.DB_POOL_MAX ?? 5),
+  idle_timeout: Number(process.env.DB_POOL_IDLE_TIMEOUT ?? 30),
+  connection: {
+    application_name: process.env.DB_APPLICATION_NAME ?? "xyne-drizzle",
+  },
 })
 // We will use the exported variable to query our db:
 export const db = drizzle(queryClient, { schema })

--- a/server/db/client.ts
+++ b/server/db/client.ts
@@ -10,8 +10,8 @@ const Logger = getLogger(Subsystem.Db).child({ module: "client" })
 const url = config.getDatabaseUrl()
 
 const queryClient = postgres(url, {
-  max: Number(process.env.DB_POOL_MAX ?? 5),
-  idle_timeout: Number(process.env.DB_POOL_IDLE_TIMEOUT ?? 30),
+  max: Number.parseInt(process.env.DB_POOL_MAX || "5", 10) || 5,
+  idle_timeout: Number.parseInt(process.env.DB_POOL_IDLE_TIMEOUT || "30", 10),
   connection: {
     application_name: process.env.DB_APPLICATION_NAME ?? "xyne-drizzle",
   },

--- a/server/lib/chunkByDocling.ts
+++ b/server/lib/chunkByDocling.ts
@@ -12,14 +12,20 @@ const Logger = getLogger(Subsystem.Integrations).child({
 
 const DEFAULT_IMAGE_DIR = "downloads/xyne_images_db"
 const DEFAULT_DOCLING_TIMEOUT_MS = 300000
-const MAX_RETRIES = 3
-const RETRY_DELAY_MS = 1000
+const DEFAULT_MAX_RETRIES = 3
+const DEFAULT_RETRY_DELAY_MS = 1000
 
 // Configuration from environment or config
 const DOCLING_BASE_URL = config.doclingServiceUrl || "http://localhost:8000"
 const DOCLING_TIMEOUT_MS = process.env.DOCLING_TIMEOUT_MS
   ? Number.parseInt(process.env.DOCLING_TIMEOUT_MS, 10)
   : DEFAULT_DOCLING_TIMEOUT_MS
+const MAX_RETRIES = process.env.DOCLING_MAX_RETRIES
+  ? Math.max(1, Number.parseInt(process.env.DOCLING_MAX_RETRIES, 10))
+  : DEFAULT_MAX_RETRIES
+const RETRY_DELAY_MS = process.env.DOCLING_RETRY_DELAY_MS
+  ? Math.max(0, Number.parseInt(process.env.DOCLING_RETRY_DELAY_MS, 10))
+  : DEFAULT_RETRY_DELAY_MS
 
 // Docling API response types
 interface DoclingBbox {

--- a/server/queue/boss.ts
+++ b/server/queue/boss.ts
@@ -3,7 +3,7 @@ import config from "@/config"
 
 export const boss = new PgBoss({
   connectionString: config.getDatabaseUrl(),
-  max: Number(process.env.PGBOSS_POOL_MAX ?? 5),
+  max: Number.parseInt(process.env.PGBOSS_POOL_MAX || "5", 10) || 5,
   application_name: process.env.PGBOSS_APPLICATION_NAME ?? "xyne-pgboss",
   monitorStateIntervalMinutes: 10, // Monitor state every 10 minutes
 })

--- a/server/queue/boss.ts
+++ b/server/queue/boss.ts
@@ -3,5 +3,7 @@ import config from "@/config"
 
 export const boss = new PgBoss({
   connectionString: config.getDatabaseUrl(),
+  max: Number(process.env.PGBOSS_POOL_MAX ?? 5),
+  application_name: process.env.PGBOSS_APPLICATION_NAME ?? "xyne-pgboss",
   monitorStateIntervalMinutes: 10, // Monitor state every 10 minutes
 })


### PR DESCRIPTION
### Description

<!-- Summarize the changes in this PR. -->
<!-- Explain the purpose of the change (e.g., bug fix, feature, refactor). -->
<!-- Describe how this change affects the system or users. -->

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Database connection pool sizing, idle timeout, and application name are now configurable via environment variables.
  * Job queue pool size and application name are now configurable via environment variables.
  * Document processing retry behavior (max retries and delay) are now configurable via environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->