### PR TITLE
feat(citations): focused cite-pass + first-click highlight fix

### DIFF
--- a/frontend/src/components/CitationPreview.tsx
+++ b/frontend/src/components/CitationPreview.tsx
@@ -65,6 +65,11 @@ const CitationPreview: React.FC<CitationPreviewProps> = ({
   initialPageIndex,
 }) => {
   const [documentContent, setDocumentContent] = useState<Blob | null>(null)
+  // Tracks whether the underlying PDF viewer has actually painted its first
+  // page canvas. We gate `onDocumentLoaded` on this so downstream consumers
+  // (e.g. chat.tsx replaying a chunk highlight) anchor their overlays to a
+  // stable canvas — not one that's still resizing from the initial render.
+  const [pdfFirstPageRendered, setPdfFirstPageRendered] = useState(false)
   const [agentDocument, setAgentDocument] = useState<AgentDocumentPayload | null>(
     null,
   )
@@ -311,6 +316,7 @@ const CitationPreview: React.FC<CitationPreviewProps> = ({
               displayMode="continuous"
               documentOperationsRef={documentOperationsRef}
               initialPage={initialPageOrSheetIndex}
+              onFirstPageRendered={() => setPdfFirstPageRendered(true)}
             />
           </div>
         )
@@ -426,16 +432,32 @@ const CitationPreview: React.FC<CitationPreviewProps> = ({
     }
   }, [citation, documentContent, initialPageIndex])
 
-  // Notify parent when document is loaded and ready
+  // Reset the "PDF actually rendered" latch whenever the citation switches
+  // to a different doc — otherwise a stale `true` from a previous citation
+  // would let onDocumentLoaded fire before the new PDF's canvas is painted.
+  useEffect(() => {
+    setPdfFirstPageRendered(false)
+  }, [citation?.docId])
+
+  // Notify parent when document is loaded AND visually rendered. For PDFs
+  // we gate on `pdfFirstPageRendered` (a real "first canvas painted" signal
+  // from PdfViewer) instead of just `documentContent` (which is the pdf.js
+  // *fetch* completing — way before the canvas is at final size). Anchoring
+  // a highlight overlay before the canvas stabilizes causes the "highlight
+  // lands in wrong spot on the first click" bug.
   useEffect(() => {
     if (!onDocumentLoaded || loading || error) return
     if (citation && isAgentDocumentCitation(citation)) {
       if (agentDocument) onDocumentLoaded()
       return
     }
-    if (documentContent && viewerElement) {
-      onDocumentLoaded()
-    }
+    if (!documentContent || !viewerElement) return
+    const extension = citation?.title?.split(".").pop()?.toLowerCase()
+    // Non-PDFs (markdown, docx, etc.) don't need the canvas-stable gate —
+    // their viewers either don't have an overlay use case or render
+    // synchronously enough that the existing "documentContent" check is OK.
+    if (extension === "pdf" && !pdfFirstPageRendered) return
+    onDocumentLoaded()
   }, [
     loading,
     error,
@@ -444,6 +466,7 @@ const CitationPreview: React.FC<CitationPreviewProps> = ({
     onDocumentLoaded,
     viewerElement,
     citation,
+    pdfFirstPageRendered,
   ])
 
   if (!isOpen) return null

--- a/frontend/src/components/PdfViewer.tsx
+++ b/frontend/src/components/PdfViewer.tsx
@@ -76,6 +76,15 @@ interface PdfViewerProps {
   showNavigation?: boolean
   /** Ref to expose document operations */
   documentOperationsRef?: React.RefObject<DocumentOperations>
+  /**
+   * Fires once, the first time ANY page canvas finishes rendering. This is
+   * a "the viewer is now actually drawn on screen" signal — distinct from
+   * `pdf.js` finishing the *document* fetch/parse, which happens earlier
+   * while the canvas is still being painted. Consumers can use this to
+   * defer downstream work (e.g. replaying a chunk highlight) until the
+   * canvas is stable enough to anchor an overlay.
+   */
+  onFirstPageRendered?: () => void
 }
 
 export const PdfViewer: React.FC<PdfViewerProps> = ({
@@ -89,7 +98,16 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
   displayMode = "continuous",
   showNavigation = true,
   documentOperationsRef,
+  onFirstPageRendered,
 }) => {
+  // Latch so onFirstPageRendered fires at most once per PdfViewer instance.
+  // (Each render-success on every page would otherwise fire it repeatedly.)
+  const firstPageRenderedFiredRef = useRef(false)
+  const fireFirstPageRendered = useCallback(() => {
+    if (firstPageRenderedFiredRef.current) return
+    firstPageRenderedFiredRef.current = true
+    onFirstPageRendered?.()
+  }, [onFirstPageRendered])
   const [numPages, setNumPages] = useState<number | null>(null)
   const [pageNumber, setPageNumber] = useState<number>(initialPage)
   const [currentVisiblePage, setCurrentVisiblePage] =
@@ -1054,7 +1072,10 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
                 key={`page_${pageNumber}`}
                 pageNumber={pageNumber}
                 scale={scale}
-                onRenderSuccess={() => mark(pageNumber, "canvas")}
+                onRenderSuccess={() => {
+                  mark(pageNumber, "canvas")
+                  fireFirstPageRendered()
+                }}
                 onRenderTextLayerSuccess={() => {
                   // ensure it's actually painted:
                   requestAnimationFrame(() => mark(pageNumber, "text"))
@@ -1114,7 +1135,10 @@ export const PdfViewer: React.FC<PdfViewerProps> = ({
                           <PageWrapper
                             pageNumber={pageNum}
                             scale={scale}
-                            onRenderSuccess={() => mark(pageNum, "canvas")}
+                            onRenderSuccess={() => {
+                              mark(pageNum, "canvas")
+                              fireFirstPageRendered()
+                            }}
                             onRenderTextLayerSuccess={() => {
                               // ensure it's actually painted:
                               requestAnimationFrame(() => mark(pageNum, "text"))

--- a/frontend/src/hooks/useChatStream.ts
+++ b/frontend/src/hooks/useChatStream.ts
@@ -498,6 +498,21 @@ export const startStream = async (
     responseQueue.addChunk(event.data)
   })
 
+  // Cite-pass: server emits this once, after synthesis ends, with the full
+  // answer text re-written to include K[N_M] markers. Frontend REPLACES the
+  // streamed plain text with this cited version so the existing markdown
+  // citation renderer (processMessage + CitationLink) lights up the inline
+  // pills. The streamed `ResponseUpdate` chunks are append-only and don't
+  // carry citations on their own.
+  streamState.es.addEventListener(ChatSSEvents.ResponseCited, (event) => {
+    const citedAnswer = event.data
+    if (!citedAnswer) return
+    streamState.partial = citedAnswer
+    streamState.response = citedAnswer
+    streamState.displayPartial = citedAnswer
+    notifySubscribers(streamKey)
+  })
+
   streamState.es.addEventListener(ChatSSEvents.Reasoning, (event) => {
     appendReasoningData(streamState, event.data)
     notifySubscribers(streamKey)
@@ -1252,6 +1267,32 @@ export const useChatStream = (
         )
         responseQueue.addChunk(event.data)
 
+        notifySubscribers(retryStreamKey)
+      })
+
+      // Cite-pass on retry stream: replace the streamed plain text with the
+      // cited version emitted after synthesis. Same idea as the matching
+      // handler on the primary stream above; see the ResponseCited comment
+      // there for details.
+      eventSource.addEventListener(ChatSSEvents.ResponseCited, (event) => {
+        const citedAnswer = event.data
+        if (!citedAnswer) return
+        streamState.partial = citedAnswer
+        streamState.response = citedAnswer
+        streamState.displayPartial = citedAnswer
+        if (chatId) {
+          queryClient.setQueryData(["chatHistory", chatId], (old: any) => {
+            if (!old?.messages) return old
+            return {
+              ...old,
+              messages: old.messages.map((m: any) =>
+                m.externalId === messageId && m.messageRole === "assistant"
+                  ? { ...m, message: citedAnswer }
+                  : m,
+              ),
+            }
+          })
+        }
         notifySubscribers(retryStreamKey)
       })
 

--- a/server/api/chat/insertCitations.ts
+++ b/server/api/chat/insertCitations.ts
@@ -1,0 +1,207 @@
+/**
+ * insertCitations — a dedicated "citation grammar" pass.
+ *
+ * Why this exists:
+ *   The main synthesis call has to do many things at once (answer, reason,
+ *   maintain tone, follow citation grammar). Citation format compliance is the
+ *   first thing the model drops under that load — we've seen mangled formats
+ *   like [K1_17], K[7], or no markers at all.
+ *
+ *   Instead of fighting non-determinism with regexes, we run a second focused
+ *   LLM pass that does ONLY one thing: insert `K[N_M]` markers into the prose
+ *   the synthesis already produced. Same model (Kimi-latest in our setup) but
+ *   a small, single-purpose prompt — much higher format-compliance rate.
+ *
+ * Failure mode:
+ *   If the cite-pass produces output we can't trust (no markers at all, or
+ *   throws), we fall back to the original answer. The user still sees the
+ *   answer; only the inline citations are missing.
+ */
+import { getLoggerWithChild } from "@/logger"
+import { Subsystem } from "@/types"
+import { ConversationRole } from "@aws-sdk/client-bedrock-runtime"
+import { getProviderByModel } from "@/ai/provider"
+import type { Models } from "@/ai/types"
+import type { MinimalAgentFragment } from "@/api/chat/types"
+import type { Message } from "@aws-sdk/client-bedrock-runtime"
+
+const loggerWithChild = getLoggerWithChild(Subsystem.Chat)
+
+const SYSTEM_PROMPT = `You are a citation marker inserter for a RAG system.
+
+Your job: take an ANSWER and a numbered list of SOURCES, then return the
+SAME ANSWER with citation markers inserted after factual claims.
+
+CITATION FORMAT — use exactly this grammar:
+  K[N_M]   where N is the 1-based source index and M is the 0-based chunk
+           index inside that source.
+
+Examples:
+  Input:  "IBFSL provided ₹293.90 crores to seven companies."
+  Output: "IBFSL provided ₹293.90 crores to seven companies K[1_5]."
+
+  Input:  "The settlement was dated November 18, 2009 and the loan was ₹232.50 crores."
+  Output: "The settlement was dated November 18, 2009 K[1_5] and the loan was ₹232.50 crores K[2_3]."
+
+RULES:
+1. DO NOT change any wording, punctuation, sentence order, or formatting.
+   Preserve markdown bullets, bold, lists, line breaks exactly as given.
+2. Insert markers immediately after the claim they support, with one space
+   before the marker.
+3. Use the source index (N) and chunk index (M) of the chunk that contains
+   the supporting evidence.
+4. If a sentence has two distinct claims from different chunks, include two
+   markers.
+5. Maximum 2 markers per sentence.
+6. If a claim cannot be grounded in any provided source, leave it WITHOUT
+   a marker.
+7. Output ONLY the cited answer text. No preamble. No explanation. No JSON.
+   No markdown code fences.`
+
+const MAX_CHUNK_CHARS = 600 // truncate per-fragment content sent to the model
+const MIN_VALID_MARKER_REGEX = /K\[\d+_\d+\]/ // at least one well-formed marker
+
+/**
+ * Build the user message presenting numbered sources + the answer to cite.
+ */
+function buildUserPrompt(
+  answer: string,
+  fragments: MinimalAgentFragment[],
+): string {
+  const sourceBlocks = fragments.map((frag, idx) => {
+    const title =
+      frag.source?.title || frag.source?.docId || `fragment ${frag.id}`
+    const visible = (frag.visibleChunkIndices ?? []).filter((v) =>
+      Number.isFinite(v),
+    )
+    const chunkIdxLabel =
+      visible.length > 0 ? visible.map((v) => `[${v}]`).join(" ") : "[0]"
+    // Trim long chunks — the model only needs enough to know what the chunk
+    // is about so it can decide whether to cite it.
+    const trimmed = frag.content
+      ? frag.content.length > MAX_CHUNK_CHARS
+        ? `${frag.content.slice(0, MAX_CHUNK_CHARS)}…`
+        : frag.content
+      : "(no content)"
+    return `[Source ${idx + 1}] (file: ${title})\n  Chunks: ${chunkIdxLabel}\n  Content: ${trimmed}`
+  })
+
+  return `SOURCES:
+${sourceBlocks.join("\n\n")}
+
+ANSWER:
+${answer}`
+}
+
+/**
+ * Insert K[N_M] citation markers into the synthesis answer using a focused
+ * second-pass LLM call. Same model as synthesis; we just give it ONE job.
+ *
+ * Returns the cited answer on success, or the original answer if the pass
+ * fails (logged so we can monitor reliability). Two attempts max, both at
+ * temperature 0 — second attempt only if the first returns no markers at all.
+ */
+export async function insertCitations(args: {
+  answer: string
+  fragments: MinimalAgentFragment[]
+  modelId: Models
+  email: string
+}): Promise<string> {
+  const { answer, fragments, modelId, email } = args
+
+  if (!answer || answer.trim().length === 0) return answer
+  if (!fragments.length) {
+    loggerWithChild({ email }).info(
+      "[insertCitations] No retrieved fragments — skipping cite-pass",
+    )
+    return answer
+  }
+
+  const userPrompt = buildUserPrompt(answer, fragments)
+  const messages: Message[] = [
+    {
+      role: ConversationRole.USER,
+      content: [{ text: userPrompt }],
+    },
+  ]
+
+  // Compute total chunk count across all fragments. Each fragment can map
+  // to multiple chunk indices (e.g. when docling's HybridChunker groups
+  // several paragraphs as one semantic chunk). Logging this gives a clearer
+  // signal than `fragmentsCount` alone of how much grounding evidence the
+  // cite-pass is being asked to consider.
+  const chunksCount = fragments.reduce((sum, frag) => {
+    const visible = (frag.visibleChunkIndices ?? []).filter((v) =>
+      Number.isFinite(v),
+    )
+    return sum + (visible.length > 0 ? visible.length : 1)
+  }, 0)
+  const promptChars = userPrompt.length
+
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    const startedAt = Date.now()
+    try {
+      loggerWithChild({ email }).info(
+        {
+          attempt,
+          modelId,
+          fragmentsCount: fragments.length,
+          chunksCount,
+          answerLen: answer.length,
+          promptChars,
+        },
+        "[insertCitations] running cite-pass",
+      )
+
+      const provider = getProviderByModel(modelId)
+      const { text } = await provider.converse(messages, {
+        modelId,
+        systemPrompt: SYSTEM_PROMPT,
+        temperature: 0,
+        stream: false,
+        json: false,
+      })
+
+      const tookMs = Date.now() - startedAt
+      const cited = (text || "").trim()
+
+      if (cited.length === 0) {
+        loggerWithChild({ email }).warn(
+          { attempt, tookMs },
+          "[insertCitations] empty response from cite-pass",
+        )
+        continue
+      }
+
+      if (!MIN_VALID_MARKER_REGEX.test(cited)) {
+        loggerWithChild({ email }).warn(
+          { attempt, tookMs, preview: cited.slice(0, 200) },
+          "[insertCitations] no K[N_M] markers in response — retrying once",
+        )
+        continue
+      }
+
+      loggerWithChild({ email }).info(
+        {
+          attempt,
+          tookMs,
+          fragmentsCount: fragments.length,
+          chunksCount,
+          markersFound: (cited.match(/K\[\d+_\d+\]/g) || []).length,
+        },
+        "[insertCitations] cite-pass succeeded",
+      )
+      return cited
+    } catch (err) {
+      loggerWithChild({ email }).warn(
+        { attempt, tookMs: Date.now() - startedAt, err },
+        "[insertCitations] cite-pass call threw",
+      )
+    }
+  }
+
+  loggerWithChild({ email }).warn(
+    "[insertCitations] all attempts failed; returning original answer",
+  )
+  return answer
+}

--- a/server/api/chat/message-agents.ts
+++ b/server/api/chat/message-agents.ts
@@ -183,6 +183,7 @@ import {
   mapCitationsForAgentDocument,
   parseAgentAppIntegrations,
 } from "./tools/utils"
+import { insertCitations } from "@/api/chat/insertCitations"
 import {
   documentMemoryToRawDocuments,
   getFragmentsForSynthesis,
@@ -947,6 +948,84 @@ async function finalizeMainRunResponse(args: {
     lastPersistedMessageId,
     lastPersistedMessageExternalId,
   }
+}
+
+/**
+ * Run the cite-pass after synthesis: retrieve fragments, call the focused
+ * citation-grammar LLM pass, then emit CitationsUpdate + ResponseCited so
+ * the frontend renders inline `K[N_M]` markers as clickable pills.
+ *
+ * Citations emitted are ONLY those whose source index actually appears in
+ * the cited answer's `K[N_M]` markers — otherwise the Sources panel would
+ * fill with every retrieved fragment regardless of what the model cited.
+ *
+ * On any failure (closed stream, no fragments, cite-pass error) the
+ * original answer is returned and no `cu`/`rcc` from this helper land on
+ * the wire (the legacy text-scanner's `cu` events, if any, still stand).
+ */
+async function runCitePassAndEmit(args: {
+  answer: string
+  agentContext: AgentRunContext
+  modelId: Models
+  email: string
+  stream: MainRunSSEStream
+  pathLabel: "tool_call_end" | "run_end"
+}): Promise<string> {
+  const { answer, agentContext, modelId, email, stream, pathLabel } = args
+
+  const fragments = await getFragmentsForSynthesis(agentContext.documentMemory, {
+    email: agentContext.user?.email,
+    userId: agentContext.user?.numericId ?? undefined,
+    workspaceId: agentContext.user?.workspaceNumericId ?? undefined,
+  })
+  const citedAnswer = await insertCitations({
+    answer,
+    fragments,
+    modelId,
+    email,
+  })
+  if (stream.closed) return citedAnswer
+
+  // Parse K[N_M] markers from the cited text. `citationMap` maps the 1-based
+  // source index (as it appears in K[N_M]) to its 0-based position in the
+  // emitted `contextChunks` array so the frontend can resolve each marker
+  // to a real URL.
+  const markerRegex = /K\[(\d+)_\d+\]/g
+  const referencedSources = new Set<number>()
+  let match: RegExpExecArray | null
+  while ((match = markerRegex.exec(citedAnswer)) !== null) {
+    referencedSources.add(parseInt(match[1], 10))
+  }
+  const contextChunks: Citation[] = []
+  const citationMap: Record<number, number> = {}
+  for (const sourceIdx of [...referencedSources].sort((a, b) => a - b)) {
+    const frag = fragments[sourceIdx - 1]
+    if (!frag || (!frag.source?.docId && !frag.source?.url)) continue
+    citationMap[sourceIdx] = contextChunks.length
+    contextChunks.push(frag.source)
+  }
+  if (contextChunks.length > 0) {
+    await stream.writeSSE({
+      event: ChatSSEvents.CitationsUpdate,
+      data: JSON.stringify({ contextChunks, citationMap }),
+    })
+  }
+  loggerWithChild({ email }).info(
+    {
+      pathLabel,
+      changed: citedAnswer !== answer,
+      answerLen: answer.length,
+      citedLen: citedAnswer.length,
+      referencedSourcesCount: referencedSources.size,
+      citeFragmentsEmitted: contextChunks.length,
+    },
+    "[MessageAgents] Emitting ResponseCited",
+  )
+  await stream.writeSSE({
+    event: ChatSSEvents.ResponseCited,
+    data: citedAnswer,
+  })
+  return citedAnswer
 }
 
 function formatClarificationsForPrompt(
@@ -6070,6 +6149,14 @@ export async function MessageAgents(c: Context): Promise<Response> {
                   },
                   "[MessageAgents][FinalSynthesis] Persist + End at tool_call_end",
                 )
+                const citedAnswer = await runCitePassAndEmit({
+                  answer,
+                  agentContext,
+                  modelId: agenticModelId,
+                  email,
+                  stream,
+                  pathLabel: "tool_call_end",
+                })
                 const finalizedState = await finalizeMainRunResponse({
                   db,
                   persistContext: {
@@ -6082,7 +6169,7 @@ export async function MessageAgents(c: Context): Promise<Response> {
                     requestStartMs,
                   },
                   persistData: {
-                    answer,
+                    answer: citedAnswer,
                     citations,
                     imageCitations,
                     citationMap,
@@ -6410,6 +6497,14 @@ export async function MessageAgents(c: Context): Promise<Response> {
                   }
                 }
 
+                const citedAnswer2 = await runCitePassAndEmit({
+                  answer,
+                  agentContext,
+                  modelId: agenticModelId,
+                  email,
+                  stream,
+                  pathLabel: "run_end",
+                })
                 const finalizedState = await finalizeMainRunResponse({
                   db,
                   persistContext: {
@@ -6422,7 +6517,7 @@ export async function MessageAgents(c: Context): Promise<Response> {
                     requestStartMs,
                   },
                   persistData: {
-                    answer,
+                    answer: citedAnswer2,
                     citations,
                     imageCitations,
                     citationMap,

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -548,6 +548,12 @@ export enum ChatSSEvents {
   AttachmentUpdate = "au",
   ClarificationRequested = "cr",
   ClarificationProvided = "cp",
+  // Emitted by the cite-pass (insertCitations.ts) after synthesis finishes:
+  // payload is the full answer text WITH `K[N_M]` markers inserted.
+  // Frontend should REPLACE the currently displayed message text with this,
+  // not append. Streamed `ResponseUpdate` chunks are append-only; this event
+  // is the single "the answer is now done and includes citations" signal.
+  ResponseCited = "rcc",
 }
 
 const messageMetadataSchema = z.object({


### PR DESCRIPTION
Add a dedicated cite-pass LLM call after synthesis that inserts K[N_M] markers into the answer. Same model as synthesis; the focused prompt gives much higher format-compliance than asking the synthesis call to cite inline.

New ResponseCited (rcc) SSE event swaps the displayed text with the cited version once the pass completes. CitationsUpdate is emitted just for the source indices actually referenced in K[N_M], so the Sources panel only shows files the answer actually cites.

Also fixes the "first citation click highlights in the wrong place" bug: PdfViewer now exposes onFirstPageRendered, and CitationPreview gates onDocumentLoaded on it so the overlay anchors to a stable canvas instead of one mid-resize.

### Description

<!-- Summarize the changes in this PR. -->
<!-- Explain the purpose of the change (e.g., bug fix, feature, refactor). -->
<!-- Describe how this change affects the system or users. -->

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat responses now include inline citation markers to identify referenced sources.
  * PDF viewer ensures the first page is fully rendered before displaying content to users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xynehq/xyne/pull/1337)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->