### PR TITLE
feat(docling): route interactive uploads to priority docling URL

### DIFF
--- a/server/api/files.ts
+++ b/server/api/files.ts
@@ -325,7 +325,7 @@ export const handleAttachmentUpload = async (c: Context) => {
             undefined,
             IMAGE_CONTEXT_CONFIG.enabled,
             IMAGE_CONTEXT_CONFIG.enabled,
-            false,
+            true,
             true,
           )
 

--- a/server/api/files.ts
+++ b/server/api/files.ts
@@ -326,6 +326,7 @@ export const handleAttachmentUpload = async (c: Context) => {
             IMAGE_CONTEXT_CONFIG.enabled,
             IMAGE_CONTEXT_CONFIG.enabled,
             false,
+            true,
           )
 
           if(processingResults.length > 0 && 'totalSheets' in processingResults[0]) {

--- a/server/api/files.ts
+++ b/server/api/files.ts
@@ -46,6 +46,54 @@ interface FileUploadToDataSourceResult extends DataSourceUploadResult {
   filename: string
 }
 
+/**
+ * Flatten a docling-emitted chunk_meta into the shape `file.sd` accepts.
+ * Mirrors `queue/fileProcessor.ts:mapChunkMeta`. `includeHeadings` for text
+ * chunks; image chunks omit headings.
+ */
+function flattenChunkMeta(meta: any, includeHeadings: boolean) {
+  const result: Record<string, unknown> = {
+    chunk_index: meta?.chunk_index,
+    page_numbers: meta?.page_numbers || [],
+    block_labels: meta?.block_labels || [],
+    width: meta?.width ?? 0,
+    height: meta?.height ?? 0,
+    bbox_l: null,
+    bbox_t: null,
+    bbox_r: null,
+    bbox_b: null,
+    bboxes_json: null,
+  }
+
+  const bbox = meta?.bbox
+  if (
+    bbox &&
+    typeof bbox.l === "number" &&
+    typeof bbox.t === "number" &&
+    typeof bbox.r === "number" &&
+    typeof bbox.b === "number"
+  ) {
+    result.bbox_l = bbox.l
+    result.bbox_t = bbox.t
+    result.bbox_r = bbox.r
+    result.bbox_b = bbox.b
+  }
+
+  if (Array.isArray(meta?.bboxes) && meta.bboxes.length > 0) {
+    try {
+      result.bboxes_json = JSON.stringify(meta.bboxes)
+    } catch {
+      result.bboxes_json = null
+    }
+  }
+
+  if (includeHeadings) {
+    result.headings = meta?.headings || []
+  }
+
+  return result
+}
+
 export const handleFileUpload = async (c: Context) => {
   let email = ""
   try {
@@ -369,8 +417,12 @@ export const handleAttachmentUpload = async (c: Context) => {
               chunks_pos: chunks_pos,
               image_chunks: image_chunks,
               image_chunks_pos: image_chunks_pos,
-              chunks_map: processingResult.chunks_map,
-              image_chunks_map: processingResult.image_chunks_map,
+              chunks_map: (processingResult.chunks_map || []).map((m: any) =>
+                flattenChunkMeta(m, true),
+              ),
+              image_chunks_map: (processingResult.image_chunks_map || []).map(
+                (m: any) => flattenChunkMeta(m, false),
+              ),
               permissions: [email],
               mimeType: getBaseMimeType(file.type || "text/plain"),
               metadata: JSON.stringify({

--- a/server/api/files.ts
+++ b/server/api/files.ts
@@ -50,10 +50,33 @@ interface FileUploadToDataSourceResult extends DataSourceUploadResult {
  * Flatten a docling-emitted chunk_meta into the shape `file.sd` accepts.
  * Mirrors `queue/fileProcessor.ts:mapChunkMeta`. `includeHeadings` for text
  * chunks; image chunks omit headings.
+ *
+ * `file.sd`'s `chunk_meta` was extended to mirror `kb_items.sd` (bbox_l/t/r/b,
+ * bboxes_json, width, height, headings). vespa-ts's `Inserts` type still
+ * declares only the narrow trio; `RichChunkMeta` is a structural superset, so
+ * the assignment to `chunks_map` typechecks via TS structural subtyping
+ * without needing a cast.
  */
-function flattenChunkMeta(meta: any, includeHeadings: boolean) {
-  const result: Record<string, unknown> = {
-    chunk_index: meta?.chunk_index,
+interface RichChunkMeta {
+  chunk_index: number
+  page_numbers: number[]
+  block_labels: string[]
+  width: number
+  height: number
+  bbox_l: number | null
+  bbox_t: number | null
+  bbox_r: number | null
+  bbox_b: number | null
+  bboxes_json: string | null
+  headings?: string[]
+}
+
+function flattenChunkMeta(
+  meta: any,
+  includeHeadings: boolean,
+): RichChunkMeta {
+  const result: RichChunkMeta = {
+    chunk_index: meta?.chunk_index ?? 0,
     page_numbers: meta?.page_numbers || [],
     block_labels: meta?.block_labels || [],
     width: meta?.width ?? 0,

--- a/server/config.ts
+++ b/server/config.ts
@@ -13,6 +13,7 @@ let paddleStatusEndpoint =
   process.env.STATUS_ENDPOINT || "http://localhost:8000/instance_status"
 let doclingServiceUrl =
   process.env.DOCLING_SERVICE_URL || "http://localhost:8000"
+let priorityDoclingServiceUrl = process.env.PRIORITY_DOCLING_SERVICE_URL || ""
 const doclingEnabled = process.env.DOCLING_ENABLED === "true"
 const pdfProcessingDisableFallbacks =
   process.env.PDF_PROCESSING_DISABLE_FALLBACKS === "true"
@@ -379,6 +380,7 @@ export default {
   keycloakLogoutRedirectUrl,
   paddleStatusEndpoint,
   doclingServiceUrl,
+  priorityDoclingServiceUrl,
   doclingEnabled,
   pdfProcessingDisableFallbacks,
   ocrProviders,

--- a/server/lib/chunkByDocling.ts
+++ b/server/lib/chunkByDocling.ts
@@ -21,6 +21,7 @@ const STATUS_FETCH_TIMEOUT_MS = 10_000
 
 type DoclingCallOptions = {
   timeoutMs?: number
+  priority?: boolean
 }
 
 function parsePositiveInteger(
@@ -37,6 +38,13 @@ function parsePositiveInteger(
 
 // Configuration from environment or config
 const DOCLING_BASE_URL = config.doclingServiceUrl || "http://localhost:8000"
+
+function resolveDoclingBaseUrl(priority?: boolean): string {
+  if (priority && config.priorityDoclingServiceUrl) {
+    return config.priorityDoclingServiceUrl
+  }
+  return DOCLING_BASE_URL
+}
 const DOCLING_TIMEOUT_MS = parsePositiveInteger(
   process.env.DOCLING_TIMEOUT_MS,
   DEFAULT_DOCLING_TIMEOUT_MS,
@@ -250,7 +258,7 @@ async function callDoclingService(
   docId: string,
   options?: DoclingCallOptions,
 ): Promise<DoclingResponse> {
-  const baseUrl = DOCLING_BASE_URL.replace(/\/+$/, "")
+  const baseUrl = resolveDoclingBaseUrl(options?.priority).replace(/\/+$/, "")
   const apiUrl = `${baseUrl}/process`
   // currentTimeoutMs grows on every "done while we were timed out" race or
   // "still running" outcome — that's direct evidence the calculated timeout

--- a/server/lib/pdfProcessor.ts
+++ b/server/lib/pdfProcessor.ts
@@ -266,6 +266,7 @@ export class PdfProcessor {
     fileName: string,
     vespaDocId: string,
     preflight: DoclingPreflight,
+    priority: boolean = false,
   ): Promise<ProcessingResult> {
     Logger.info(
       {
@@ -282,7 +283,7 @@ export class PdfProcessor {
       buffer,
       fileName,
       vespaDocId,
-      { timeoutMs: preflight.timeoutMs },
+      { timeoutMs: preflight.timeoutMs, priority },
     )
     return this.finalizeProcessingResult(
       {
@@ -323,6 +324,7 @@ export class PdfProcessor {
     extractImages: boolean = false,
     describeImages: boolean = false,
     useOCR: boolean = true,
+    priority: boolean = false,
   ): Promise<ProcessingResult> {
     const pageCount = await this.getPdfPageCount(buffer)
     if (pageCount !== null && pageCount > MAX_PDF_PAGE_COUNT) {
@@ -349,6 +351,7 @@ export class PdfProcessor {
             fileName,
             vespaDocId,
             doclingPreflight,
+            priority,
           )
           Logger.info(`Docling processing successful for ${fileName}`)
           return doclingResult

--- a/server/queue/fileProcessor.ts
+++ b/server/queue/fileProcessor.ts
@@ -325,7 +325,6 @@ async function processFileJob(jobData: FileProcessingJob, startTime: number) {
       IMAGE_CONTEXT_CONFIG.enabled, // extractImages
       IMAGE_CONTEXT_CONFIG.enabled, // describeImages
       useOCR, // useOCR option
-      true,
     )
 
     // Extract title for markdown files

--- a/server/queue/fileProcessor.ts
+++ b/server/queue/fileProcessor.ts
@@ -325,6 +325,7 @@ async function processFileJob(jobData: FileProcessingJob, startTime: number) {
       IMAGE_CONTEXT_CONFIG.enabled, // extractImages
       IMAGE_CONTEXT_CONFIG.enabled, // describeImages
       useOCR, // useOCR option
+      true,
     )
 
     // Extract title for markdown files

--- a/server/services/fileProcessor.ts
+++ b/server/services/fileProcessor.ts
@@ -55,6 +55,7 @@ export class FileProcessorService {
     extractImages: boolean = false,
     describeImages: boolean = false,
     useOCR: boolean = true,
+    priority: boolean = false,
   ): Promise<ProcessingResultArray> {
     const baseMimeType = getBaseMimeType(mimeType || "text/plain")
     let chunks: string[] = []
@@ -73,6 +74,7 @@ export class FileProcessorService {
           extractImages,
           describeImages,
           useOCR,
+          priority,
         )
         // Wrap in array to match return type
         return [pdfResult]

--- a/server/vespa/schemas/file.sd
+++ b/server/vespa/schemas/file.sd
@@ -4,6 +4,14 @@ schema file {
     field chunk_index type int {}
     field page_numbers type array<int> {}
     field block_labels type array<string> {}
+    field bbox_l type double {}
+    field bbox_t type double {}
+    field bbox_r type double {}
+    field bbox_b type double {}
+    field bboxes_json type string {}
+    field width type int {}
+    field height type int {}
+    field headings type array<string> {}
   }
   
   document file {


### PR DESCRIPTION
This pull request introduces a mechanism to route PDF processing requests to a priority Docling service instance when handling interactive uploads, such as chat attachments or user-initiated KB uploads. This is achieved by adding a `priority` flag throughout the file processing pipeline, which, when set and the environment variable `PRIORITY_DOCLING_SERVICE_URL` is configured, directs requests to the priority endpoint. The changes ensure that interactive PDF processing is handled with higher priority, potentially reducing latency for user-facing operations.

**Priority Docling Service Routing:**

* Added support for a new environment variable, `PRIORITY_DOCLING_SERVICE_URL`, in `server/config.ts`, and exposed it in the config export. [[1]](diffhunk://#diff-b5e32f68bcc433506f573cc64aae69018f0a1caa3822686806a704ac1c8e906cR16) [[2]](diffhunk://#diff-b5e32f68bcc433506f573cc64aae69018f0a1caa3822686806a704ac1c8e906cR383)
* Implemented the `resolveDoclingBaseUrl` function in `server/lib/chunkByDocling.ts` to select the priority Docling service URL when the `priority` option is set, falling back to the regular service if not configured.
* Updated the Docling service call logic to use the resolved base URL based on the `priority` flag.

**Pipeline and API Changes:**

* Propagated the `priority` flag through the file processing pipeline, including `FileProcessorService`, `PdfProcessor`, and all relevant method signatures and calls. [[1]](diffhunk://#diff-3cf75e048f556b0653fbe8078594c0dbab5db93a9b5c37d91f04bcb305b6c12aR58) [[2]](diffhunk://#diff-3cf75e048f556b0653fbe8078594c0dbab5db93a9b5c37d91f04bcb305b6c12aR77) [[3]](diffhunk://#diff-79fde29aed12f61f5d9200b00fb9d87111c94a457e2832e4efc8083e069c4d06R269) [[4]](diffhunk://#diff-79fde29aed12f61f5d9200b00fb9d87111c94a457e2832e4efc8083e069c4d06L285-R286) [[5]](diffhunk://#diff-79fde29aed12f61f5d9200b00fb9d87111c94a457e2832e4efc8083e069c4d06R327) [[6]](diffhunk://#diff-79fde29aed12f61f5d9200b00fb9d87111c94a457e2832e4efc8083e069c4d06R354)
* Set the `priority` flag to `true` for interactive chat attachment uploads and user-initiated KB uploads, ensuring these requests are routed to the priority service when available. [[1]](diffhunk://#diff-f556dd03fb2f849691f76f82b6dea576fe49d206b4945da3563d2d846aad5a8dL319-R321) [[2]](diffhunk://#diff-f556dd03fb2f849691f76f82b6dea576fe49d206b4945da3563d2d846aad5a8dR331) [[3]](diffhunk://#diff-9d74a56606b5bdd5c304c79de361286ccf68498ec00cd65f2b04e41a503ce95aR319-R320) [[4]](diffhunk://#diff-9d74a56606b5bdd5c304c79de361286ccf68498ec00cd65f2b04e41a503ce95aR330)

**Documentation and Type Updates:**

* Updated type definitions and comments to document the new `priority` flag and its intended use for interactive uploads.

These changes collectively ensure that interactive PDF uploads are processed with higher priority, improving responsiveness for end users when `PRIORITY_DOCLING_SERVICE_URL` is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable high‑priority processing for non-image attachments (when a priority service is configured).
  * Stored attachment chunks are normalized to include layout/geometry and size info (bbox coordinates, optional bboxes JSON, width/height) and include text headings where applicable, improving document layout and search.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/xynehq/xyne/pull/1348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->