### PR TITLE
fix(citation-regex): Citation regex handling robust

### DIFF
--- a/frontend/src/utils/chatUtils.tsx
+++ b/frontend/src/utils/chatUtils.tsx
@@ -5,12 +5,16 @@ import type { Citation } from "@/components/CitationLink"
 export { generateUUID } from "@/utils/uuid"
 
 export const textToCitationIndex = /\[(\d+)\]/g
-export const textToImageCitationIndex = /(?<!K)\[(\d+_\d+)\]/g
-// KB citations emitted by stronger models:
-//   K[<docIndex>_<chunkIndex>] e.g. K[1_21]
-// We also support weaker models emitting doc keys directly:
-//   K[<docKey>_<chunkIndex>] e.g. K[docId_21]
-export const textToChunkCitationIndex = /K\[([A-Za-z0-9_-]+)_([0-9]+)\]/g
+// Image citations from `[N_M]` are now treated as KB chunks. Kept as never-match
+// so existing image-replace passes are silently no-ops.
+export const textToImageCitationIndex = /(?!)/g
+// KB chunk citations. Matches all six variants emitted by various models:
+//   K[1_0], [K1_0], [1_0], K(1_0), (K1_0), (1_0) — and the alphanumeric doc-key
+//   forms like K[attf_uuid_21], [Kattf_uuid_21]. Alphanumeric body REQUIRES a K
+//   marker so bare `[var_1]` (user content) is left alone; the `(?=\d)` lookahead
+//   on the bare-bracket alternative allows numeric `[1_0]` through.
+export const textToChunkCitationIndex =
+  /(?:K[\[\(]+|[\[\(]+K|[\[\(]+(?=\d))([A-Za-z0-9_-]+)_([0-9]+)[\]\)]/g
 
 // Function to clean citation numbers from response text
 export const cleanCitationsFromResponse = (text: string): string => {

--- a/server/api/chat/chat.ts
+++ b/server/api/chat/chat.ts
@@ -499,7 +499,9 @@ const checkAndYieldCitations = async function* (
   let chunkMatch = null
   let chunkDocKeyMatch = null
 
-  const textToChunkCitationIndexWithDocKey = /K\[([A-Za-z0-9_-]+)_([0-9]+)\]/g
+  // See server/api/chat/utils.ts for pattern rationale.
+  const textToChunkCitationIndexWithDocKey =
+    /(?:K[\[\(]+|[\[\(]+K|[\[\(]+(?=\d))([A-Za-z0-9_-]+)_([0-9]+)[\]\)]/g
 
   // Reset global RegExp state so this function can be called repeatedly per request.
   textToCitationIndex.lastIndex = 0

--- a/server/api/chat/pi-mono/tools/tool-utils.ts
+++ b/server/api/chat/pi-mono/tools/tool-utils.ts
@@ -28,8 +28,10 @@ export function formatFragmentsForLLM(
 }
 
 export const textToCitationIndex = /\[(\d+)\]/g
-export const textToImageCitationIndex = /(?<!K)\[(\d+_\d+)\]/g
-export const textToChunkCitationIndex = /K\[(\d+_\d+)\]/g
+// Image citations from `[N_M]` are now treated as KB chunks (see utils.ts).
+export const textToImageCitationIndex = /(?!)/g
+// Matches K[N_M], [KN_M], [N_M], K(N_M), (KN_M), (N_M) — numeric body only.
+export const textToChunkCitationIndex = /[K\[\(]+(\d+_\d+)[\]\)]/g
 
 export const checkAndYieldCitationsForAgent = async function* (
   textInput: string,

--- a/server/api/chat/utils.ts
+++ b/server/api/chat/utils.ts
@@ -724,13 +724,20 @@ const searchToCitations = (results: VespaSearchResults[]): Citation[] => {
 }
 
 export const textToCitationIndex = /\[(\d+)\]/g
-export const textToImageCitationIndex = /(?<!K)\[(\d+_\d+)\]/g
-export const textToChunkCitationIndex = /K\[(\d+_\d+)\]/g
-// Fallback for weaker LLMs emitting KB citations as:
-//   K[<docId>_<chunkIndex>]  (e.g. K[attf_<uuid>_21])
-// instead of the expected:
-//   K[<docIndex>_<chunkIndex>] (e.g. K[1_21])
-const textToChunkCitationIndexWithDocKey = /K\[([A-Za-z0-9_-]+)_([0-9]+)\]/g
+// Image citations from `[N_M]` are now treated as KB chunks, so this regex
+// is intentionally never-match. Kept exported because downstream code imports it.
+export const textToImageCitationIndex = /(?!)/g
+// Numeric KB chunk citations. Matches all six emitted variants:
+//   K[1_0], [K1_0], [1_0], K(1_0), (K1_0), (1_0)
+// The `[K\[\(]+` prefix accepts K/`[`/`(` in any combination; the captured body
+// is strictly numeric so plain user text like `[var_1]` doesn't get swallowed.
+export const textToChunkCitationIndex = /[K\[\(]+(\d+_\d+)[\]\)]/g
+// Fallback for weaker LLMs emitting KB citations with an alphanumeric doc key
+// e.g. K[attf_<uuid>_21]. Alphanumeric body REQUIRES a K marker (either before
+// or inside the bracket/paren) so bare `[var_1]` is left alone. The `(?=\d)`
+// lookahead lets bare brackets/parens fall through to the numeric form above.
+const textToChunkCitationIndexWithDocKey =
+  /(?:K[\[\(]+|[\[\(]+K|[\[\(]+(?=\d))([A-Za-z0-9_-]+)_([0-9]+)[\]\)]/g
 
 export const processMessage = (
   text: string,


### PR DESCRIPTION
Fix:

Models are right now not returning citations in proper format. Making regex handling more deterministic to handle such cases
[1_0], (1_0)
[K1_0]
(K1_0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced citation recognition across the system to properly process citation formats from diverse AI models, ensuring consistent citation handling and improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xynehq/xyne/pull/1342)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->