### PR TITLE
feat(ui2) add kb ui and general improvements

### DIFF
--- a/ui2/src/components/ChatHistory.tsx
+++ b/ui2/src/components/ChatHistory.tsx
@@ -1,0 +1,252 @@
+import { useMemo, useRef, useState } from "react"
+import { MessageSquarePlus, MoreHorizontal, Pencil, Trash2 } from "lucide-react"
+import { SidebarListRow } from "./SidebarListRow"
+import { InlineRenameField } from "./InlineRenameField"
+import { InlineConfirmRow } from "./InlineConfirmRow"
+import { MenuPopover } from "./MenuPopover"
+
+export type ChatHistoryItem = {
+  id: string
+  title: string
+  updatedAt: number
+}
+
+type Props = {
+  items: ChatHistoryItem[]
+  activeId?: string | undefined
+  loading?: boolean | undefined
+  query?: string | undefined
+  emptyTitle?: string | undefined
+  emptySubtitle?: string | undefined
+  sectionLabel?: string | undefined
+  onSelect: (id: string) => void
+  onRename: (id: string, title: string) => Promise<void>
+  onDelete: (id: string) => Promise<void>
+}
+
+type RowAction =
+  | { id: string; kind: "rename" }
+  | { id: string; kind: "confirm-delete" }
+  | null
+
+export function ChatHistory({
+  items,
+  activeId,
+  loading,
+  query = "",
+  emptyTitle = "No conversations yet",
+  emptySubtitle = "Start a new chat above to see it here.",
+  sectionLabel = "Recents",
+  onSelect,
+  onRename,
+  onDelete,
+}: Props): JSX.Element {
+  const [action, setAction] = useState<RowAction>(null)
+  // Keyed refs to each row's button so we can restore focus after an inline
+  // edit/cancel — otherwise focus snaps to <body> and Tab restarts.
+  const rowRefs = useRef(new Map<string, HTMLButtonElement>())
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return items
+    return items.filter((it) => it.title.toLowerCase().includes(q))
+  }, [items, query])
+
+  // Close any inline action and restore keyboard focus to the row's button on
+  // the next paint (after React commits the swapped-in display row).
+  const exitAction = (focusBackId: string): void => {
+    setAction(null)
+    requestAnimationFrame(() => {
+      rowRefs.current.get(focusBackId)?.focus()
+    })
+  }
+
+  if (loading && items.length === 0) {
+    return <SkeletonList />
+  }
+
+  if (filtered.length === 0) {
+    return (
+      <EmptyHint
+        hasQuery={query.trim().length > 0}
+        query={query}
+        title={emptyTitle}
+        subtitle={emptySubtitle}
+      />
+    )
+  }
+
+  return (
+    <div>
+      <div className="px-2.5 pb-1 pt-3 text-[10.5px] font-medium uppercase tracking-[0.08em] text-muted-foreground/80">
+        {sectionLabel}
+      </div>
+      <ul className="flex flex-col gap-0.5">
+        {filtered.map((it) => {
+          const mode = action?.id === it.id ? action.kind : null
+          if (mode === "rename") {
+            return (
+              <li key={it.id}>
+                <InlineRenameField
+                  initial={it.title}
+                  onCancel={(): void => {
+                    exitAction(it.id)
+                  }}
+                  onCommit={async (next): Promise<void> => {
+                    if (!next || next === it.title) {
+                      exitAction(it.id)
+                      return
+                    }
+                    try {
+                      await onRename(it.id, next)
+                    } finally {
+                      exitAction(it.id)
+                    }
+                  }}
+                />
+              </li>
+            )
+          }
+          if (mode === "confirm-delete") {
+            return (
+              <li key={it.id}>
+                <InlineConfirmRow
+                  message={
+                    <>
+                      Delete{" "}
+                      <span className="text-foreground">
+                        {it.title || "Untitled"}
+                      </span>
+                      ?
+                    </>
+                  }
+                  confirmLabel="Delete"
+                  tone="danger"
+                  onCancel={(): void => {
+                    exitAction(it.id)
+                  }}
+                  onConfirm={async (): Promise<void> => {
+                    await onDelete(it.id)
+                  }}
+                />
+              </li>
+            )
+          }
+          return (
+            <li key={it.id}>
+              <SidebarListRow
+                title={it.title}
+                active={it.id === activeId}
+                ariaCurrent={it.id === activeId ? "page" : undefined}
+                onClick={(): void => {
+                  onSelect(it.id)
+                }}
+                buttonRef={(el): void => {
+                  if (el) {
+                    rowRefs.current.set(it.id, el)
+                  } else {
+                    rowRefs.current.delete(it.id)
+                  }
+                }}
+                actions={
+                  <MenuPopover
+                    align="right"
+                    trigger={({ open, toggle }): JSX.Element => (
+                      <button
+                        type="button"
+                        aria-label="More actions"
+                        aria-haspopup="menu"
+                        aria-expanded={open}
+                        onClick={(e): void => {
+                          e.stopPropagation()
+                          toggle()
+                        }}
+                        className={
+                          "grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-background/80 hover:text-foreground " +
+                          (open ? "bg-background/80 text-foreground" : "")
+                        }
+                      >
+                        <MoreHorizontal
+                          className="h-4 w-4"
+                          aria-hidden
+                          strokeWidth={1.75}
+                        />
+                      </button>
+                    )}
+                    items={[
+                      {
+                        icon: Pencil,
+                        label: "Rename",
+                        onClick: (): void => {
+                          setAction({ id: it.id, kind: "rename" })
+                        },
+                      },
+                      {
+                        icon: Trash2,
+                        label: "Delete",
+                        tone: "danger",
+                        onClick: (): void => {
+                          setAction({ id: it.id, kind: "confirm-delete" })
+                        },
+                      },
+                    ]}
+                  />
+                }
+              />
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}
+
+// ─── Internals ──────────────────────────────────────────────────────────────
+function EmptyHint({
+  hasQuery,
+  query,
+  title,
+  subtitle,
+}: {
+  hasQuery: boolean
+  query: string
+  title: string
+  subtitle: string
+}): JSX.Element {
+  return (
+    <div className="px-3 pt-10 text-center">
+      <div className="mx-auto mb-3 grid h-10 w-10 place-items-center rounded-full bg-secondary/60">
+        <MessageSquarePlus
+          className="h-4 w-4 text-muted-foreground"
+          aria-hidden
+          strokeWidth={1.5}
+        />
+      </div>
+      {hasQuery ? (
+        <p className="text-[12.5px] text-muted-foreground">
+          No matches for{" "}
+          <span className="text-foreground">&quot;{query}&quot;</span>
+        </p>
+      ) : (
+        <>
+          <p className="text-[13px] text-foreground">{title}</p>
+          <p className="mt-1 text-[12px] text-muted-foreground">{subtitle}</p>
+        </>
+      )}
+    </div>
+  )
+}
+
+function SkeletonList(): JSX.Element {
+  return (
+    <div className="space-y-1.5 px-2 pt-3">
+      {[60, 80, 45, 70, 55, 80, 50].map((w, i) => (
+        <div
+          key={i}
+          className="h-9 animate-pulse rounded-lg bg-secondary/50"
+          style={{ width: `${String(w)}%` }}
+        />
+      ))}
+    </div>
+  )
+}

--- a/ui2/src/components/Composer.tsx
+++ b/ui2/src/components/Composer.tsx
@@ -23,7 +23,8 @@ type Props = {
    * last user message). Bump `key` to push a new seed even if `text` is the
    * same as before.
    */
-  seed?: { text: string; key: number }
+  seed?: { text: string; key: number } | undefined
+  hideDisclaimer?: boolean | undefined
 }
 
 const newChatId = (): string => {
@@ -36,6 +37,7 @@ export function Composer({
   onSubmit,
   placeholder = "Ask anything",
   seed,
+  hideDisclaimer,
 }: Props): JSX.Element {
   const [value, setValue] = useState("")
   const navigate = useNavigate()
@@ -151,9 +153,11 @@ export function Composer({
           </div>
         </div>
       </div>
-      <p className="mt-2 text-center text-[11px] text-muted-foreground/80">
-        xyne can be mistaken. Verify important details.
-      </p>
+      {hideDisclaimer ? null : (
+        <p className="mt-2 text-center text-[11px] text-muted-foreground/80">
+          Xyne can make mistakes. Verify important details.
+        </p>
+      )}
     </form>
   )
 }

--- a/ui2/src/components/EmptyState.tsx
+++ b/ui2/src/components/EmptyState.tsx
@@ -1,5 +1,3 @@
-import { Sparkles } from "lucide-react"
-
 type Props = {
   name?: string | undefined
 }
@@ -35,29 +33,9 @@ export function EmptyState({ name }: Props): JSX.Element {
   const display = firstName(name)
 
   return (
-    <div className="relative isolate flex w-full max-w-2xl flex-col items-center gap-6 px-6 text-center animate-fade-up">
-      <div className="halo pointer-events-none absolute inset-x-0 -top-10 -z-10 h-72" />
-
-      <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-2.5 py-1 text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-        <Sparkles className="h-3 w-3" aria-hidden strokeWidth={1.75} />
-        <span>xyne · workspace AI</span>
-      </span>
-
-      <h1 className="font-display text-5xl leading-[1.05] tracking-tight text-foreground sm:text-6xl">
-        {greet}
-        {display ? (
-          <>
-            ,{" "}
-            <em className="italic text-foreground/90">{display}</em>
-          </>
-        ) : null}
-        .
-      </h1>
-
-      <p className="max-w-md text-[15px] leading-relaxed text-muted-foreground">
-        Ask anything across your workspace — drafts, decisions, code,
-        documents. Answers stream back with citations from your sources.
-      </p>
-    </div>
+    <h1 className="animate-fade-up text-center text-[28px] font-normal leading-tight tracking-tight text-foreground">
+      {greet}
+      {display ? `, ${display}` : ""}
+    </h1>
   )
 }

--- a/ui2/src/components/InlineConfirmRow.tsx
+++ b/ui2/src/components/InlineConfirmRow.tsx
@@ -1,0 +1,70 @@
+import { useState, type ReactNode } from "react"
+import { X } from "lucide-react"
+
+type Props = {
+  message: ReactNode
+  confirmLabel?: string
+  cancelLabel?: string
+  tone?: "danger" | "default"
+  onConfirm: () => void | Promise<void>
+  onCancel: () => void
+}
+
+export function InlineConfirmRow({
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  tone = "default",
+  onConfirm,
+  onCancel,
+}: Props): JSX.Element {
+  const [pending, setPending] = useState(false)
+  const bg =
+    tone === "danger" ? "bg-destructive/[0.08]" : "bg-secondary"
+  const btn =
+    tone === "danger"
+      ? "bg-destructive text-destructive-foreground"
+      : "bg-primary text-primary-foreground"
+
+  return (
+    <div
+      className={
+        "flex h-9 items-center gap-1.5 rounded-lg px-2.5 text-[12.5px] " + bg
+      }
+    >
+      <span className="min-w-0 flex-1 truncate text-foreground/80">
+        {message}
+      </span>
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={pending}
+        aria-label={cancelLabel}
+        title={cancelLabel}
+        className="grid h-6 w-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-background/60 hover:text-foreground disabled:opacity-50"
+      >
+        <X className="h-3.5 w-3.5" aria-hidden strokeWidth={2} />
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setPending(true)
+          void (async (): Promise<void> => {
+            try {
+              await onConfirm()
+            } finally {
+              setPending(false)
+            }
+          })()
+        }}
+        disabled={pending}
+        className={
+          "inline-flex h-6 items-center rounded-md px-2 text-[11.5px] font-medium transition-opacity hover:opacity-90 disabled:opacity-60 " +
+          btn
+        }
+      >
+        {pending ? "…" : confirmLabel}
+      </button>
+    </div>
+  )
+}

--- a/ui2/src/components/InlineRenameField.tsx
+++ b/ui2/src/components/InlineRenameField.tsx
@@ -1,0 +1,48 @@
+import { useInlineEdit } from "@/hooks/useInlineEdit"
+
+type Props = {
+  initial: string
+  placeholder?: string
+  onCommit: (next: string) => void | Promise<void>
+  onCancel: () => void
+  className?: string
+  inputClassName?: string
+}
+
+export function InlineRenameField({
+  initial,
+  placeholder,
+  onCommit,
+  onCancel,
+  className,
+  inputClassName,
+}: Props): JSX.Element {
+  const { value, setValue, inputRef, onKeyDown, onBlur } = useInlineEdit({
+    initial,
+    onCommit,
+    onCancel,
+  })
+  return (
+    <div
+      className={
+        className ?? "flex h-9 items-center rounded-lg bg-secondary px-2"
+      }
+    >
+      <input
+        ref={inputRef}
+        value={value}
+        onChange={(e): void => {
+          setValue(e.target.value)
+        }}
+        onKeyDown={onKeyDown}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        aria-label="Edit"
+        className={
+          inputClassName ??
+          "h-7 w-full min-w-0 flex-1 rounded-md bg-transparent px-1.5 text-[13px] text-foreground focus:outline-none"
+        }
+      />
+    </div>
+  )
+}

--- a/ui2/src/components/MenuPopover.tsx
+++ b/ui2/src/components/MenuPopover.tsx
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
+import type { LucideIcon } from "lucide-react"
+
+// Hover-revealed dropdown menu. The trigger is a render-prop so the consumer
+// owns the trigger button's exact look (kebab, chevron, avatar, whatever).
+//
+// Keyboard contract:
+//   - Open: focus moves to first menu item.
+//   - ↑ / ↓ / Home / End cycle through items.
+//   - Enter on a focused item invokes it and closes.
+//   - Escape closes and restores focus to the element that was focused
+//     before opening (typically the trigger button).
+//   - Mousedown outside closes silently (no focus restoration — user clicked
+//     elsewhere intentionally).
+export type MenuItem = {
+  icon?: LucideIcon
+  label: string
+  onClick: () => void
+  tone?: "default" | "danger"
+}
+
+type TriggerArgs = {
+  open: boolean
+  toggle: () => void
+}
+
+type Props = {
+  trigger: (args: TriggerArgs) => ReactNode
+  items: MenuItem[]
+  align?: "left" | "right"
+  className?: string
+}
+
+export function MenuPopover({
+  trigger,
+  items,
+  align = "right",
+  className,
+}: Props): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLDivElement | null>(null)
+  const menuRef = useRef<HTMLDivElement | null>(null)
+  const restoreFocusRef = useRef<HTMLElement | null>(null)
+
+  const close = useCallback((restoreFocus: boolean): void => {
+    setOpen(false)
+    if (restoreFocus && restoreFocusRef.current) {
+      const el = restoreFocusRef.current
+      requestAnimationFrame(() => {
+        el.focus()
+      })
+    }
+    restoreFocusRef.current = null
+  }, [])
+
+  const toggle = useCallback((): void => {
+    setOpen((prev) => {
+      if (!prev) {
+        // About to open: remember what had focus so Escape can restore it.
+        restoreFocusRef.current = document.activeElement as HTMLElement
+      }
+      return !prev
+    })
+  }, [])
+
+  // Outside click closes (no focus restore — focus moves to wherever the user
+  // clicked). Escape closes + restores focus to the trigger.
+  useEffect((): (() => void) | undefined => {
+    if (!open) return undefined
+    const onDoc = (e: MouseEvent): void => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        close(false)
+      }
+    }
+    const onKey = (e: globalThis.KeyboardEvent): void => {
+      if (e.key === "Escape") {
+        e.preventDefault()
+        close(true)
+      }
+    }
+    document.addEventListener("mousedown", onDoc)
+    document.addEventListener("keydown", onKey)
+    return () => {
+      document.removeEventListener("mousedown", onDoc)
+      document.removeEventListener("keydown", onKey)
+    }
+  }, [open, close])
+
+  // Focus the first item on open + handle arrow-key navigation while open.
+  useEffect((): (() => void) | undefined => {
+    if (!open) return undefined
+    const buttons = (): HTMLButtonElement[] =>
+      Array.from(
+        menuRef.current?.querySelectorAll<HTMLButtonElement>(
+          "[role='menuitem']",
+        ) ?? [],
+      )
+
+    buttons()[0]?.focus()
+
+    const onKey = (e: globalThis.KeyboardEvent): void => {
+      const list = buttons()
+      if (list.length === 0) return
+      const idx = list.indexOf(document.activeElement as HTMLButtonElement)
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        list[(idx + 1 + list.length) % list.length]?.focus()
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault()
+        list[(idx - 1 + list.length) % list.length]?.focus()
+      } else if (e.key === "Home") {
+        e.preventDefault()
+        list[0]?.focus()
+      } else if (e.key === "End") {
+        e.preventDefault()
+        list[list.length - 1]?.focus()
+      }
+    }
+    document.addEventListener("keydown", onKey)
+    return () => {
+      document.removeEventListener("keydown", onKey)
+    }
+  }, [open])
+
+  return (
+    <div ref={wrapRef} className={"relative " + (className ?? "")}>
+      {trigger({ open, toggle })}
+      {open ? (
+        <div
+          ref={menuRef}
+          role="menu"
+          aria-orientation="vertical"
+          className={
+            "animate-fade-up absolute top-[calc(100%+4px)] z-30 w-40 overflow-hidden rounded-xl border border-border bg-surface-elevated p-1 shadow-lg shadow-foreground/[0.06] " +
+            (align === "right" ? "right-0" : "left-0")
+          }
+        >
+          {items.map((item, i) => {
+            const Icon = item.icon
+            return (
+              <button
+                key={i}
+                type="button"
+                role="menuitem"
+                onClick={(e): void => {
+                  e.stopPropagation()
+                  // Item handles the action itself — no focus restoration
+                  // because the trigger may not exist after the action runs
+                  // (e.g. row gets replaced by an inline editor).
+                  close(false)
+                  item.onClick()
+                }}
+                className={
+                  "flex h-8 w-full items-center gap-2 rounded-lg px-2.5 text-[13px] transition-colors focus:outline-none " +
+                  (item.tone === "danger"
+                    ? "text-destructive hover:bg-destructive/[0.08] focus-visible:bg-destructive/[0.08]"
+                    : "text-foreground hover:bg-secondary focus-visible:bg-secondary")
+                }
+              >
+                {Icon ? (
+                  <Icon
+                    className="h-3.5 w-3.5"
+                    aria-hidden
+                    strokeWidth={1.75}
+                  />
+                ) : null}
+                <span className="flex-1 text-left">{item.label}</span>
+              </button>
+            )
+          })}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/ui2/src/components/MessageBubble.tsx
+++ b/ui2/src/components/MessageBubble.tsx
@@ -1,7 +1,6 @@
 import { Copy, RefreshCcw, AlertTriangle } from "lucide-react"
 import ReactMarkdown from "react-markdown"
 import remarkGfm from "remark-gfm"
-import { BrandMark } from "./BrandMark"
 import { ToolCallChip } from "./ToolCallChip"
 import { ThinkingChip } from "./ThinkingChip"
 import type { Block } from "@/lib/chat-store"
@@ -57,19 +56,8 @@ export function MessageBubble({
   const hasAnyContent = blocks.length > 0
 
   return (
-    <article className="group flex w-full gap-3 px-2 py-5 sm:px-4">
-      <div className="mt-0.5 flex-shrink-0">
-        <span className="relative inline-flex">
-          <BrandMark withWordmark={false} />
-          {pending && (
-            <span
-              aria-hidden
-              className="absolute inset-[-5px] animate-spin rounded-full border-2 border-foreground/15 border-t-foreground/80"
-            />
-          )}
-        </span>
-      </div>
-      <div className="flex min-w-0 flex-1 flex-col gap-2">
+    <article className="group w-full px-2 py-5 sm:px-4">
+      <div className="flex min-w-0 flex-col gap-2">
         {hasAnyContent && (
           <div className="prose-chat text-[15px] leading-7 text-foreground">
             {blocks.map((b, i) => {
@@ -81,7 +69,14 @@ export function MessageBubble({
                 )
               }
               if (b.kind === "thinking") {
-                return <ThinkingChip key={i} text={b.text} />
+                const isLast = i === blocks.length - 1
+                return (
+                  <ThinkingChip
+                    key={i}
+                    text={b.text}
+                    pending={pending && isLast}
+                  />
+                )
               }
               if (b.kind === "tool_use") {
                 return (

--- a/ui2/src/components/ModelSelector.tsx
+++ b/ui2/src/components/ModelSelector.tsx
@@ -1,19 +1,99 @@
-import { useEffect, useRef, useState } from "react"
-import { Check, ChevronDown, Sparkles, Zap } from "lucide-react"
-import { useModels, type ModelFamily } from "@/lib/models"
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react"
+import { Check, ChevronDown, Search } from "lucide-react"
+import { useModels } from "@/lib/models"
 
-const familyIcon: Record<ModelFamily, typeof Sparkles> = {
-  Claude: Sparkles,
-  GPT: Sparkles,
-  Gemini: Sparkles,
-  Other: Zap,
-}
+type Row =
+  | { kind: "header"; family: string }
+  | { kind: "item"; labelName: string; description?: string; flatIdx: number }
 
 export function ModelSelector(): JSX.Element {
   const { models, selected, setSelected, groups, loading } = useModels()
   const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const [focusIdx, setFocusIdx] = useState(0)
   const rootRef = useRef<HTMLDivElement | null>(null)
+  const searchRef = useRef<HTMLInputElement | null>(null)
+  const listRef = useRef<HTMLUListElement | null>(null)
 
+  // Filter by query (case-insensitive, substring match on labelName).
+  const filteredGroups = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) {
+      return groups
+    }
+    return groups
+      .map((g) => ({
+        ...g,
+        items: g.items.filter((m) => m.labelName.toLowerCase().includes(q)),
+      }))
+      .filter((g) => g.items.length > 0)
+  }, [groups, query])
+
+  // Build the rendered row list. Group headers are only shown when there are
+  // multiple visible families — otherwise they're noise.
+  const rows = useMemo<Row[]>(() => {
+    const out: Row[] = []
+    const showHeaders = filteredGroups.length > 1
+    let flatIdx = 0
+    for (const g of filteredGroups) {
+      if (showHeaders) {
+        out.push({ kind: "header", family: g.family })
+      }
+      for (const m of g.items) {
+        out.push({
+          kind: "item",
+          labelName: m.labelName,
+          ...(m.description ? { description: m.description } : {}),
+          flatIdx,
+        })
+        flatIdx++
+      }
+    }
+    return out
+  }, [filteredGroups])
+
+  const flatItems = useMemo(
+    () => rows.filter((r): r is Extract<Row, { kind: "item" }> => r.kind === "item"),
+    [rows],
+  )
+
+  // Open: focus search input + pre-position the focused index on the currently
+  // selected model so Enter (no typing) is a no-op confirm.
+  useEffect((): void => {
+    if (!open) {
+      setQuery("")
+      return
+    }
+    requestAnimationFrame((): void => {
+      searchRef.current?.focus()
+    })
+    const idx = flatItems.findIndex((m) => m.labelName === selected)
+    setFocusIdx(idx >= 0 ? idx : 0)
+  }, [open, flatItems, selected])
+
+  // Reset focus when filter changes; keep within bounds.
+  useEffect((): void => {
+    setFocusIdx((i) => Math.min(i, Math.max(flatItems.length - 1, 0)))
+  }, [flatItems.length])
+
+  // Scroll the focused row into view.
+  useEffect((): void => {
+    if (!open) {
+      return
+    }
+    const el = listRef.current?.querySelector<HTMLElement>(
+      `[data-flat-idx="${String(focusIdx)}"]`,
+    )
+    el?.scrollIntoView({ block: "nearest" })
+  }, [focusIdx, open])
+
+  // Outside click closes.
   useEffect((): (() => void) => {
     const onDoc = (e: MouseEvent): void => {
       if (!rootRef.current) {
@@ -24,20 +104,54 @@ export function ModelSelector(): JSX.Element {
       }
     }
     document.addEventListener("mousedown", onDoc)
-    return () => {
+    return (): void => {
       document.removeEventListener("mousedown", onDoc)
     }
   }, [])
 
+  const commit = (labelName: string): void => {
+    setSelected(labelName)
+    setOpen(false)
+  }
+
+  const onKey = (e: KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === "Escape") {
+      e.preventDefault()
+      setOpen(false)
+      return
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      setFocusIdx((i) =>
+        flatItems.length === 0 ? 0 : (i + 1) % flatItems.length,
+      )
+      return
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault()
+      setFocusIdx((i) =>
+        flatItems.length === 0 ? 0 : (i - 1 + flatItems.length) % flatItems.length,
+      )
+      return
+    }
+    if (e.key === "Enter") {
+      e.preventDefault()
+      const item = flatItems[focusIdx]
+      if (item) {
+        commit(item.labelName)
+      }
+    }
+  }
+
   const label = loading
     ? "Loading…"
-    : selected ?? (models[0]?.labelName ?? "No models")
+    : selected ?? models[0]?.labelName ?? "No models"
 
   return (
     <div ref={rootRef} className="relative">
       <button
         type="button"
-        onClick={() => {
+        onClick={(): void => {
           setOpen((v) => !v)
         }}
         disabled={loading || models.length === 0}
@@ -49,70 +163,125 @@ export function ModelSelector(): JSX.Element {
         <ChevronDown className="h-3.5 w-3.5 opacity-70" aria-hidden />
       </button>
 
-      {open && groups.length > 0 && (
+      {open && (
         <div
-          role="listbox"
-          aria-label="Model"
-          className="absolute bottom-full right-0 z-30 mb-2 w-80 max-w-[calc(100vw-2rem)] overflow-hidden rounded-2xl border border-border bg-surface-elevated shadow-2xl"
+          role="dialog"
+          aria-label="Select model"
+          className="absolute bottom-full right-0 z-30 mb-2 w-64 overflow-hidden rounded-2xl border border-border bg-surface-elevated shadow-2xl shadow-foreground/10"
         >
-          <ul className="max-h-[60vh] overflow-y-auto py-1.5">
-            {groups.map((group) => {
-              const Icon = familyIcon[group.family]
-              return (
-                <li key={group.family}>
-                  <div className="flex items-center gap-2 px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
-                    <Icon
-                      className="h-3 w-3"
-                      aria-hidden
-                      strokeWidth={1.75}
-                    />
-                    <span>{group.family}</span>
-                  </div>
-                  <ul>
-                    {group.items.map((m) => {
-                      const active = selected === m.labelName
-                      return (
-                        <li key={m.labelName}>
-                          <button
-                            type="button"
-                            role="option"
-                            aria-selected={active}
-                            onClick={() => {
-                              setSelected(m.labelName)
-                              setOpen(false)
-                            }}
-                            className="flex w-full items-start gap-2.5 px-3 py-2 text-left transition hover:bg-secondary/70"
-                          >
-                            <span className="mt-[3px] inline-flex h-4 w-4 flex-shrink-0 items-center justify-center text-foreground">
-                              {active && (
-                                <Check
-                                  className="h-3.5 w-3.5"
-                                  aria-hidden
-                                  strokeWidth={2.25}
-                                />
-                              )}
-                            </span>
-                            <span className="flex min-w-0 flex-col">
-                              <span className="text-[13px] font-medium text-foreground">
-                                {m.labelName}
-                              </span>
-                              {m.description && (
-                                <span className="text-[11.5px] leading-snug text-muted-foreground">
-                                  {m.description}
-                                </span>
-                              )}
-                            </span>
-                          </button>
-                        </li>
-                      )
-                    })}
-                  </ul>
-                </li>
+          {/* Search */}
+          <div className="relative border-b border-border/60 p-2">
+            <Search
+              aria-hidden
+              strokeWidth={1.75}
+              className="pointer-events-none absolute left-[18px] top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+            />
+            <input
+              ref={searchRef}
+              type="search"
+              value={query}
+              onChange={(e): void => {
+                setQuery(e.target.value)
+              }}
+              onKeyDown={onKey}
+              placeholder="Search models…"
+              aria-label="Search models"
+              className="h-8 w-full rounded-lg bg-surface pl-8 pr-2 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/40"
+            />
+          </div>
+
+          {/* List */}
+          <ul
+            ref={listRef}
+            role="listbox"
+            aria-label="Models"
+            className="max-h-72 overflow-y-auto py-1"
+          >
+            {rows.length === 0 ? (
+              <li className="px-3 py-4 text-center text-[12px] text-muted-foreground">
+                No models match “{query}”
+              </li>
+            ) : (
+              rows.map((row) =>
+                row.kind === "header" ? (
+                  <li
+                    key={`h-${row.family}`}
+                    className="select-none px-3 pb-0.5 pt-2 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground"
+                  >
+                    {row.family}
+                  </li>
+                ) : (
+                  <RowItem
+                    key={row.labelName}
+                    labelName={row.labelName}
+                    {...(row.description ? { description: row.description } : {})}
+                    flatIdx={row.flatIdx}
+                    active={selected === row.labelName}
+                    focused={focusIdx === row.flatIdx}
+                    onSelect={commit}
+                    onHover={setFocusIdx}
+                  />
+                ),
               )
-            })}
+            )}
           </ul>
         </div>
       )}
     </div>
+  )
+}
+
+type ItemProps = {
+  labelName: string
+  description?: string
+  flatIdx: number
+  active: boolean
+  focused: boolean
+  onSelect: (labelName: string) => void
+  onHover: (flatIdx: number) => void
+}
+
+function RowItem({
+  labelName,
+  description,
+  flatIdx,
+  active,
+  focused,
+  onSelect,
+  onHover,
+}: ItemProps): JSX.Element {
+  return (
+    <li>
+      <button
+        type="button"
+        role="option"
+        aria-selected={active}
+        data-flat-idx={flatIdx}
+        title={description ?? labelName}
+        onMouseEnter={(): void => {
+          onHover(flatIdx)
+        }}
+        onClick={(): void => {
+          onSelect(labelName)
+        }}
+        className={
+          "flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-[13px] transition-colors " +
+          (focused
+            ? "bg-secondary text-foreground"
+            : "text-foreground/90 hover:bg-secondary/60")
+        }
+      >
+        <span className={"truncate " + (active ? "font-medium" : "")}>
+          {labelName}
+        </span>
+        {active && (
+          <Check
+            className="h-3.5 w-3.5 flex-shrink-0 text-foreground"
+            aria-hidden
+            strokeWidth={2.25}
+          />
+        )}
+      </button>
+    </li>
   )
 }

--- a/ui2/src/components/Sidebar.tsx
+++ b/ui2/src/components/Sidebar.tsx
@@ -1,6 +1,30 @@
 import { Link } from "@tanstack/react-router"
-import { MessageSquarePlus, Search } from "lucide-react"
+import {
+  FolderTree,
+  MessageSquarePlus,
+  PanelLeftClose,
+  PanelLeftOpen,
+  Search,
+} from "lucide-react"
+import { useSidebarCollapse } from "@/hooks/useSidebarCollapse"
+import { useSidebarMobile } from "@/hooks/useSidebarMobile"
+import { useSidebarSearch } from "@/hooks/useSidebarSearch"
 import { BrandMark } from "./BrandMark"
+import { ThemeToggle } from "./ThemeToggle"
+import { SidebarNavItem } from "./SidebarNavItem"
+import { ChatHistory, type ChatHistoryItem } from "./ChatHistory"
+
+type Props = {
+  me?: { email: string; role: string } | undefined
+  chats: ChatHistoryItem[]
+  activeChatId?: string | undefined
+  chatsLoading?: boolean | undefined
+  onCreateChat: () => void
+  onSelectChat: (id: string) => void
+  onRenameChat: (id: string, title: string) => Promise<void>
+  onDeleteChat: (id: string) => Promise<void>
+  onAccount?: () => void
+}
 
 function initials(email: string): string {
   const local = email.split("@")[0] ?? email
@@ -10,43 +34,136 @@ function initials(email: string): string {
   return (a + b).toUpperCase()
 }
 
-type Props = {
-  me?: { email: string; role: string } | undefined
-}
+export function Sidebar({
+  me,
+  chats,
+  activeChatId,
+  chatsLoading,
+  onCreateChat,
+  onSelectChat,
+  onRenameChat,
+  onDeleteChat,
+  onAccount,
+}: Props): JSX.Element {
+  const { collapsed, toggle: onToggle } = useSidebarCollapse()
+  const { open: mobileOpen, setOpen: setMobileOpen } = useSidebarMobile()
+  const { query, setQuery, searchRef } = useSidebarSearch({
+    collapsed,
+    expand: onToggle,
+  })
 
-export function Sidebar({ me }: Props): JSX.Element {
+  const closeMobile = (): void => {
+    setMobileOpen(false)
+  }
+  const handleCreateChat = (): void => {
+    onCreateChat()
+    closeMobile()
+  }
+  const handleSelectChat = (id: string): void => {
+    onSelectChat(id)
+    closeMobile()
+  }
+
+  // On mobile the drawer always renders the full (expanded) shell —
+  // a "collapsed icon rail" doesn't make sense inside a slide-in drawer.
+  const showExpanded = !collapsed || mobileOpen
+
   return (
-    <aside className="hidden h-full w-14 flex-shrink-0 flex-col items-center border-r border-sidebar-border bg-sidebar py-3 md:flex">
-      <Link
-        to="/"
-        aria-label="Home"
-        className="grid h-9 w-9 place-items-center rounded-md transition hover:bg-secondary"
-      >
-        <BrandMark withWordmark={false} size="md" />
-      </Link>
-
-      <div className="mt-3 flex w-full flex-col items-center gap-1">
-        <Link
-          to="/"
-          aria-label="New chat"
-          title="New chat"
-          className="grid h-9 w-9 place-items-center rounded-md text-muted-foreground transition hover:bg-secondary hover:text-foreground"
-          activeProps={{
-            className:
-              "grid h-9 w-9 place-items-center rounded-md text-foreground bg-secondary",
-          }}
-        >
-          <MessageSquarePlus className="h-4 w-4" aria-hidden strokeWidth={1.75} />
-        </Link>
-
+    <>
+      {mobileOpen && (
         <button
           type="button"
-          aria-label="Search"
-          title="Search conversations  (⌘K)"
-          className="grid h-9 w-9 place-items-center rounded-md text-muted-foreground transition hover:bg-secondary hover:text-foreground"
+          aria-label="Close sidebar"
+          onClick={closeMobile}
+          className="fixed inset-0 z-30 bg-black/30 md:hidden"
+        />
+      )}
+      <aside
+        id="app-sidebar"
+        aria-label="Sidebar"
+        className={
+          "fixed inset-y-0 left-0 z-40 h-full w-[280px] flex-shrink-0 overflow-hidden border-r border-sidebar-border bg-sidebar transition-[transform,width] duration-300 ease-[cubic-bezier(0.2,0.7,0.1,1)] md:static md:translate-x-0 " +
+          (mobileOpen ? "translate-x-0 " : "-translate-x-full ") +
+          (collapsed ? "md:w-14 " : "md:w-[272px] ")
+        }
+      >
+        {showExpanded ? (
+          <ExpandedShell
+            me={me}
+            collapsed={collapsed}
+            query={query}
+            setQuery={setQuery}
+            searchRef={searchRef}
+            chats={chats}
+            activeChatId={activeChatId}
+            chatsLoading={chatsLoading}
+            onToggle={onToggle}
+            onCreateChat={handleCreateChat}
+            onSelectChat={handleSelectChat}
+            onRenameChat={onRenameChat}
+            onDeleteChat={onDeleteChat}
+            onAccount={onAccount}
+          />
+        ) : (
+          <CollapsedShell
+            me={me}
+            collapsed={collapsed}
+            onToggle={onToggle}
+            onCreateChat={onCreateChat}
+          />
+        )}
+      </aside>
+    </>
+  )
+}
+
+// ─── Collapsed shell (icon rail) ───────────────────────────────────────────
+type CollapsedProps = {
+  me?: { email: string; role: string } | undefined
+  collapsed: boolean
+  onToggle: () => void
+  onCreateChat: () => void
+}
+
+function CollapsedShell({
+  me,
+  collapsed,
+  onToggle,
+  onCreateChat,
+}: CollapsedProps): JSX.Element {
+  return (
+    <div className="flex h-full w-14 flex-col items-center py-3">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-label="Expand sidebar"
+        aria-expanded={!collapsed}
+        aria-controls="app-sidebar"
+        title="Expand sidebar  (⌘\\)"
+        className="grid h-9 w-9 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground"
+      >
+        <PanelLeftOpen className="h-4 w-4" aria-hidden strokeWidth={1.75} />
+      </button>
+
+      <div className="mt-2 flex flex-col items-center gap-1">
+        <SidebarNavItem
+          icon={MessageSquarePlus}
+          label="New chat"
+          collapsed
+          onClick={onCreateChat}
+        />
+        <Link
+          to="/kb"
+          aria-label="Knowledge"
+          title="Knowledge"
+          className="grid h-9 w-9 place-items-center rounded-lg text-muted-foreground transition-colors duration-150 hover:bg-secondary/60 hover:text-foreground"
+          activeProps={{
+            className:
+              "grid h-9 w-9 place-items-center rounded-lg bg-secondary text-foreground transition-colors duration-150",
+          }}
         >
-          <Search className="h-4 w-4" aria-hidden strokeWidth={1.75} />
-        </button>
+          <FolderTree className="h-4 w-4" aria-hidden strokeWidth={1.75} />
+        </Link>
       </div>
 
       <div className="flex-1" />
@@ -63,6 +180,145 @@ export function Sidebar({ me }: Props): JSX.Element {
       >
         {me ? initials(me.email) : "··"}
       </Link>
-    </aside>
+    </div>
+  )
+}
+
+// ─── Expanded shell (brand + nav + chats + footer) ─────────────────────────
+type ExpandedProps = {
+  me?: { email: string; role: string } | undefined
+  collapsed: boolean
+  query: string
+  setQuery: (next: string) => void
+  searchRef: React.RefObject<HTMLInputElement | null>
+  chats: ChatHistoryItem[]
+  activeChatId?: string | undefined
+  chatsLoading?: boolean | undefined
+  onToggle: () => void
+  onCreateChat: () => void
+  onSelectChat: (id: string) => void
+  onRenameChat: (id: string, title: string) => Promise<void>
+  onDeleteChat: (id: string) => Promise<void>
+  onAccount?: (() => void) | undefined
+}
+
+function ExpandedShell({
+  me,
+  collapsed,
+  query,
+  setQuery,
+  searchRef,
+  chats,
+  activeChatId,
+  chatsLoading,
+  onToggle,
+  onCreateChat,
+  onSelectChat,
+  onRenameChat,
+  onDeleteChat,
+  onAccount,
+}: ExpandedProps): JSX.Element {
+  return (
+    <div className="flex h-full w-[272px] flex-col">
+      {/* Header — brand + collapse toggle */}
+      <header className="flex items-center justify-between px-3 pb-2 pt-3">
+        <BrandMark withWordmark size="md" />
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-label="Collapse sidebar"
+          aria-expanded={!collapsed}
+          aria-controls="app-sidebar"
+          title="Collapse sidebar  (⌘\\)"
+          className="grid h-8 w-8 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground"
+        >
+          <PanelLeftClose
+            className="h-4 w-4"
+            aria-hidden
+            strokeWidth={1.75}
+          />
+        </button>
+      </header>
+
+      {/* Primary nav */}
+      <nav className="flex flex-col gap-0.5 px-2 pt-1">
+        <SidebarNavItem
+          icon={MessageSquarePlus}
+          label="New chat"
+          onClick={onCreateChat}
+        />
+        <Link
+          to="/kb"
+          className="group flex h-9 w-full items-center gap-2.5 rounded-lg px-2.5 text-[13.5px] text-muted-foreground transition-colors duration-150 hover:bg-secondary/60 hover:text-foreground"
+          activeProps={{
+            className:
+              "group flex h-9 w-full items-center gap-2.5 rounded-lg bg-secondary px-2.5 text-[13.5px] font-medium text-foreground transition-colors duration-150",
+          }}
+        >
+          <FolderTree className="h-4 w-4 shrink-0" aria-hidden strokeWidth={1.75} />
+          <span className="flex-1 truncate text-left">Knowledge</span>
+        </Link>
+      </nav>
+
+      {/* Search input */}
+      <div className="px-3 pb-1 pt-2">
+        <div className="relative">
+          <Search
+            className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+            strokeWidth={1.75}
+          />
+          <input
+            ref={searchRef}
+            type="search"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") setQuery("")
+            }}
+            placeholder="Search conversations…"
+            aria-label="Search conversations"
+            className="h-9 w-full rounded-lg bg-surface-elevated px-3 pl-9 pr-3 text-[13px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/40"
+          />
+        </div>
+      </div>
+
+      {/* Recents — chat history list */}
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
+        <ChatHistory
+          items={chats}
+          activeId={activeChatId}
+          loading={chatsLoading}
+          query={query}
+          onSelect={onSelectChat}
+          onRename={onRenameChat}
+          onDelete={onDeleteChat}
+        />
+      </div>
+
+      {/* Footer — theme above, account below */}
+      <footer className="flex flex-col gap-2 border-t border-sidebar-border px-3 py-3">
+        <div className="flex justify-start">
+          <ThemeToggle />
+        </div>
+        <button
+          type="button"
+          onClick={onAccount}
+          title={me?.email ?? "Account"}
+          className="group inline-flex min-w-0 items-center gap-2 rounded-full px-1.5 py-1 transition-colors hover:bg-secondary/70"
+        >
+          <span className="grid h-7 w-7 flex-shrink-0 place-items-center rounded-full bg-primary text-[10.5px] font-medium text-primary-foreground">
+            {me ? initials(me.email) : "··"}
+          </span>
+          {me?.email ? (
+            <span className="truncate text-[12px] text-muted-foreground group-hover:text-foreground">
+              {me.email}
+            </span>
+          ) : null}
+        </button>
+      </footer>
+    </div>
   )
 }

--- a/ui2/src/components/SidebarListRow.tsx
+++ b/ui2/src/components/SidebarListRow.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react"
+
+type Props = {
+  title: string
+  active?: boolean
+  onClick?: () => void
+  actions?: ReactNode
+  ariaCurrent?: "page" | undefined
+  buttonRef?: (el: HTMLButtonElement | null) => void
+}
+
+export function SidebarListRow({
+  title,
+  active = false,
+  onClick,
+  actions,
+  ariaCurrent,
+  buttonRef,
+}: Props): JSX.Element {
+  return (
+    <div className="group relative">
+      <button
+        type="button"
+        ref={buttonRef}
+        onClick={onClick}
+        aria-current={ariaCurrent}
+        className={
+          "flex h-9 w-full items-center rounded-lg pl-2.5 text-left text-[13px] leading-tight transition-colors duration-150 " +
+          (actions ? "pr-9 " : "pr-2.5 ") +
+          (active
+            ? "bg-secondary text-foreground"
+            : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground")
+        }
+      >
+        <span className="block min-w-0 flex-1 truncate">
+          {title || "Untitled"}
+        </span>
+      </button>
+      {actions ? (
+        <div className="absolute inset-y-0 right-1.5 flex items-center opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+          {actions}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/ui2/src/components/SidebarNavItem.tsx
+++ b/ui2/src/components/SidebarNavItem.tsx
@@ -1,0 +1,67 @@
+import type { LucideIcon } from "lucide-react"
+
+type Props = {
+  icon: LucideIcon
+  label: string
+  collapsed?: boolean
+  active?: boolean
+  onClick?: () => void
+  shortcut?: string
+  ariaCurrent?: "page" | undefined
+}
+
+export function SidebarNavItem({
+  icon,
+  label,
+  collapsed = false,
+  active = false,
+  onClick,
+  shortcut,
+  ariaCurrent,
+}: Props): JSX.Element {
+  const Icon = icon
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-label={label}
+        aria-current={ariaCurrent}
+        title={label}
+        className={
+          "grid h-9 w-9 place-items-center rounded-lg transition-colors duration-150 " +
+          (active
+            ? "bg-secondary text-foreground"
+            : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground")
+        }
+      >
+        <Icon className="h-4 w-4" aria-hidden strokeWidth={1.75} />
+      </button>
+    )
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-current={ariaCurrent}
+      className={
+        "group flex h-9 w-full items-center gap-2.5 rounded-lg px-2.5 text-[13.5px] transition-colors duration-150 " +
+        (active
+          ? "bg-secondary font-medium text-foreground"
+          : "text-muted-foreground hover:bg-secondary/60 hover:text-foreground")
+      }
+    >
+      <Icon
+        className="h-4 w-4 shrink-0"
+        aria-hidden
+        strokeWidth={1.75}
+      />
+      <span className="flex-1 truncate text-left">{label}</span>
+      {shortcut ? (
+        <kbd className="hidden rounded-md bg-foreground/[0.06] px-1.5 py-0.5 text-[10.5px] font-medium tracking-wide text-muted-foreground group-hover:text-foreground/70 sm:inline-block">
+          {shortcut}
+        </kbd>
+      ) : null}
+    </button>
+  )
+}

--- a/ui2/src/components/ThinkingChip.tsx
+++ b/ui2/src/components/ThinkingChip.tsx
@@ -1,14 +1,47 @@
-import { useState } from "react"
-import { ChevronRight, Brain, Loader2 } from "lucide-react"
+import { useEffect, useState } from "react"
+import { ChevronRight, Brain } from "lucide-react"
 
 type Props = {
   text: string
   pending?: boolean
 }
 
+const BRAILLE_FRAMES = [
+  "⠋",
+  "⠙",
+  "⠹",
+  "⠸",
+  "⠼",
+  "⠴",
+  "⠦",
+  "⠧",
+  "⠇",
+  "⠏",
+] as const
+
+function BrailleLoader(): JSX.Element {
+  const [frame, setFrame] = useState(0)
+  useEffect((): (() => void) => {
+    const id = window.setInterval((): void => {
+      setFrame((x): number => (x + 1) % BRAILLE_FRAMES.length)
+    }, 90)
+    return (): void => {
+      window.clearInterval(id)
+    }
+  }, [])
+  return (
+    <span
+      aria-hidden
+      className="inline-flex h-3.5 w-3.5 flex-shrink-0 items-center justify-center font-mono text-[15px] leading-none"
+      style={{ color: "#E63946" }}
+    >
+      {BRAILLE_FRAMES[frame]}
+    </span>
+  )
+}
+
 export function ThinkingChip({ text, pending = false }: Props): JSX.Element {
-  // Open while streaming so the user sees reasoning happen; collapse on done.
-  const [open, setOpen] = useState(pending)
+  const [open, setOpen] = useState(false)
 
   return (
     <div className="my-2 overflow-hidden rounded-lg border border-border/60 text-[12.5px]">
@@ -25,20 +58,22 @@ export function ThinkingChip({ text, pending = false }: Props): JSX.Element {
           }
           aria-hidden
         />
-        <Brain
-          className="h-3 w-3 flex-shrink-0 text-muted-foreground"
-          aria-hidden
-          strokeWidth={1.75}
-        />
-        <span className="text-foreground/80">
-          {pending ? "Thinking…" : "Thought"}
-        </span>
-        {pending && (
-          <Loader2
-            className="ml-auto h-3 w-3 animate-spin text-muted-foreground"
+        {pending ? (
+          <BrailleLoader />
+        ) : (
+          <Brain
+            className="h-3 w-3 flex-shrink-0 text-muted-foreground"
             aria-hidden
+            strokeWidth={1.75}
           />
         )}
+        <span
+          className={
+            "text-foreground/80 " + (pending ? "animate-breathe" : "")
+          }
+        >
+          {pending ? "Thinking…" : "Thought"}
+        </span>
       </button>
 
       {open && text.length > 0 && (

--- a/ui2/src/components/Topbar.tsx
+++ b/ui2/src/components/Topbar.tsx
@@ -1,19 +1,35 @@
-import { ThemeToggle } from "./ThemeToggle"
+import { Menu } from "lucide-react"
+import { useSidebarMobile } from "@/hooks/useSidebarMobile"
 
 type Props = {
-  title: string
+  title?: string | undefined
 }
 
 export function Topbar({ title }: Props): JSX.Element {
+  const { setOpen } = useSidebarMobile()
   return (
-    <header className="flex items-center justify-between border-b border-border bg-background/70 px-4 py-2 backdrop-blur-md">
-      <h1 className="truncate text-[13.5px] font-medium text-foreground">
-        {title}
-      </h1>
-
-      <div className="flex items-center gap-2">
-        <ThemeToggle />
-      </div>
+    <header
+      className={
+        "flex h-11 items-center gap-1 px-3 sm:px-4 " +
+        (title ? "border-b border-border bg-background/70 backdrop-blur-md" : "")
+      }
+    >
+      <button
+        type="button"
+        onClick={(): void => {
+          setOpen(true)
+        }}
+        aria-label="Open sidebar"
+        aria-controls="app-sidebar"
+        className="grid h-8 w-8 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-secondary/60 hover:text-foreground md:hidden"
+      >
+        <Menu className="h-4 w-4" aria-hidden strokeWidth={1.75} />
+      </button>
+      {title ? (
+        <h1 className="truncate text-[13.5px] font-medium text-foreground">
+          {title}
+        </h1>
+      ) : null}
     </header>
   )
 }

--- a/ui2/src/components/file-browser/EntryGrid.tsx
+++ b/ui2/src/components/file-browser/EntryGrid.tsx
@@ -1,0 +1,83 @@
+// Card grid of folder + file entries. Feature-agnostic: takes neutral
+// BrowserEntry shapes, a single open handler, and optional escape hatches
+// for the leading visual / per-kind interactivity.
+
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+import type { BrowserEntry, LeadingRenderer } from "./types"
+import { FileCard } from "./FileCard"
+import { FolderCard } from "./FolderCard"
+import { StatusBadge } from "./StatusBadge"
+
+type Props = {
+  entries: ReadonlyArray<BrowserEntry>
+  onOpen?: (entry: BrowserEntry) => void
+  renderLeading?: LeadingRenderer
+  disableFiles?: boolean
+  disableFolders?: boolean
+  // Optional caller-controlled cell rendered as the FIRST grid item — used
+  // for things like the inline new-folder draft. Receives no props; the
+  // caller supplies a fully-styled card matching the grid cell shape.
+  leadingItem?: ReactNode
+}
+
+const defaultLeading: LeadingRenderer = (entry, size) =>
+  entry.kind === "folder" ? (
+    <FolderCard size={size} />
+  ) : (
+    <FileCard format={entry.format || "txt"} size={size} />
+  )
+
+export function EntryGrid({
+  entries,
+  onOpen,
+  renderLeading = defaultLeading,
+  disableFiles = false,
+  disableFolders = false,
+  leadingItem,
+}: Props): JSX.Element {
+  const isDisabled = (e: BrowserEntry): boolean =>
+    (e.kind === "file" && disableFiles) ||
+    (e.kind === "folder" && disableFolders)
+  return (
+    <ul className="grid animate-fade-up grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+      {leadingItem ? <li>{leadingItem}</li> : null}
+      {entries.map((e) => {
+        const disabled = isDisabled(e)
+        return (
+          <li key={`${e.kind}-${e.id}`}>
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={() => {
+                onOpen?.(e)
+              }}
+              className={cn(
+                "group relative flex w-full flex-col items-start gap-3 rounded-2xl border border-border bg-surface-elevated p-4 text-left transition",
+                disabled
+                  ? "cursor-default"
+                  : "hover:border-ring/40 hover:bg-secondary/60 active:scale-[0.99]",
+              )}
+              title={e.name}
+            >
+              {e.indicator ? (
+                <StatusBadge indicator={e.indicator} variant="card" />
+              ) : null}
+              <div className="pl-1 pt-1">{renderLeading(e, "md")}</div>
+              <span className="flex w-full min-w-0 flex-col gap-0.5">
+                <span className="truncate text-[13.5px] font-medium text-foreground">
+                  {e.name}
+                </span>
+                {e.caption ? (
+                  <span className="truncate text-[11.5px] text-muted-foreground">
+                    {e.caption}
+                  </span>
+                ) : null}
+              </span>
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/ui2/src/components/file-browser/EntryList.tsx
+++ b/ui2/src/components/file-browser/EntryList.tsx
@@ -1,0 +1,117 @@
+// Tabular list of folder + file entries. Columns are caller-provided so the
+// list adapts to any feature (KB shows Kind/Size/Updated; Custom Agents
+// could show Model/Author/Updated; etc.).
+
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+import type { BrowserEntry, ColumnDef, LeadingRenderer } from "./types"
+import { FileCard } from "./FileCard"
+import { FolderCard } from "./FolderCard"
+import { StatusBadge } from "./StatusBadge"
+
+type Props = {
+  entries: ReadonlyArray<BrowserEntry>
+  columns?: ReadonlyArray<ColumnDef>
+  onOpen?: (entry: BrowserEntry) => void
+  nameHeader?: string
+  renderLeading?: LeadingRenderer
+  disableFiles?: boolean
+  disableFolders?: boolean
+  // Optional caller-controlled row rendered as the FIRST row inside the
+  // tabular body — used for things like the inline new-folder draft.
+  leadingItem?: ReactNode
+}
+
+const DEFAULT_COL_WIDTH = "120px"
+
+const defaultLeading: LeadingRenderer = (entry, size) =>
+  entry.kind === "folder" ? (
+    <FolderCard size={size} />
+  ) : (
+    <FileCard format={entry.format || "txt"} size={size} />
+  )
+
+export function EntryList({
+  entries,
+  columns = [],
+  onOpen,
+  nameHeader = "Name",
+  renderLeading = defaultLeading,
+  disableFiles = false,
+  disableFolders = false,
+  leadingItem,
+}: Props): JSX.Element {
+  const template = [
+    "1fr",
+    ...columns.map((c) => c.width ?? DEFAULT_COL_WIDTH),
+  ].join(" ")
+  const isDisabled = (e: BrowserEntry): boolean =>
+    (e.kind === "file" && disableFiles) ||
+    (e.kind === "folder" && disableFolders)
+  return (
+    <div className="animate-fade-up overflow-hidden rounded-2xl border border-border bg-surface-elevated">
+      <div
+        className="grid items-center gap-3 border-b border-border bg-surface-muted/60 px-4 py-2 text-[11.5px] font-medium uppercase tracking-wide text-muted-foreground"
+        style={{ gridTemplateColumns: template }}
+      >
+        <span>{nameHeader}</span>
+        {columns.map((c) => (
+          <span
+            key={`h-${c.key}`}
+            className={c.mdOnly === false ? undefined : "hidden md:block"}
+          >
+            {c.header}
+          </span>
+        ))}
+      </div>
+      <ul className="divide-y divide-border">
+        {leadingItem ? <li>{leadingItem}</li> : null}
+        {entries.map((e) => {
+          const disabled = isDisabled(e)
+          return (
+            <li key={`${e.kind}-${e.id}`}>
+              <button
+                type="button"
+                disabled={disabled}
+                onClick={() => {
+                  onOpen?.(e)
+                }}
+                className={cn(
+                  "grid w-full items-center gap-3 px-4 py-2 text-left transition",
+                  disabled ? "cursor-default" : "hover:bg-secondary/60",
+                )}
+                style={{ gridTemplateColumns: template }}
+                title={e.name}
+              >
+                <span className="flex min-w-0 items-center gap-3">
+                  <span className="flex-shrink-0 pr-1">
+                    {renderLeading(e, "sm")}
+                  </span>
+                  <span className="flex min-w-0 items-center gap-2">
+                    <span className="truncate text-[13.5px] font-medium text-foreground">
+                      {e.name}
+                    </span>
+                    {e.indicator ? (
+                      <StatusBadge indicator={e.indicator} variant="inline" />
+                    ) : null}
+                  </span>
+                </span>
+                {columns.map((c) => (
+                  <span
+                    key={`c-${c.key}`}
+                    className={cn(
+                      c.mdOnly === false ? undefined : "hidden md:block",
+                      "truncate tabular-nums text-[12px] text-muted-foreground",
+                    )}
+                  >
+                    {c.render ? c.render(e) : (e.columns?.[c.key] ?? "—")}
+                  </span>
+                ))}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/ui2/src/components/file-browser/FileCard.tsx
+++ b/ui2/src/components/file-browser/FileCard.tsx
@@ -1,0 +1,377 @@
+// Tiny paper-like preview card for a file. Each format gets a subtly different
+// interior so the card itself communicates "this is a spreadsheet / a slide
+// deck / an archive" before the user reads the filename. Banner uses
+// information-bearing color (pdf=red, xlsx=green, …) — the only place we let
+// non-neutral color in; surrounding chrome stays on xyne tokens.
+
+import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+
+type Props = {
+  // Lowercase format key (e.g. "pdf", "xlsx", "code"). Anything outside the
+  // BANNER table falls back to a neutral zinc banner.
+  format: string
+  size?: "sm" | "md"
+}
+
+const BANNER: Record<string, string> = {
+  doc: "bg-blue-500 text-white",
+  docx: "bg-blue-500 text-white",
+  pdf: "bg-red-500 text-white",
+  md: "bg-neutral-600 text-white",
+  mdx: "bg-neutral-600 text-white",
+  txt: "bg-gray-500 text-white",
+  csv: "bg-teal-700 text-white",
+  xls: "bg-emerald-600 text-white",
+  xlsx: "bg-emerald-600 text-white",
+  ppt: "bg-orange-500 text-white",
+  pptx: "bg-orange-500 text-white",
+  zip: "bg-purple-500 text-white",
+  rar: "bg-purple-600 text-white",
+  tar: "bg-yellow-600 text-white",
+  gz: "bg-yellow-700 text-white",
+  html: "bg-orange-600 text-white",
+  js: "bg-yellow-600 text-white",
+  jsx: "bg-blue-600 text-white",
+  css: "bg-blue-600 text-white",
+  json: "bg-yellow-500 text-white",
+  tsx: "bg-blue-600 text-white",
+  ts: "bg-blue-600 text-white",
+  code: "bg-orange-600 text-white",
+  img: "bg-pink-500 text-white",
+  png: "bg-neutral-600 text-white",
+  jpg: "bg-green-700 text-white",
+  jpeg: "bg-green-700 text-white",
+  gif: "bg-pink-600 text-white",
+  webp: "bg-pink-500 text-white",
+  mp4: "bg-green-700 text-white",
+  mov: "bg-green-700 text-white",
+  webm: "bg-green-700 text-white",
+  mp3: "bg-fuchsia-600 text-white",
+  wav: "bg-fuchsia-600 text-white",
+  flac: "bg-fuchsia-700 text-white",
+  video: "bg-green-700 text-white",
+}
+
+const DefaultLines = (): JSX.Element => (
+  <div className="space-y-1.5">
+    <div className="flex gap-2">
+      <div className="h-0.5 w-1/2 rounded-full bg-foreground/20" />
+    </div>
+    <div className="flex gap-1">
+      <div className="h-0.5 w-1/3 rounded-full bg-foreground/10" />
+      <div className="h-0.5 w-1/3 rounded-full bg-foreground/10" />
+    </div>
+    <div className="flex gap-1">
+      <div className="h-0.5 w-1/2 rounded-full bg-foreground/10" />
+      <div className="h-0.5 w-1/3 rounded-full bg-foreground/10" />
+    </div>
+    <div className="flex gap-1">
+      <div className="h-0.5 w-1/3 rounded-full bg-foreground/10" />
+      <div className="h-0.5 w-1/3 rounded-full bg-foreground/10" />
+    </div>
+    <div className="flex gap-1">
+      <div className="h-0.5 w-1/3 rounded-full bg-foreground/10" />
+      <div className="h-0.5 w-1/2 rounded-full bg-foreground/10" />
+    </div>
+    <div className="flex gap-1">
+      <div className="h-0.5 w-1/3 rounded-full bg-foreground/10" />
+    </div>
+  </div>
+)
+
+const MarkdownInterior = (): JSX.Element => (
+  <div className="space-y-1.5">
+    <div className="flex items-center gap-1">
+      <div className="text-[10px] font-bold text-foreground/30">#</div>
+      <div className="h-0.5 w-6 rounded-full bg-foreground/20" />
+    </div>
+    <div className="space-y-1">
+      <div className="h-0.5 w-1/3 rounded-full bg-foreground/10" />
+      <div className="h-0.5 w-7 rounded-full bg-foreground/10" />
+    </div>
+    <div className="space-y-1">
+      <div className="h-0.5 w-8 rounded-full bg-foreground/10" />
+      <div className="h-0.5 w-4 rounded-full bg-foreground/10" />
+      <div className="h-0.5 w-1/3 rounded-full bg-foreground/10" />
+    </div>
+  </div>
+)
+
+const SpreadsheetInterior = (): JSX.Element => (
+  <div className="space-y-0.5">
+    <div className="grid grid-cols-3 gap-0.5">
+      <div className="h-2 bg-foreground/20" />
+      <div className="h-2 bg-foreground/20" />
+      <div className="h-2 bg-foreground/20" />
+    </div>
+    <div className="grid grid-cols-3 gap-0.5">
+      <div className="h-2 bg-foreground/5" />
+      <div className="h-2 bg-foreground/5" />
+      <div className="h-2 bg-foreground/5" />
+      <div className="h-2 bg-foreground/5" />
+      <div className="h-2 bg-foreground/5" />
+      <div className="h-2 bg-foreground/5" />
+    </div>
+    <div className="grid grid-cols-3 gap-0.5">
+      <div className="h-2 bg-foreground/5" />
+      <div className="h-2 bg-foreground/5" />
+    </div>
+    <div className="grid grid-cols-3 gap-0.5">
+      <div className="h-2 bg-foreground/5" />
+    </div>
+  </div>
+)
+
+const CsvInterior = (): JSX.Element => (
+  <>
+    <div className="mb-2 grid grid-cols-3 gap-0.5">
+      <div className="h-1.5 rounded-full bg-foreground/20" />
+      <div className="h-1.5 rounded-full bg-foreground/20" />
+      <div className="h-1.5 rounded-full bg-foreground/20" />
+    </div>
+    <div className="space-y-1.5">
+      <div className="grid grid-cols-3 gap-0.5">
+        <div className="h-1 rounded-full bg-foreground/5" />
+        <div className="h-1 rounded-full bg-foreground/5" />
+        <div className="h-1 rounded-full bg-foreground/5" />
+      </div>
+      <div className="grid grid-cols-3 gap-0.5">
+        <div className="h-1 rounded-full bg-foreground/5" />
+        <div className="h-1 rounded-full bg-foreground/5" />
+        <div className="h-1 rounded-full bg-foreground/5" />
+      </div>
+      <div className="grid grid-cols-3 gap-0.5">
+        <div className="h-1 rounded-full bg-foreground/5" />
+        <div className="h-1 rounded-full bg-foreground/5" />
+      </div>
+      <div className="grid grid-cols-3 gap-0.5">
+        <div className="h-1 rounded-full bg-foreground/5" />
+      </div>
+    </div>
+  </>
+)
+
+const ArchiveInterior = (): JSX.Element => (
+  <div className="relative flex h-full flex-col items-center justify-center">
+    <div className="space-y-0">
+      {Array.from({ length: 9 }).map((_, i) => (
+        <div key={i} className="flex overflow-hidden rounded-full">
+          <div
+            className={cn(
+              "size-1.5",
+              i % 2 === 0 ? "bg-foreground/20" : "bg-foreground/5",
+            )}
+          />
+          <div
+            className={cn(
+              "size-1.5",
+              i % 2 === 0 ? "bg-foreground/5" : "bg-foreground/20",
+            )}
+          />
+        </div>
+      ))}
+    </div>
+  </div>
+)
+
+const SlideInterior = (): JSX.Element => (
+  <>
+    <div className="mb-1.5 space-y-1 rounded border border-border bg-foreground/5 p-1">
+      <div className="flex justify-center gap-1">
+        <div className="size-3 rounded-sm bg-orange-400/40" />
+      </div>
+      <div className="mx-auto h-[3px] w-8 rounded-full bg-foreground/15" />
+    </div>
+    <div className="mb-1 flex justify-center gap-1">
+      <div className="h-[3px] w-8 rounded-full bg-foreground/15" />
+      <div className="h-[3px] w-4 rounded-full bg-foreground/15" />
+    </div>
+    <div className="space-y-1">
+      <div className="h-[3px] w-4 rounded-full bg-foreground/15" />
+      <div className="h-[3px] w-5 rounded-full bg-foreground/15" />
+    </div>
+  </>
+)
+
+const ImageInterior = (): JSX.Element => (
+  <div className="mb-1.5 space-y-1 rounded border border-border bg-foreground/5 p-1">
+    <div className="flex justify-center gap-1">
+      <div className="size-3 rounded-sm bg-yellow-400/40" />
+    </div>
+    <div className="mx-auto mt-1 h-[3px] w-4 rounded-full bg-foreground/15" />
+    <div className="mx-auto h-[3px] w-8 rounded-full bg-foreground/15" />
+  </div>
+)
+
+const VideoInterior = (): JSX.Element => (
+  <div className="mb-1.5 space-y-1 rounded border border-border bg-foreground/5 p-1">
+    <div className="flex justify-center gap-1">
+      <div className="size-0 border-y-[5px] border-l-8 border-y-transparent border-l-green-400/60" />
+    </div>
+    <div className="mx-auto mt-1 h-[3px] w-4 rounded-full bg-foreground/15" />
+    <div className="mx-auto h-[3px] w-8 rounded-full bg-foreground/15" />
+  </div>
+)
+
+const AudioInterior = (): JSX.Element => (
+  <div className="flex h-full items-end justify-center gap-[3px] py-1">
+    {[3, 6, 4, 8, 5, 7, 4, 6, 3].map((h, i) => (
+      <div
+        key={i}
+        className="w-[2px] rounded-full bg-fuchsia-400/60"
+        style={{ height: `${String(h * 3)}px` }}
+      />
+    ))}
+  </div>
+)
+
+const CodeInterior = (): JSX.Element => (
+  <div className="space-y-1">
+    <div className="flex items-center gap-0.5">
+      <div className="font-mono text-[5px] text-foreground/30">&lt;</div>
+      <div className="h-[3px] w-3 rounded-full bg-emerald-400/60" />
+      <div className="font-mono text-[5px] text-foreground/30">&gt;</div>
+    </div>
+    <div className="flex items-center gap-0.5 pl-1">
+      <div className="font-mono text-[5px] text-foreground/30">&lt;</div>
+      <div className="h-[3px] w-2.5 rounded-full bg-sky-400/60" />
+      <div className="font-mono text-[5px] text-foreground/30">&gt;</div>
+    </div>
+    <div className="flex items-center gap-0.5 pl-1">
+      <div className="font-mono text-[5px] text-foreground/30">&lt;/</div>
+      <div className="h-[3px] w-2.5 rounded-full bg-sky-400/60" />
+      <div className="font-mono text-[5px] text-foreground/30">&gt;</div>
+    </div>
+    <div className="flex items-center gap-0.5">
+      <div className="font-mono text-[5px] text-foreground/30">&lt;</div>
+      <div className="h-[3px] w-1 rounded-full bg-emerald-400/60" />
+      <div className="font-mono text-[5px] text-foreground/30">/&gt;</div>
+    </div>
+  </div>
+)
+
+const CssInterior = (): JSX.Element => (
+  <div className="space-y-1">
+    <div className="font-mono text-[6px] text-foreground/40">{"{"}</div>
+    <div className="flex items-center gap-1 pl-1.5">
+      <div className="h-[3px] w-3 rounded-full bg-sky-400/60" />
+      <div className="h-[3px] w-4 rounded-full bg-sky-400/60" />
+    </div>
+    <div className="flex items-center gap-1 pl-1.5">
+      <div className="h-[3px] w-4 rounded-full bg-sky-400/60" />
+      <div className="h-[3px] w-2 rounded-full bg-sky-400/60" />
+    </div>
+    <div className="flex items-center gap-1 pl-1.5">
+      <div className="h-[3px] w-3 rounded-full bg-sky-400/60" />
+      <div className="h-[3px] w-4 rounded-full bg-sky-400/60" />
+    </div>
+    <div className="font-mono text-[6px] text-foreground/40">{"}"}</div>
+  </div>
+)
+
+const JsonInterior = (): JSX.Element => (
+  <div className="space-y-1">
+    <div className="font-mono text-[6px] text-foreground/40">{"{"}</div>
+    <div className="flex items-center gap-1 pl-1.5">
+      <div className="h-[3px] w-3 rounded-full bg-foreground/20" />
+      <div className="h-[3px] w-4 rounded-full bg-foreground/20" />
+    </div>
+    <div className="flex items-center gap-1 pl-1.5">
+      <div className="h-[3px] w-4 rounded-full bg-foreground/10" />
+      <div className="h-[3px] w-2 rounded-full bg-foreground/10" />
+    </div>
+    <div className="flex items-center gap-1 pl-1.5">
+      <div className="h-[3px] w-3 rounded-full bg-foreground/10" />
+      <div className="h-[3px] w-4 rounded-full bg-foreground/10" />
+    </div>
+    <div className="flex items-center gap-1 pl-1.5">
+      <div className="h-[3px] w-3 rounded-full bg-foreground/10" />
+    </div>
+    <div className="font-mono text-[6px] text-foreground/40">{"}"}</div>
+  </div>
+)
+
+const interiorFor = (fmt: string): ReactNode => {
+  switch (fmt) {
+    case "md":
+    case "mdx":
+      return <MarkdownInterior />
+    case "xls":
+    case "xlsx":
+      return <SpreadsheetInterior />
+    case "csv":
+      return <CsvInterior />
+    case "zip":
+    case "rar":
+    case "tar":
+    case "gz":
+      return <ArchiveInterior />
+    case "ppt":
+    case "pptx":
+      return <SlideInterior />
+    case "img":
+    case "png":
+    case "jpg":
+    case "jpeg":
+    case "gif":
+    case "webp":
+      return <ImageInterior />
+    case "mp4":
+    case "mov":
+    case "webm":
+    case "video":
+      return <VideoInterior />
+    case "mp3":
+    case "wav":
+    case "flac":
+      return <AudioInterior />
+    case "html":
+    case "js":
+    case "jsx":
+    case "tsx":
+    case "ts":
+    case "code":
+      return <CodeInterior />
+    case "css":
+      return <CssInterior />
+    case "json":
+      return <JsonInterior />
+    default:
+      return <DefaultLines />
+  }
+}
+
+export function FileCard({ format, size = "md" }: Props): JSX.Element {
+  const fmt = format.toLowerCase()
+  const banner = BANNER[fmt] ?? "bg-zinc-500 text-white"
+  const dims =
+    size === "sm"
+      ? "w-9 h-[3rem] p-1.5 space-y-2"
+      : "w-14 h-[4.5rem] p-2 space-y-3"
+  const bannerPos =
+    size === "sm"
+      ? "-right-1.5 bottom-1 text-[7px] px-1 py-px"
+      : "-right-2 bottom-1.5 text-[8px] px-1.5 py-0.5"
+  return (
+    <div aria-hidden className="relative size-fit">
+      <div
+        className={cn(
+          "absolute z-[2] rounded font-medium uppercase tracking-wide",
+          bannerPos,
+          banner,
+        )}
+      >
+        {fmt}
+      </div>
+      <div
+        className={cn(
+          "relative z-[1] overflow-hidden rounded-md bg-surface ring-1 ring-border dark:bg-secondary",
+          dims,
+        )}
+      >
+        {interiorFor(fmt)}
+      </div>
+    </div>
+  )
+}

--- a/ui2/src/components/file-browser/FolderCard.tsx
+++ b/ui2/src/components/file-browser/FolderCard.tsx
@@ -1,0 +1,30 @@
+// Plain folder glyph, centered inside the same bounding box FileCard
+// occupies so the grid lays out evenly.
+
+import { Folder } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+type Props = {
+  size?: "sm" | "md"
+}
+
+export function FolderCard({ size = "md" }: Props): JSX.Element {
+  const isSm = size === "sm"
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "flex items-center justify-center",
+        isSm ? "h-[3rem] w-9" : "h-[4.5rem] w-14",
+      )}
+    >
+      <Folder
+        strokeWidth={1.5}
+        className={cn(
+          "text-muted-foreground",
+          isSm ? "h-5 w-5" : "h-10 w-10",
+        )}
+      />
+    </div>
+  )
+}

--- a/ui2/src/components/file-browser/PathBreadcrumb.tsx
+++ b/ui2/src/components/file-browser/PathBreadcrumb.tsx
@@ -1,0 +1,91 @@
+// Path-style breadcrumb. The "root" label/icon is configurable so this works
+// for any hierarchical section (Knowledge, Agent groups, …). Empty path
+// renders just the root.
+
+import { ChevronRight, Home } from "lucide-react"
+import type { ReactNode } from "react"
+import { splitPath } from "@/lib/files"
+
+type Props = {
+  path: string
+  onNavigate: (path: string) => void
+  // Label for the root entry. Defaults to "Home".
+  rootLabel?: string
+  // Glyph for the root entry. Defaults to a small Home icon. Pass `null` to
+  // omit (label-only root).
+  rootIcon?: ReactNode | null
+  // Separator between segments. Defaults to a small ChevronRight.
+  separator?: ReactNode
+  // aria-label for the nav element.
+  ariaLabel?: string
+}
+
+const DefaultSeparator = (
+  <ChevronRight
+    className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground/60"
+    aria-hidden
+    strokeWidth={1.75}
+  />
+)
+
+const DefaultRootIcon = (
+  <Home className="h-3.5 w-3.5" aria-hidden strokeWidth={1.75} />
+)
+
+export function PathBreadcrumb({
+  path,
+  onNavigate,
+  rootLabel = "Home",
+  rootIcon = DefaultRootIcon,
+  separator = DefaultSeparator,
+  ariaLabel = "Path",
+}: Props): JSX.Element {
+  const segs = splitPath(path)
+  const rootIsCurrent = segs.length === 0
+  return (
+    <nav
+      aria-label={ariaLabel}
+      className="flex min-w-0 items-center gap-1 text-[13px] text-muted-foreground"
+    >
+      <button
+        type="button"
+        onClick={() => {
+          onNavigate("")
+        }}
+        aria-current={rootIsCurrent ? "page" : undefined}
+        className={
+          rootIsCurrent
+            ? "inline-flex items-center gap-1.5 rounded-md px-1.5 py-0.5 font-medium text-foreground"
+            : "inline-flex items-center gap-1.5 rounded-md px-1.5 py-0.5 transition hover:bg-secondary hover:text-foreground"
+        }
+      >
+        {rootIcon}
+        <span>{rootLabel}</span>
+      </button>
+      {segs.map((seg, i) => {
+        const isLast = i === segs.length - 1
+        const target = segs.slice(0, i + 1).join("/")
+        return (
+          <span key={target} className="flex min-w-0 items-center gap-1">
+            {separator}
+            <button
+              type="button"
+              onClick={() => {
+                onNavigate(target)
+              }}
+              aria-current={isLast ? "page" : undefined}
+              className={
+                isLast
+                  ? "max-w-[28ch] truncate rounded-md px-1.5 py-0.5 font-medium text-foreground"
+                  : "max-w-[20ch] truncate rounded-md px-1.5 py-0.5 transition hover:bg-secondary hover:text-foreground"
+              }
+              title={seg}
+            >
+              {seg}
+            </button>
+          </span>
+        )
+      })}
+    </nav>
+  )
+}

--- a/ui2/src/components/file-browser/SearchField.tsx
+++ b/ui2/src/components/file-browser/SearchField.tsx
@@ -1,0 +1,60 @@
+import { Search, X } from "lucide-react"
+import { useEffect, useRef } from "react"
+import { cn } from "@/lib/utils"
+
+type Props = {
+  value: string
+  onChange: (next: string) => void
+  placeholder?: string
+  autoFocus?: boolean
+  className?: string
+  ariaLabel?: string
+}
+
+export function SearchField({
+  value,
+  onChange,
+  placeholder = "Search",
+  autoFocus,
+  className,
+  ariaLabel,
+}: Props): JSX.Element {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  useEffect((): void => {
+    if (autoFocus) {
+      inputRef.current?.focus()
+    }
+  }, [autoFocus])
+  return (
+    <div className={cn("relative flex items-center", className)}>
+      <Search
+        className="pointer-events-none absolute left-2.5 h-3.5 w-3.5 text-muted-foreground"
+        aria-hidden
+        strokeWidth={1.75}
+      />
+      <input
+        ref={inputRef}
+        type="search"
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value)
+        }}
+        placeholder={placeholder}
+        aria-label={ariaLabel ?? placeholder}
+        className="h-8 w-full rounded-full border border-border bg-surface-elevated pl-7 pr-7 text-[12.5px] text-foreground placeholder:text-muted-foreground/80 focus:border-ring focus:outline-none [&::-webkit-search-cancel-button]:hidden [&::-webkit-search-decoration]:hidden"
+      />
+      {value !== "" ? (
+        <button
+          type="button"
+          aria-label="Clear search"
+          onClick={() => {
+            onChange("")
+          }}
+          className="absolute right-2 grid h-4 w-4 place-items-center rounded-full text-muted-foreground transition hover:text-foreground"
+        >
+          <X className="h-3 w-3" aria-hidden strokeWidth={2} />
+        </button>
+      ) : null}
+    </div>
+  )
+}

--- a/ui2/src/components/file-browser/StatusBadge.tsx
+++ b/ui2/src/components/file-browser/StatusBadge.tsx
@@ -1,0 +1,51 @@
+// Small colored dot used to surface per-entry state (e.g. an in-flight
+// ingest). Pending pulses gently so users notice it's still working.
+
+import { cn } from "@/lib/utils"
+import type { EntryIndicator } from "./types"
+
+type Props = {
+  indicator: EntryIndicator
+  // "card" sits absolute in a card corner; "inline" flows with text.
+  variant?: "card" | "inline"
+}
+
+const TONE: Record<EntryIndicator["tone"], string> = {
+  pending: "bg-amber-400",
+  failed: "bg-red-500",
+  ready: "bg-emerald-500",
+}
+
+export function StatusBadge({ indicator, variant = "inline" }: Props): JSX.Element {
+  const dot = (
+    <span
+      className={cn(
+        "inline-block h-2 w-2 rounded-full ring-2 ring-surface-elevated",
+        TONE[indicator.tone],
+        indicator.tone === "pending" && "animate-pulse",
+      )}
+    />
+  )
+  if (variant === "card") {
+    return (
+      <span
+        className="absolute right-2.5 top-2.5 inline-flex"
+        role="status"
+        aria-label={indicator.label}
+        title={indicator.label}
+      >
+        {dot}
+      </span>
+    )
+  }
+  return (
+    <span
+      className="inline-flex flex-shrink-0"
+      role="status"
+      aria-label={indicator.label}
+      title={indicator.label}
+    >
+      {dot}
+    </span>
+  )
+}

--- a/ui2/src/components/file-browser/ViewToggle.tsx
+++ b/ui2/src/components/file-browser/ViewToggle.tsx
@@ -1,0 +1,49 @@
+import { LayoutGrid, List } from "lucide-react"
+
+export type ViewMode = "grid" | "list"
+
+type Props = {
+  value: ViewMode
+  onChange: (mode: ViewMode) => void
+}
+
+export function ViewToggle({ value, onChange }: Props): JSX.Element {
+  return (
+    <div
+      role="group"
+      aria-label="View mode"
+      className="inline-flex items-center rounded-full border border-border bg-surface-elevated p-0.5"
+    >
+      <button
+        type="button"
+        aria-label="Grid view"
+        aria-pressed={value === "grid"}
+        onClick={() => {
+          onChange("grid")
+        }}
+        className={
+          value === "grid"
+            ? "inline-flex h-7 w-7 items-center justify-center rounded-full bg-secondary text-foreground"
+            : "inline-flex h-7 w-7 items-center justify-center rounded-full text-muted-foreground transition hover:text-foreground"
+        }
+      >
+        <LayoutGrid className="h-3.5 w-3.5" aria-hidden strokeWidth={1.75} />
+      </button>
+      <button
+        type="button"
+        aria-label="List view"
+        aria-pressed={value === "list"}
+        onClick={() => {
+          onChange("list")
+        }}
+        className={
+          value === "list"
+            ? "inline-flex h-7 w-7 items-center justify-center rounded-full bg-secondary text-foreground"
+            : "inline-flex h-7 w-7 items-center justify-center rounded-full text-muted-foreground transition hover:text-foreground"
+        }
+      >
+        <List className="h-3.5 w-3.5" aria-hidden strokeWidth={1.75} />
+      </button>
+    </div>
+  )
+}

--- a/ui2/src/components/file-browser/index.ts
+++ b/ui2/src/components/file-browser/index.ts
@@ -1,0 +1,20 @@
+// File-browser primitives. Feature-agnostic — any section that needs to
+// browse a collection of folders + files (Knowledge, Custom Agents,
+// attachments, …) composes these with its own data layer.
+
+export { EntryGrid } from "./EntryGrid"
+export { EntryList } from "./EntryList"
+export { FileCard } from "./FileCard"
+export { FolderCard } from "./FolderCard"
+export { PathBreadcrumb } from "./PathBreadcrumb"
+export { SearchField } from "./SearchField"
+export { StatusBadge } from "./StatusBadge"
+export { ViewToggle, type ViewMode } from "./ViewToggle"
+export type {
+  BrowserEntry,
+  ColumnDef,
+  EntryIndicator,
+  FileEntry,
+  FolderEntry,
+  LeadingRenderer,
+} from "./types"

--- a/ui2/src/components/file-browser/types.ts
+++ b/ui2/src/components/file-browser/types.ts
@@ -1,0 +1,47 @@
+// Neutral shapes for the file-browser primitives. Any feature (KB, Custom
+// Agents, attachments list, …) maps its own data into these so the grid /
+// list / cards stay completely feature-agnostic.
+
+import type { ReactNode } from "react"
+
+// Small state hint rendered as a corner dot on each entry. Tone maps to a
+// fixed color (pending = yellow, failed = red, ready = green). The label is
+// used for the title attribute + screen readers.
+export type EntryIndicator = {
+  tone: "pending" | "failed" | "ready"
+  label: string
+}
+
+export type FileEntry = {
+  kind: "file"
+  id: string
+  name: string
+  format: string
+  caption?: string
+  columns?: Readonly<Record<string, string>>
+  indicator?: EntryIndicator
+}
+
+export type FolderEntry = {
+  kind: "folder"
+  id: string
+  name: string
+  caption?: string
+  columns?: Readonly<Record<string, string>>
+  indicator?: EntryIndicator
+}
+
+export type BrowserEntry = FileEntry | FolderEntry
+
+export type ColumnDef = {
+  key: string
+  header: string
+  width?: string
+  render?: (entry: BrowserEntry) => ReactNode
+  mdOnly?: boolean
+}
+
+export type LeadingRenderer = (
+  entry: BrowserEntry,
+  size: "sm" | "md",
+) => ReactNode

--- a/ui2/src/components/kb/DraftFolder.tsx
+++ b/ui2/src/components/kb/DraftFolder.tsx
@@ -1,0 +1,82 @@
+// Inline placeholder that takes the visual slot of a normal entry (card in
+// grid view, row in list view) and presents an InlineRenameField for the
+// user to name a new folder. Commits on Enter / blur, cancels on Escape.
+
+import { InlineRenameField } from "@/components/InlineRenameField"
+import { FolderCard, type ColumnDef } from "@/components/file-browser"
+
+type Props = {
+  mode: "grid" | "list"
+  onCommit: (name: string) => void
+  onCancel: () => void
+  // For list view: must match the grid template used by the surrounding
+  // EntryList so the row aligns with the data rows underneath it.
+  listColumns?: ReadonlyArray<ColumnDef>
+}
+
+const DEFAULT_COL_WIDTH = "120px"
+
+export function DraftFolder({
+  mode,
+  onCommit,
+  onCancel,
+  listColumns = [],
+}: Props): JSX.Element {
+  if (mode === "grid") {
+    return (
+      <div className="flex w-full flex-col items-start gap-3 rounded-2xl border border-ring/60 bg-surface-elevated p-4">
+        <div className="pl-1 pt-1">
+          <FolderCard size="md" />
+        </div>
+        <InlineRenameField
+          initial="Untitled folder"
+          placeholder="Untitled folder"
+          onCommit={(next): void => {
+            onCommit(next)
+          }}
+          onCancel={onCancel}
+          className="w-full"
+          inputClassName="h-8 w-full min-w-0 rounded-md border border-border bg-surface px-2 text-[13.5px] font-medium text-foreground focus:border-ring focus:outline-none"
+        />
+      </div>
+    )
+  }
+  const template = [
+    "1fr",
+    ...listColumns.map((c) => c.width ?? DEFAULT_COL_WIDTH),
+  ].join(" ")
+  return (
+    <div
+      className="grid w-full items-center gap-3 bg-secondary/40 px-4 py-2"
+      style={{ gridTemplateColumns: template }}
+    >
+      <span className="flex min-w-0 items-center gap-3">
+        <span className="flex-shrink-0 pr-1">
+          <FolderCard size="sm" />
+        </span>
+        <InlineRenameField
+          initial="Untitled folder"
+          placeholder="Untitled folder"
+          onCommit={(next): void => {
+            onCommit(next)
+          }}
+          onCancel={onCancel}
+          className="flex h-8 min-w-0 flex-1 items-center rounded-md bg-transparent px-1"
+          inputClassName="h-7 w-full min-w-0 flex-1 rounded-md bg-surface px-1.5 text-[13.5px] font-medium text-foreground focus:outline-none focus:ring-2 focus:ring-ring/40"
+        />
+      </span>
+      {listColumns.map((c) => (
+        <span
+          key={`d-${c.key}`}
+          className={
+            c.mdOnly === false
+              ? "text-[12px] text-muted-foreground"
+              : "hidden text-[12px] text-muted-foreground md:block"
+          }
+        >
+          —
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/ui2/src/components/kb/DropZone.tsx
+++ b/ui2/src/components/kb/DropZone.tsx
@@ -1,0 +1,178 @@
+// Drag-and-drop region. Wraps the main scroll area, shows an overlay while
+// something is being dragged over the window, and yields the dropped files
+// to the caller — preserving subfolder structure when the user drops an
+// actual directory (via webkitGetAsEntry).
+
+import { useRef, useState, type ReactNode } from "react"
+import { Upload } from "lucide-react"
+import { cn } from "@/lib/utils"
+import type { IncomingFile } from "@/lib/kb"
+
+type Props = {
+  onDrop: (incoming: ReadonlyArray<IncomingFile>) => void
+  // Caption shown in the overlay (typically the destination path).
+  destinationLabel: string
+  className?: string
+  children: ReactNode
+}
+
+const readDirEntries = (
+  reader: FileSystemDirectoryReader,
+): Promise<FileSystemEntry[]> =>
+  new Promise((resolve, reject) => {
+    const all: FileSystemEntry[] = []
+    const readBatch = (): void => {
+      reader.readEntries(
+        (batch) => {
+          if (batch.length === 0) {
+            resolve(all)
+          } else {
+            all.push(...batch)
+            readBatch()
+          }
+        },
+        (err) => {
+          reject(err instanceof Error ? err : new Error(String(err)))
+        },
+      )
+    }
+    readBatch()
+  })
+
+const fileFromEntry = (entry: FileSystemFileEntry): Promise<File> =>
+  new Promise((resolve, reject) => {
+    entry.file(resolve, (err) => {
+      reject(err instanceof Error ? err : new Error(String(err)))
+    })
+  })
+
+const walkEntry = async (
+  entry: FileSystemEntry,
+  base: string,
+): Promise<IncomingFile[]> => {
+  if (entry.isFile) {
+    const file = await fileFromEntry(entry as FileSystemFileEntry)
+    return [{ file, relativePath: base + entry.name }]
+  }
+  if (entry.isDirectory) {
+    const reader = (entry as FileSystemDirectoryEntry).createReader()
+    const children = await readDirEntries(reader)
+    const all: IncomingFile[] = []
+    for (const child of children) {
+      const sub = await walkEntry(child, `${base}${entry.name}/`)
+      all.push(...sub)
+    }
+    return all
+  }
+  return []
+}
+
+export function DropZone({
+  onDrop,
+  destinationLabel,
+  className,
+  children,
+}: Props): JSX.Element {
+  const [hovering, setHovering] = useState(false)
+  // Child elements bubble dragenter/dragleave events; track depth so the
+  // overlay only hides when the cursor actually leaves the outer container.
+  const depth = useRef(0)
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>): void => {
+    e.preventDefault()
+    depth.current = 0
+    setHovering(false)
+
+    const items = e.dataTransfer.items
+    const fallback = e.dataTransfer.files
+
+    // Prefer the DataTransferItemList path — gives us folder support via
+    // webkitGetAsEntry. Falls back to a flat list of files if unavailable.
+    const entries: FileSystemEntry[] = []
+    if (items.length > 0) {
+      for (let i = 0; i < items.length; i += 1) {
+        const it = items[i]
+        if (!it) continue
+        const entry = it.webkitGetAsEntry()
+        if (entry) {
+          entries.push(entry)
+        }
+      }
+    }
+
+    if (entries.length > 0) {
+      void (async (): Promise<void> => {
+        const all: IncomingFile[] = []
+        for (const e0 of entries) {
+          const sub = await walkEntry(e0, "")
+          all.push(...sub)
+        }
+        if (all.length > 0) {
+          onDrop(all)
+        }
+      })()
+      return
+    }
+
+    // No DataTransferItemList — pull plain Files.
+    const flat: IncomingFile[] = []
+    for (let i = 0; i < fallback.length; i += 1) {
+      const f = fallback.item(i)
+      if (f) {
+        flat.push({ file: f, relativePath: f.name })
+      }
+    }
+    if (flat.length > 0) {
+      onDrop(flat)
+    }
+  }
+
+  return (
+    <div
+      className={cn("relative", className)}
+      onDragEnter={(e): void => {
+        // Only react when the drag actually carries files.
+        if (!e.dataTransfer.types.includes("Files")) {
+          return
+        }
+        depth.current += 1
+        if (!hovering) {
+          setHovering(true)
+        }
+      }}
+      onDragOver={(e): void => {
+        if (!e.dataTransfer.types.includes("Files")) {
+          return
+        }
+        // Must call preventDefault to opt in as a drop target.
+        e.preventDefault()
+        e.dataTransfer.dropEffect = "copy"
+      }}
+      onDragLeave={(): void => {
+        depth.current = Math.max(0, depth.current - 1)
+        if (depth.current === 0) {
+          setHovering(false)
+        }
+      }}
+      onDrop={handleDrop}
+    >
+      {children}
+      {hovering ? (
+        <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-background/70 backdrop-blur-sm">
+          <div className="animate-fade-up flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed border-ring/60 bg-surface-elevated px-6 py-5 text-center shadow-sm">
+            <span className="grid h-10 w-10 place-items-center rounded-2xl bg-secondary text-foreground">
+              <Upload className="h-4 w-4" aria-hidden strokeWidth={1.75} />
+            </span>
+            <p className="text-[13.5px] font-medium text-foreground">
+              Drop to add to{" "}
+              <span className="text-foreground">{destinationLabel}</span>
+            </p>
+            <p className="text-[11.5px] text-muted-foreground">
+              Files and folders are uploaded with their structure preserved.
+            </p>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/ui2/src/components/kb/NewMenu.tsx
+++ b/ui2/src/components/kb/NewMenu.tsx
@@ -1,0 +1,127 @@
+// "+ New" toolbar entry. Owns the hidden file + folder pickers and yields
+// the resulting File lists to the caller; the route decides what to do
+// with them (enqueue uploads into the store, etc.).
+
+import { useEffect, useRef } from "react"
+import { ChevronDown, FolderPlus, FolderUp, Plus, Upload } from "lucide-react"
+import { MenuPopover } from "@/components/MenuPopover"
+import type { IncomingFile } from "@/lib/kb"
+
+type Props = {
+  onNewFolder: () => void
+  onFiles: (incoming: ReadonlyArray<IncomingFile>) => void
+  onFolder: (incoming: ReadonlyArray<IncomingFile>) => void
+}
+
+const toIncoming = (
+  list: FileList | null,
+  useRelative: boolean,
+): IncomingFile[] => {
+  if (!list) {
+    return []
+  }
+  const out: IncomingFile[] = []
+  for (let i = 0; i < list.length; i += 1) {
+    const f = list.item(i)
+    if (!f) {
+      continue
+    }
+    // `webkitRelativePath` is the only way to recover folder structure from
+    // a directory <input>. Plain file pickers leave it as "".
+    const rel = useRelative && f.webkitRelativePath ? f.webkitRelativePath : f.name
+    out.push({ file: f, relativePath: rel })
+  }
+  return out
+}
+
+export function NewMenu({
+  onNewFolder,
+  onFiles,
+  onFolder,
+}: Props): JSX.Element {
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const folderInputRef = useRef<HTMLInputElement | null>(null)
+
+  // `webkitdirectory` is non-standard, set imperatively to keep the JSX
+  // attributes table happy under strict TS.
+  useEffect((): void => {
+    const el = folderInputRef.current
+    if (!el) {
+      return
+    }
+    el.setAttribute("webkitdirectory", "")
+    el.setAttribute("directory", "")
+  }, [])
+
+  return (
+    <>
+      <MenuPopover
+        align="right"
+        trigger={({ open, toggle }): JSX.Element => (
+          <button
+            type="button"
+            onClick={toggle}
+            aria-haspopup="menu"
+            aria-expanded={open}
+            className={
+              "inline-flex h-8 items-center gap-1.5 rounded-full border border-border bg-surface-elevated px-3 text-[12.5px] font-medium text-foreground transition hover:bg-secondary/60 " +
+              (open ? "bg-secondary/60" : "")
+            }
+          >
+            <Plus className="h-3.5 w-3.5" aria-hidden strokeWidth={2} />
+            <span>New</span>
+            <ChevronDown className="h-3 w-3 opacity-60" aria-hidden strokeWidth={2} />
+          </button>
+        )}
+        items={[
+          {
+            icon: FolderPlus,
+            label: "New folder",
+            onClick: onNewFolder,
+          },
+          {
+            icon: Upload,
+            label: "Upload files",
+            onClick: (): void => {
+              fileInputRef.current?.click()
+            },
+          },
+          {
+            icon: FolderUp,
+            label: "Upload folder",
+            onClick: (): void => {
+              folderInputRef.current?.click()
+            },
+          },
+        ]}
+      />
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        hidden
+        onChange={(e): void => {
+          const incoming = toIncoming(e.target.files, false)
+          // Reset so picking the same file twice re-fires the change event.
+          e.target.value = ""
+          if (incoming.length > 0) {
+            onFiles(incoming)
+          }
+        }}
+      />
+      <input
+        ref={folderInputRef}
+        type="file"
+        multiple
+        hidden
+        onChange={(e): void => {
+          const incoming = toIncoming(e.target.files, true)
+          e.target.value = ""
+          if (incoming.length > 0) {
+            onFolder(incoming)
+          }
+        }}
+      />
+    </>
+  )
+}

--- a/ui2/src/components/kb/UploadTray.tsx
+++ b/ui2/src/components/kb/UploadTray.tsx
@@ -1,0 +1,127 @@
+// Bottom-right tray that surfaces in-flight uploads and their ingestion
+// progress. Subscribes to the kb store; collapses to a compact pill when
+// nothing is happening.
+
+import { useState } from "react"
+import { Check, ChevronDown, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { formatBytes } from "@/lib/files"
+import { cancelUpload, useKbUploads, type UploadJob } from "@/lib/kb"
+
+const stageLabel = (j: UploadJob): string => {
+  switch (j.stage) {
+    case "uploading":
+      return `Uploading… ${String(Math.round(j.progress))}%`
+    case "queued":
+      return "Queued"
+    case "parsing":
+      return "Parsing"
+    case "embedding":
+      return "Indexing"
+    case "ready":
+      return "Indexed"
+    case "failed":
+      return j.error ?? "Failed"
+  }
+}
+
+export function UploadTray(): JSX.Element | null {
+  const jobs = useKbUploads()
+  const [collapsed, setCollapsed] = useState(false)
+
+  if (jobs.length === 0) {
+    return null
+  }
+
+  const active = jobs.filter(
+    (j) => j.stage !== "ready" && j.stage !== "failed",
+  ).length
+  const summary =
+    active > 0
+      ? `Uploading ${String(active)} of ${String(jobs.length)}`
+      : `${String(jobs.length)} upload${jobs.length === 1 ? "" : "s"}`
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="animate-fade-up fixed bottom-4 right-4 z-30 w-[320px] max-w-[calc(100vw-2rem)] overflow-hidden rounded-2xl border border-border bg-surface-elevated shadow-lg shadow-foreground/[0.08]"
+    >
+      <button
+        type="button"
+        onClick={(): void => {
+          setCollapsed((c) => !c)
+        }}
+        className="flex w-full items-center justify-between gap-2 border-b border-border bg-surface-muted/60 px-3 py-2 text-[12.5px] font-medium text-foreground hover:bg-secondary/60"
+        aria-expanded={!collapsed}
+      >
+        <span>{summary}</span>
+        <ChevronDown
+          className={cn(
+            "h-3.5 w-3.5 text-muted-foreground transition",
+            collapsed ? "" : "rotate-180",
+          )}
+          aria-hidden
+          strokeWidth={1.75}
+        />
+      </button>
+      {!collapsed ? (
+        <ul className="max-h-[260px] overflow-y-auto">
+          {jobs.map((j) => (
+            <li
+              key={j.id}
+              className="flex items-center gap-2 border-b border-border/60 px-3 py-2 last:border-b-0"
+            >
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[12.5px] font-medium text-foreground">
+                  {j.fileName}
+                </span>
+                <span className="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                  <span>{formatBytes(j.sizeBytes)}</span>
+                  <span aria-hidden>·</span>
+                  <span
+                    className={cn(
+                      j.stage === "failed" && "text-destructive",
+                      j.stage === "ready" && "text-emerald-600 dark:text-emerald-500",
+                    )}
+                  >
+                    {stageLabel(j)}
+                  </span>
+                </span>
+                {j.stage === "uploading" ? (
+                  <span className="mt-1.5 block h-1 w-full overflow-hidden rounded-full bg-secondary">
+                    <span
+                      className="block h-full rounded-full bg-foreground/70 transition-[width]"
+                      style={{ width: `${String(j.progress)}%` }}
+                    />
+                  </span>
+                ) : null}
+              </span>
+              {j.stage === "ready" ? (
+                <Check
+                  className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-500"
+                  aria-hidden
+                  strokeWidth={2.25}
+                />
+              ) : (
+                <button
+                  type="button"
+                  aria-label={
+                    j.stage === "failed" ? "Dismiss" : "Cancel upload"
+                  }
+                  title={j.stage === "failed" ? "Dismiss" : "Cancel"}
+                  onClick={(): void => {
+                    cancelUpload(j.id)
+                  }}
+                  className="grid h-6 w-6 place-items-center rounded-md text-muted-foreground transition hover:bg-secondary hover:text-foreground"
+                >
+                  <X className="h-3 w-3" aria-hidden strokeWidth={2} />
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  )
+}

--- a/ui2/src/hooks/useChatHistory.ts
+++ b/ui2/src/hooks/useChatHistory.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react"
+import { useLocation, useNavigate } from "@tanstack/react-router"
+import {
+  chatStore,
+  useConversationList,
+  type Conversation,
+} from "@/lib/chat-store"
+
+// Bundles every wiring the sidebar's chat history needs: the live list, the
+// in-flight load flag, the active-route detection from the URL, and the four
+// callbacks (create / select / rename / delete). The return shape lines up
+// with Sidebar's chat-related props so the route can spread it directly.
+type Result = {
+  chats: Conversation[]
+  activeChatId: string | undefined
+  chatsLoading: boolean
+  onCreateChat: () => void
+  onSelectChat: (id: string) => void
+  onRenameChat: (id: string, title: string) => Promise<void>
+  onDeleteChat: (id: string) => Promise<void>
+}
+
+export function useChatHistory(): Result {
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+  const chats = useConversationList()
+  const [listLoaded, setListLoaded] = useState(false)
+  const activeChatId = pathname.match(/^\/c\/([^/?#]+)/)?.[1]
+
+  useEffect((): (() => void) => {
+    let cancelled = false
+    void chatStore.loadList().finally((): void => {
+      if (!cancelled) setListLoaded(true)
+    })
+    return (): void => {
+      cancelled = true
+    }
+  }, [])
+
+  return {
+    chats,
+    activeChatId,
+    chatsLoading: !listLoaded,
+    onCreateChat: (): void => {
+      void navigate({ to: "/" })
+    },
+    onSelectChat: (id: string): void => {
+      void navigate({ to: "/c/$chatId", params: { chatId: id } })
+    },
+    onRenameChat: (id: string, title: string): Promise<void> =>
+      chatStore.renameConv(id, title),
+    onDeleteChat: async (id: string): Promise<void> => {
+      await chatStore.deleteConv(id)
+      if (id === activeChatId) {
+        void navigate({ to: "/" })
+      }
+    },
+  }
+}

--- a/ui2/src/hooks/useInlineEdit.ts
+++ b/ui2/src/hooks/useInlineEdit.ts
@@ -1,0 +1,61 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react"
+
+// Single-line inline editable field state machine. Commits on Enter / blur,
+// cancels on Escape. Auto-focuses + selects on mount. `commit` and `cancel`
+// are guarded by a `doneRef` so a sequence like Enter → blur fires only once.
+type Args = {
+  initial: string
+  onCommit: (next: string) => void | Promise<void>
+  onCancel: () => void
+}
+
+type Result = {
+  value: string
+  setValue: (next: string) => void
+  inputRef: React.RefObject<HTMLInputElement | null>
+  onKeyDown: (e: ReactKeyboardEvent<HTMLInputElement>) => void
+  onBlur: () => void
+}
+
+export function useInlineEdit({ initial, onCommit, onCancel }: Args): Result {
+  const [value, setValue] = useState(initial)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const doneRef = useRef(false)
+
+  useEffect((): void => {
+    inputRef.current?.focus()
+    inputRef.current?.select()
+  }, [])
+
+  const commit = (): void => {
+    if (doneRef.current) return
+    doneRef.current = true
+    void onCommit(value.trim())
+  }
+  const cancel = (): void => {
+    if (doneRef.current) return
+    doneRef.current = true
+    onCancel()
+  }
+
+  return {
+    value,
+    setValue,
+    inputRef,
+    onKeyDown: (e): void => {
+      if (e.key === "Enter") {
+        e.preventDefault()
+        commit()
+      } else if (e.key === "Escape") {
+        e.preventDefault()
+        cancel()
+      }
+    },
+    onBlur: commit,
+  }
+}

--- a/ui2/src/hooks/useSidebarCollapse.ts
+++ b/ui2/src/hooks/useSidebarCollapse.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from "react"
+
+// Persistent sidebar collapse state + ⌘\ / Ctrl+\ shortcut to toggle.
+// State is sticky across reloads via localStorage.
+
+const STORAGE_KEY = "ui2.sidebarCollapsed"
+
+function readInitial(): boolean {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "true"
+  } catch {
+    return false
+  }
+}
+
+type Result = {
+  collapsed: boolean
+  toggle: () => void
+}
+
+export function useSidebarCollapse(): Result {
+  const [collapsed, setCollapsed] = useState<boolean>(readInitial)
+
+  const toggle = useCallback((): void => {
+    setCollapsed((prev): boolean => {
+      const next = !prev
+      try {
+        window.localStorage.setItem(STORAGE_KEY, String(next))
+      } catch {
+        // ignore
+      }
+      return next
+    })
+  }, [])
+
+  useEffect((): (() => void) => {
+    const onKey = (e: globalThis.KeyboardEvent): void => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "\\") {
+        e.preventDefault()
+        toggle()
+      }
+    }
+    window.addEventListener("keydown", onKey)
+    return (): void => {
+      window.removeEventListener("keydown", onKey)
+    }
+  }, [toggle])
+
+  return { collapsed, toggle }
+}

--- a/ui2/src/hooks/useSidebarMobile.ts
+++ b/ui2/src/hooks/useSidebarMobile.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react"
+
+// Shared signal so the Topbar (hamburger) and Sidebar (drawer) can coordinate
+// without threading state through every route.
+
+let current = false
+const listeners = new Set<(next: boolean) => void>()
+
+const set = (next: boolean): void => {
+  current = next
+  for (const l of listeners) {
+    l(next)
+  }
+}
+
+type Result = {
+  open: boolean
+  setOpen: (next: boolean) => void
+}
+
+export function useSidebarMobile(): Result {
+  const [open, setLocal] = useState<boolean>(current)
+  useEffect((): (() => void) => {
+    listeners.add(setLocal)
+    return (): void => {
+      listeners.delete(setLocal)
+    }
+  }, [])
+  return { open, setOpen: set }
+}

--- a/ui2/src/hooks/useSidebarSearch.ts
+++ b/ui2/src/hooks/useSidebarSearch.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+// Manages the sidebar's "find conversations" input — value, ref, and the
+// "focus the input now, or expand the sidebar first then focus" behavior used
+// by both ⌘K and the collapsed-state search icon.
+//
+// The 320ms delay matches the sidebar's width transition; we wait for the
+// input to be in its expanded position before focusing.
+const EXPAND_TRANSITION_MS = 320
+
+type Args = {
+  collapsed: boolean
+  expand: () => void
+}
+
+type Result = {
+  query: string
+  setQuery: (next: string) => void
+  searchRef: React.RefObject<HTMLInputElement | null>
+  focusSearch: () => void
+}
+
+export function useSidebarSearch({ collapsed, expand }: Args): Result {
+  const [query, setQuery] = useState("")
+  const searchRef = useRef<HTMLInputElement | null>(null)
+  const [pendingFocus, setPendingFocus] = useState(false)
+
+  const focusSearch = useCallback((): void => {
+    if (collapsed) {
+      // Will focus once expand animation finishes (see effect below).
+      setPendingFocus(true)
+      expand()
+    } else {
+      searchRef.current?.focus()
+      searchRef.current?.select()
+    }
+  }, [collapsed, expand])
+
+  // Drain `pendingFocus` once the sidebar has finished expanding.
+  useEffect((): (() => void) | undefined => {
+    if (collapsed || !pendingFocus) return undefined
+    const t = window.setTimeout((): void => {
+      searchRef.current?.focus()
+      searchRef.current?.select()
+      setPendingFocus(false)
+    }, EXPAND_TRANSITION_MS)
+    return (): void => {
+      window.clearTimeout(t)
+    }
+  }, [collapsed, pendingFocus])
+
+  // ⌘K / Ctrl+K focuses the search field (expanding the sidebar first if
+  // it's collapsed). Universal pattern matching Slack/Linear/GitHub.
+  useEffect((): (() => void) => {
+    const onKey = (e: globalThis.KeyboardEvent): void => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault()
+        focusSearch()
+      }
+    }
+    window.addEventListener("keydown", onKey)
+    return (): void => {
+      window.removeEventListener("keydown", onKey)
+    }
+  }, [focusSearch])
+
+  return { query, setQuery, searchRef, focusSearch }
+}

--- a/ui2/src/lib/chat-store.ts
+++ b/ui2/src/lib/chat-store.ts
@@ -605,6 +605,40 @@ export const chatStore = {
       return out
     })
   },
+
+  async renameConv(convId: string, title: string): Promise<void> {
+    const trimmed = title.trim()
+    if (!trimmed) {
+      throw new Error("title required")
+    }
+    await apiFetch<{ ok: true }>(`/v2/chat/conversations/${convId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ title: trimmed }),
+    })
+    updateConv(convId, (p) => ({ ...p, title: trimmed }))
+    const idx = convList.findIndex((c) => c.id === convId)
+    if (idx >= 0) {
+      const existing = convList[idx]
+      if (existing) {
+        const next = convList.slice()
+        next[idx] = { ...existing, title: trimmed, updatedAt: Date.now() }
+        convList = next
+        notifyList()
+      }
+    }
+  },
+
+  async deleteConv(convId: string): Promise<void> {
+    // If a stream is open, close it before the row vanishes.
+    closeStream(convId)
+    await apiFetch<{ ok: true }>(`/v2/chat/conversations/${convId}`, {
+      method: "DELETE",
+    })
+    convList = convList.filter((c) => c.id !== convId)
+    convs.delete(convId)
+    notifyList()
+    notifyConv(convId)
+  },
 }
 
 // ─── React hooks ────────────────────────────────────────────────────────────

--- a/ui2/src/lib/files.ts
+++ b/ui2/src/lib/files.ts
@@ -1,0 +1,49 @@
+// Neutral file-related formatters. Used by feature data layers to prepare
+// caption / column text for the file-browser primitives.
+
+export const formatBytes = (n: number): string => {
+  if (n < 1024) {
+    return `${String(n)} B`
+  }
+  if (n < 1024 * 1024) {
+    return `${(n / 1024).toFixed(0)} KB`
+  }
+  if (n < 1024 * 1024 * 1024) {
+    return `${(n / (1024 * 1024)).toFixed(1)} MB`
+  }
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`
+}
+
+export const formatDate = (iso: string): string => {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) {
+    return iso
+  }
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+// Pull the lowercase file extension from a path or filename. Returns "" if
+// the basename has no extension.
+export const extOf = (pathOrName: string): string => {
+  const slash = pathOrName.lastIndexOf("/")
+  const base = slash >= 0 ? pathOrName.slice(slash + 1) : pathOrName
+  const dot = base.lastIndexOf(".")
+  return dot > 0 ? base.slice(dot + 1).toLowerCase() : ""
+}
+
+// Strip the extension off a basename (for display). Keeps things untouched
+// if there's no dot.
+export const stripExt = (name: string): string => {
+  const dot = name.lastIndexOf(".")
+  return dot > 0 ? name.slice(0, dot) : name
+}
+
+// Slash-delimited path helpers shared between the data layer and any
+// breadcrumb-like primitive. Empty string → empty segments.
+export const splitPath = (p: string): string[] =>
+  p === "" ? [] : p.split("/")
+export const joinPath = (segs: ReadonlyArray<string>): string => segs.join("/")

--- a/ui2/src/lib/kb.ts
+++ b/ui2/src/lib/kb.ts
@@ -1,0 +1,612 @@
+// Knowledge-base in-memory store.
+//
+// Holds folders, files, and in-flight uploads with subscription-based change
+// notification (useSyncExternalStore). All mutations are local — backend
+// wiring lands in a later phase. The mock upload simulator drives every file
+// through queued → uploading → parsing → embedding → ready (or failed) so
+// the UI can be tested end-to-end without a server.
+
+import { useSyncExternalStore } from "react"
+import type {
+  BrowserEntry,
+  FileEntry,
+  FolderEntry,
+} from "@/components/file-browser"
+import { extOf, formatBytes, formatDate, stripExt } from "@/lib/files"
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export type FileStatus = "pending" | "ready" | "failed"
+
+type StoredFile = {
+  id: string
+  // Full path including filename ("Reports/Annual Reports/2024.pdf")
+  path: string
+  sizeBytes: number
+  ingestedAt: string
+  status: FileStatus
+  error?: string
+}
+
+type StoredFolder = {
+  // Full path ("Reports/Annual Reports") — root folder is never stored
+  // explicitly; an empty path means "root" and is implicit.
+  path: string
+  createdAt: string
+}
+
+export type UploadStage =
+  | "queued"
+  | "uploading"
+  | "parsing"
+  | "embedding"
+  | "ready"
+  | "failed"
+
+export type UploadJob = {
+  id: string
+  // Display name (basename, no folders)
+  fileName: string
+  // Destination folder path (no trailing slash; "" for root)
+  parentPath: string
+  // Full path the file will live at
+  destinationPath: string
+  sizeBytes: number
+  stage: UploadStage
+  // 0–100 during "uploading", clamped at 100 for later stages
+  progress: number
+  error?: string
+  // Id of the StoredFile that mirrors this job (so we can update status)
+  fileId: string
+}
+
+// ─── Seed ───────────────────────────────────────────────────────────────────
+
+type RawFile = {
+  path: string
+  sizeBytes: number
+  ingestedAt: string
+}
+
+const MOCK_FILES: ReadonlyArray<RawFile> = [
+  // SEBI Enforcements
+  {
+    path: "Enforcements/Recovery Proceedings/2026-02-12_release-order-recovery-certificate-no-rc422-of-2014-against-ahilya-commercial-pv.pdf",
+    sizeBytes: 412_318,
+    ingestedAt: "2026-02-12",
+  },
+  {
+    path: "Enforcements/Recovery Proceedings/2026-02-12_release-order-recovery-certificate-no-rc737-of-2015-against-ahilya-commercial-pv.pdf",
+    sizeBytes: 388_204,
+    ingestedAt: "2026-02-12",
+  },
+  {
+    path: "Enforcements/Recovery Proceedings/2025-12-30_completion-of-recovery-certificate-no-rc738-of-2015-against-ahilya-commercial-pv.pdf",
+    sizeBytes: 410_990,
+    ingestedAt: "2025-12-30",
+  },
+  {
+    path: "Enforcements/Recovery Proceedings/2024-06-27_certificate-no-rc7864-of-2024-notice-of-demand.pdf",
+    sizeBytes: 521_233,
+    ingestedAt: "2024-06-27",
+  },
+  {
+    path: "Enforcements/Recovery Proceedings/2024-03-20_notice-of-demand-dated-20-03-2024.pdf",
+    sizeBytes: 364_122,
+    ingestedAt: "2024-03-20",
+  },
+  {
+    path: "Enforcements/Orders/Orders of AA under the RTI Act/2024-09-03_appeal-no-6108-of-2024-virendra-sharma.pdf",
+    sizeBytes: 222_440,
+    ingestedAt: "2024-09-03",
+  },
+  {
+    path: "Enforcements/Orders/Orders of AA under the RTI Act/2025-12-22_appeal-no-6635-of-2025-madhup-sharma.pdf",
+    sizeBytes: 218_330,
+    ingestedAt: "2025-12-22",
+  },
+  {
+    path: "Enforcements/Orders/Orders of Chairperson or Members/2024-02-16_order-non-compliance-alt-investment-funds.pdf",
+    sizeBytes: 1_205_440,
+    ingestedAt: "2024-02-16",
+  },
+  {
+    path: "Enforcements/Unserved Summons or Notices/2024-01-17_unserved-hearing-notice-arjun-sharma.pdf",
+    sizeBytes: 188_400,
+    ingestedAt: "2024-01-17",
+  },
+
+  // Filings
+  {
+    path: "Filings/Public Issues/Draft Offer Documents filed with SEBI/2025-02-04_prostarm-info-systems-addendum-to-drhp.pdf",
+    sizeBytes: 4_120_220,
+    ingestedAt: "2025-02-04",
+  },
+  {
+    path: "Filings/Public Issues/Draft Offer Documents filed with SEBI/2026-01-05_HORIZON-INDUSTRIAL-PARKS-DRHP.pdf",
+    sizeBytes: 8_843_120,
+    ingestedAt: "2026-01-05",
+  },
+
+  // Reports
+  {
+    path: "Reports/Annual Reports/2024-annual-report.pdf",
+    sizeBytes: 12_344_200,
+    ingestedAt: "2024-09-30",
+  },
+  {
+    path: "Reports/Annual Reports/2025-annual-report.pdf",
+    sizeBytes: 13_120_980,
+    ingestedAt: "2025-09-30",
+  },
+  {
+    path: "Reports/Annual Reports/2025-annual-financials.xlsx",
+    sizeBytes: 1_904_220,
+    ingestedAt: "2025-09-30",
+  },
+  {
+    path: "Reports/Quarterly Bulletins/2025-Q4-bulletin.pdf",
+    sizeBytes: 2_204_330,
+    ingestedAt: "2025-12-15",
+  },
+  {
+    path: "Reports/Investor Decks/2025-investor-presentation.pptx",
+    sizeBytes: 8_120_300,
+    ingestedAt: "2025-11-10",
+  },
+  {
+    path: "Reports/Datasets/recovery-proceedings-register.csv",
+    sizeBytes: 442_100,
+    ingestedAt: "2026-03-01",
+  },
+
+  // Circulars
+  {
+    path: "Circulars/2025-11-04_master-circular-mutual-funds.pdf",
+    sizeBytes: 980_220,
+    ingestedAt: "2025-11-04",
+  },
+  {
+    path: "Circulars/2026-03-18_circular-on-disclosure-requirements.pdf",
+    sizeBytes: 712_140,
+    ingestedAt: "2026-03-18",
+  },
+  {
+    path: "Circulars/release-notes-2026-Q1.md",
+    sizeBytes: 18_320,
+    ingestedAt: "2026-04-02",
+  },
+  {
+    path: "Circulars/supporting-data/aif-non-compliance.json",
+    sizeBytes: 64_220,
+    ingestedAt: "2026-03-15",
+  },
+]
+
+// ─── Mutable store ──────────────────────────────────────────────────────────
+
+const files = new Map<string, StoredFile>()
+const folders = new Map<string, StoredFolder>()
+const uploads = new Map<string, UploadJob>()
+const listeners = new Set<() => void>()
+let rev = 0
+
+const bump = (): void => {
+  rev += 1
+  for (const fn of listeners) {
+    fn()
+  }
+}
+
+const subscribe = (fn: () => void): (() => void) => {
+  listeners.add(fn)
+  return () => {
+    listeners.delete(fn)
+  }
+}
+
+const getRev = (): number => rev
+
+const newId = (): string =>
+  globalThis.crypto?.randomUUID?.() ??
+  `id-${String(Math.random()).slice(2)}-${String(Date.now())}`
+
+// Seed: every starter file ships as `ready`; intermediate folders are derived
+// from file paths so the seed stays compact.
+const splitParentAndName = (
+  fullPath: string,
+): { parent: string; name: string } => {
+  const slash = fullPath.lastIndexOf("/")
+  if (slash < 0) {
+    return { parent: "", name: fullPath }
+  }
+  return { parent: fullPath.slice(0, slash), name: fullPath.slice(slash + 1) }
+}
+
+const ensureFolderChain = (folderPath: string): void => {
+  if (folderPath === "") {
+    return
+  }
+  const segs = folderPath.split("/")
+  for (let i = 0; i < segs.length; i += 1) {
+    const here = segs.slice(0, i + 1).join("/")
+    if (!folders.has(here)) {
+      folders.set(here, { path: here, createdAt: new Date().toISOString() })
+    }
+  }
+}
+
+const seed = (): void => {
+  for (const raw of MOCK_FILES) {
+    const { parent } = splitParentAndName(raw.path)
+    ensureFolderChain(parent)
+    const id = newId()
+    files.set(id, {
+      id,
+      path: raw.path,
+      sizeBytes: raw.sizeBytes,
+      ingestedAt: raw.ingestedAt,
+      status: "ready",
+    })
+  }
+}
+seed()
+
+// ─── Lookup helpers ─────────────────────────────────────────────────────────
+
+const parentOfFolder = (folderPath: string): string => {
+  const slash = folderPath.lastIndexOf("/")
+  return slash < 0 ? "" : folderPath.slice(0, slash)
+}
+
+const childFolders = (folderPath: string): StoredFolder[] => {
+  const out: StoredFolder[] = []
+  for (const f of folders.values()) {
+    if (parentOfFolder(f.path) === folderPath) {
+      out.push(f)
+    }
+  }
+  return out
+}
+
+const filesInFolder = (folderPath: string): StoredFile[] => {
+  const out: StoredFile[] = []
+  for (const f of files.values()) {
+    const parent = splitParentAndName(f.path).parent
+    if (parent === folderPath) {
+      out.push(f)
+    }
+  }
+  return out
+}
+
+const folderCounts = (
+  folderPath: string,
+): { folderCount: number; fileCount: number } => {
+  let folderCount = 0
+  let fileCount = 0
+  for (const f of folders.values()) {
+    if (parentOfFolder(f.path) === folderPath) {
+      folderCount += 1
+    }
+  }
+  for (const f of files.values()) {
+    if (splitParentAndName(f.path).parent === folderPath) {
+      fileCount += 1
+    }
+  }
+  return { folderCount, fileCount }
+}
+
+// ─── Entry projection ───────────────────────────────────────────────────────
+
+const folderToEntry = (f: StoredFolder): FolderEntry => {
+  const { folderCount, fileCount } = folderCounts(f.path)
+  const total = folderCount + fileCount
+  const parts: string[] = []
+  if (folderCount > 0) {
+    parts.push(`${String(folderCount)} folder${folderCount === 1 ? "" : "s"}`)
+  }
+  if (fileCount > 0) {
+    parts.push(`${String(fileCount)} file${fileCount === 1 ? "" : "s"}`)
+  }
+  const caption = parts.length === 0 ? "Empty" : parts.join(" · ")
+  const { name } = splitParentAndName(f.path)
+  return {
+    kind: "folder",
+    id: f.path,
+    name,
+    caption,
+    columns: {
+      kind: "Folder",
+      size:
+        total === 0
+          ? "Empty"
+          : `${String(total)} item${total === 1 ? "" : "s"}`,
+      updated: formatDate(f.createdAt),
+    },
+  }
+}
+
+const fileToEntry = (f: StoredFile): FileEntry => {
+  const name = stripExt(splitParentAndName(f.path).name)
+  const ext = extOf(f.path)
+  const entry: FileEntry = {
+    kind: "file",
+    id: f.id,
+    name,
+    format: ext || "txt",
+    caption: `${ext.toUpperCase() || "FILE"} · ${formatBytes(f.sizeBytes)} · ${formatDate(f.ingestedAt)}`,
+    columns: {
+      kind: ext.toUpperCase() || "File",
+      size: formatBytes(f.sizeBytes),
+      updated: formatDate(f.ingestedAt),
+    },
+  }
+  if (f.status === "pending") {
+    entry.indicator = { tone: "pending", label: "Indexing…" }
+  } else if (f.status === "failed") {
+    entry.indicator = {
+      tone: "failed",
+      label: f.error ?? "Ingestion failed",
+    }
+  }
+  return entry
+}
+
+// ─── Read API ───────────────────────────────────────────────────────────────
+
+export const listEntries = (
+  folderPath: string,
+): ReadonlyArray<BrowserEntry> => {
+  const folderEntries = childFolders(folderPath)
+    .slice()
+    .sort((a, b) => a.path.localeCompare(b.path))
+    .map(folderToEntry)
+  const fileEntries = filesInFolder(folderPath)
+    .slice()
+    .sort((a, b) => b.ingestedAt.localeCompare(a.ingestedAt))
+    .map(fileToEntry)
+  return [...folderEntries, ...fileEntries]
+}
+
+export const searchFiles = (
+  folderPath: string,
+  query: string,
+  limit = 50,
+): ReadonlyArray<BrowserEntry> => {
+  const q = query.trim().toLowerCase()
+  if (!q) {
+    return []
+  }
+  const scope = folderPath === "" ? "" : `${folderPath}/`
+  const hits: FileEntry[] = []
+  for (const f of files.values()) {
+    if (scope !== "" && !f.path.startsWith(scope)) {
+      continue
+    }
+    if (f.path.toLowerCase().includes(q)) {
+      hits.push(fileToEntry(f))
+      if (hits.length >= limit) {
+        break
+      }
+    }
+  }
+  return hits
+}
+
+export const listUploads = (): ReadonlyArray<UploadJob> => {
+  // Newest first — feels right for a tray.
+  return Array.from(uploads.values()).sort((a, b) =>
+    b.id.localeCompare(a.id),
+  )
+}
+
+// ─── Write API ──────────────────────────────────────────────────────────────
+
+const uniqueFolderName = (parent: string, base: string): string => {
+  const taken = new Set<string>()
+  for (const f of folders.values()) {
+    if (parentOfFolder(f.path) === parent) {
+      taken.add(splitParentAndName(f.path).name)
+    }
+  }
+  if (!taken.has(base)) {
+    return base
+  }
+  for (let i = 2; i < 1000; i += 1) {
+    const candidate = `${base} (${String(i)})`
+    if (!taken.has(candidate)) {
+      return candidate
+    }
+  }
+  return `${base} (${String(Date.now())})`
+}
+
+const uniqueFileName = (parent: string, base: string): string => {
+  const taken = new Set<string>()
+  for (const f of files.values()) {
+    if (splitParentAndName(f.path).parent === parent) {
+      taken.add(splitParentAndName(f.path).name)
+    }
+  }
+  if (!taken.has(base)) {
+    return base
+  }
+  const dot = base.lastIndexOf(".")
+  const stem = dot > 0 ? base.slice(0, dot) : base
+  const ext = dot > 0 ? base.slice(dot) : ""
+  for (let i = 2; i < 1000; i += 1) {
+    const candidate = `${stem} (${String(i)})${ext}`
+    if (!taken.has(candidate)) {
+      return candidate
+    }
+  }
+  return `${stem} (${String(Date.now())})${ext}`
+}
+
+export const createFolder = (parent: string, rawName: string): string => {
+  const trimmed = rawName.trim() || "Untitled folder"
+  const name = uniqueFolderName(parent, trimmed)
+  const path = parent === "" ? name : `${parent}/${name}`
+  folders.set(path, { path, createdAt: new Date().toISOString() })
+  bump()
+  return path
+}
+
+// File the user dropped or picked. The optional relativePath preserves
+// subfolder structure when a directory was selected.
+export type IncomingFile = {
+  file: File
+  // "subdir/file.pdf" or just "file.pdf"
+  relativePath: string
+}
+
+const startMockProgression = (jobId: string): void => {
+  // Phase 1: uploading 0 → 100 over ~1.4s. Phase 2: parsing. Phase 3:
+  // embedding. Phase 4: ready or failed. All driven by setTimeout chains so
+  // we don't need real network code for the demo.
+  const tickMs = 120
+  const stepMs = 700
+  const upTick = (): void => {
+    const j = uploads.get(jobId)
+    if (!j || j.stage !== "uploading") {
+      return
+    }
+    const next = Math.min(100, j.progress + 8 + Math.random() * 14)
+    j.progress = next
+    bump()
+    if (next < 100) {
+      setTimeout(upTick, tickMs)
+    } else {
+      j.stage = "parsing"
+      bump()
+      setTimeout(toEmbedding, stepMs)
+    }
+  }
+  const toEmbedding = (): void => {
+    const j = uploads.get(jobId)
+    if (!j || j.stage !== "parsing") {
+      return
+    }
+    j.stage = "embedding"
+    bump()
+    setTimeout(toReady, stepMs)
+  }
+  const toReady = (): void => {
+    const j = uploads.get(jobId)
+    if (!j || j.stage !== "embedding") {
+      return
+    }
+    // Deterministic failure hook for demos: any filename containing "fail"
+    // (case-insensitive) ends in the failed state. Everything else succeeds.
+    const wantsFail = j.fileName.toLowerCase().includes("fail")
+    const stored = files.get(j.fileId)
+    if (wantsFail) {
+      j.stage = "failed"
+      j.error = "Unsupported format"
+      if (stored) {
+        stored.status = "failed"
+        stored.error = "Unsupported format"
+      }
+    } else {
+      j.stage = "ready"
+      if (stored) {
+        stored.status = "ready"
+      }
+    }
+    bump()
+    // Auto-dismiss successful uploads after a brief moment so the tray stays
+    // lean — failed ones persist until the user dismisses them.
+    if (j.stage === "ready") {
+      setTimeout((): void => {
+        uploads.delete(jobId)
+        bump()
+      }, 2500)
+    }
+  }
+  setTimeout(upTick, tickMs)
+}
+
+export const enqueueUploads = (
+  parentPath: string,
+  incoming: ReadonlyArray<IncomingFile>,
+): ReadonlyArray<string> => {
+  const jobIds: string[] = []
+  for (const item of incoming) {
+    const { relativePath, file } = item
+    const segs = relativePath.split("/").filter(Boolean)
+    if (segs.length === 0) {
+      continue
+    }
+    const baseName = segs[segs.length - 1] as string
+    const subParent = segs.slice(0, -1).join("/")
+    const destParent = [parentPath, subParent].filter(Boolean).join("/")
+    ensureFolderChain(destParent)
+    const uniqueName = uniqueFileName(destParent, baseName)
+    const destPath =
+      destParent === "" ? uniqueName : `${destParent}/${uniqueName}`
+    const fileId = newId()
+    files.set(fileId, {
+      id: fileId,
+      path: destPath,
+      sizeBytes: file.size,
+      ingestedAt: new Date().toISOString(),
+      status: "pending",
+    })
+    const jobId = newId()
+    uploads.set(jobId, {
+      id: jobId,
+      fileName: uniqueName,
+      parentPath: destParent,
+      destinationPath: destPath,
+      sizeBytes: file.size,
+      stage: "uploading",
+      progress: 0,
+      fileId,
+    })
+    jobIds.push(jobId)
+    startMockProgression(jobId)
+  }
+  bump()
+  return jobIds
+}
+
+export const cancelUpload = (jobId: string): void => {
+  const j = uploads.get(jobId)
+  if (!j) {
+    return
+  }
+  // Cancel during in-flight stages removes both the job and the staged file.
+  // Cancel on a terminal stage just dismisses the tray entry.
+  if (j.stage === "uploading" || j.stage === "parsing" || j.stage === "embedding") {
+    files.delete(j.fileId)
+  }
+  uploads.delete(jobId)
+  bump()
+}
+
+// ─── React hooks ────────────────────────────────────────────────────────────
+
+// useSyncExternalStore gates re-renders to revisions of the store; the
+// projection (listEntries / searchFiles / listUploads) is fast enough to
+// just recompute each time the gated render fires.
+export const useKbEntries = (
+  folderPath: string,
+): ReadonlyArray<BrowserEntry> => {
+  useSyncExternalStore(subscribe, getRev, getRev)
+  return listEntries(folderPath)
+}
+
+export const useKbSearch = (
+  folderPath: string,
+  query: string,
+): ReadonlyArray<BrowserEntry> => {
+  useSyncExternalStore(subscribe, getRev, getRev)
+  return searchFiles(folderPath, query)
+}
+
+export const useKbUploads = (): ReadonlyArray<UploadJob> => {
+  useSyncExternalStore(subscribe, getRev, getRev)
+  return listUploads()
+}

--- a/ui2/src/lib/utils.ts
+++ b/ui2/src/lib/utils.ts
@@ -1,0 +1,5 @@
+// Tiny class-name joiner. Filters out falsy values so callers can pass
+// conditional expressions inline (e.g. `cn("a", flag && "b")`).
+export const cn = (
+  ...parts: Array<string | false | null | undefined>
+): string => parts.filter(Boolean).join(" ")

--- a/ui2/src/routes/_authenticated.tsx
+++ b/ui2/src/routes/_authenticated.tsx
@@ -1,15 +1,19 @@
-import { Outlet, createFileRoute, redirect } from "@tanstack/react-router"
+import {
+  Outlet,
+  createFileRoute,
+  redirect,
+  useNavigate,
+} from "@tanstack/react-router"
 import { ApiError, getMe, type Me } from "@/lib/api"
 import { Sidebar } from "@/components/Sidebar"
+import { useChatHistory } from "@/hooks/useChatHistory"
 
 export const Route = createFileRoute("/_authenticated")({
   beforeLoad: async (): Promise<{ me: Me }> => {
     try {
-      const me = await getMe()
-      return { me }
+      return { me: await getMe() }
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) {
-        // TanStack Router uses thrown redirects as control flow.
         // eslint-disable-next-line @typescript-eslint/only-throw-error
         throw redirect({ to: "/signin", replace: true })
       }
@@ -21,9 +25,18 @@ export const Route = createFileRoute("/_authenticated")({
 
 function AuthenticatedLayout(): JSX.Element {
   const { me } = Route.useRouteContext()
+  const navigate = useNavigate()
+  const chat = useChatHistory()
+
   return (
     <div className="flex h-full bg-background">
-      <Sidebar me={me} />
+      <Sidebar
+        me={me}
+        {...chat}
+        onAccount={(): void => {
+          void navigate({ to: "/account" })
+        }}
+      />
       <div className="flex h-full min-w-0 flex-1 flex-col">
         <Outlet />
       </div>

--- a/ui2/src/routes/_authenticated/c.$chatId.tsx
+++ b/ui2/src/routes/_authenticated/c.$chatId.tsx
@@ -44,6 +44,12 @@ function ChatThreadRoute(): JSX.Element {
       const synthetic: Block[] = []
       if (isStreaming && conv.streamingThinking.length > 0) {
         synthetic.push({ kind: "thinking", text: conv.streamingThinking })
+      } else if (
+        isStreaming &&
+        m.blocks.length === 0 &&
+        conv.streamingText.length === 0
+      ) {
+        synthetic.push({ kind: "thinking", text: "" })
       }
       if (isStreaming && conv.streamingText.length > 0) {
         synthetic.push({
@@ -111,8 +117,8 @@ function ChatThreadRoute(): JSX.Element {
             <div ref={tailRef} aria-hidden />
           </div>
         </div>
-        <div className="border-t border-border bg-background/70 backdrop-blur-md">
-          <div className="mx-auto w-full max-w-3xl px-4 py-4">
+        <div className="bg-background/70 backdrop-blur-md">
+          <div className="mx-auto w-full max-w-3xl px-4 pb-4">
             <Composer onSubmit={onSubmit} placeholder="Reply…" seed={seed} />
           </div>
         </div>

--- a/ui2/src/routes/_authenticated/index.tsx
+++ b/ui2/src/routes/_authenticated/index.tsx
@@ -31,14 +31,12 @@ function NewChatRoute(): JSX.Element {
 
   return (
     <div className="flex h-full flex-col">
-      <Topbar title="New chat" />
-      <main className="flex flex-1 flex-col">
-        <div className="flex flex-1 items-center justify-center px-6 py-8">
+      <Topbar />
+      <main className="flex flex-1 items-center justify-center px-6 pb-24 pt-8">
+        <div className="flex w-full max-w-2xl flex-col">
           <EmptyState name={me.email} />
-        </div>
-        <div className="border-t border-border bg-background/70 backdrop-blur-md">
-          <div className="mx-auto w-full max-w-3xl px-4 py-4">
-            <Composer autoFocus onSubmit={onSubmit} />
+          <div className="mt-6">
+            <Composer autoFocus onSubmit={onSubmit} hideDisclaimer />
           </div>
         </div>
       </main>

--- a/ui2/src/routes/_authenticated/kb.tsx
+++ b/ui2/src/routes/_authenticated/kb.tsx
@@ -1,0 +1,252 @@
+import { useState } from "react"
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { ArrowLeft, FolderOpen } from "lucide-react"
+import { Topbar } from "@/components/Topbar"
+import {
+  EntryGrid,
+  EntryList,
+  PathBreadcrumb,
+  SearchField,
+  ViewToggle,
+  type BrowserEntry,
+  type ColumnDef,
+  type ViewMode,
+} from "@/components/file-browser"
+import { splitPath } from "@/lib/files"
+import {
+  createFolder,
+  enqueueUploads,
+  useKbEntries,
+  useKbSearch,
+  type IncomingFile,
+} from "@/lib/kb"
+import { NewMenu } from "@/components/kb/NewMenu"
+import { DropZone } from "@/components/kb/DropZone"
+import { UploadTray } from "@/components/kb/UploadTray"
+import { DraftFolder } from "@/components/kb/DraftFolder"
+
+type KbSearch = {
+  path?: string
+  q?: string
+}
+
+export const Route = createFileRoute("/_authenticated/kb")({
+  validateSearch: (raw: Record<string, unknown>): KbSearch => {
+    const out: KbSearch = {}
+    if (typeof raw["path"] === "string" && raw["path"] !== "") {
+      out.path = raw["path"]
+    }
+    if (typeof raw["q"] === "string" && raw["q"] !== "") {
+      out.q = raw["q"]
+    }
+    return out
+  },
+  component: KnowledgeRoute,
+})
+
+const KB_COLUMNS: ReadonlyArray<ColumnDef> = [
+  { key: "kind", header: "Kind", width: "120px" },
+  { key: "size", header: "Size", width: "120px" },
+  { key: "updated", header: "Updated", width: "140px" },
+]
+
+function KnowledgeRoute(): JSX.Element {
+  const { path, q } = Route.useSearch()
+  const navigate = useNavigate({ from: Route.fullPath })
+  const [view, setView] = useState<ViewMode>("grid")
+  const [draftFolder, setDraftFolder] = useState(false)
+
+  const currentPath = path ?? ""
+  const query = q ?? ""
+
+  const folderEntries = useKbEntries(currentPath)
+  const searchResults = useKbSearch(currentPath, query)
+
+  const isSearching = query.trim().length > 0
+  const entries = isSearching ? searchResults : folderEntries
+
+  const goToPath = (next: string): void => {
+    setDraftFolder(false)
+    void navigate({
+      search: (): KbSearch => (next === "" ? {} : { path: next }),
+    })
+  }
+
+  const setQuery = (next: string): void => {
+    void navigate({
+      replace: true,
+      search: (prev: KbSearch): KbSearch => {
+        const out: KbSearch = {}
+        if (prev.path !== undefined) {
+          out.path = prev.path
+        }
+        if (next !== "") {
+          out.q = next
+        }
+        return out
+      },
+    })
+  }
+
+  const onOpenEntry = (entry: BrowserEntry): void => {
+    if (entry.kind === "folder") {
+      goToPath(entry.id)
+    }
+  }
+
+  const goUp = (): void => {
+    const segs = splitPath(currentPath)
+    goToPath(segs.slice(0, -1).join("/"))
+  }
+
+  const handleUpload = (incoming: ReadonlyArray<IncomingFile>): void => {
+    if (incoming.length === 0) {
+      return
+    }
+    enqueueUploads(currentPath, incoming)
+  }
+
+  const handleNewFolder = (): void => {
+    setDraftFolder(true)
+  }
+
+  const handleDraftCommit = (name: string): void => {
+    createFolder(currentPath, name)
+    setDraftFolder(false)
+  }
+
+  const segs = splitPath(currentPath)
+  const folderCount = entries.filter((e) => e.kind === "folder").length
+  const fileCount = entries.length - folderCount
+  const lastSeg = segs[segs.length - 1]
+  const destinationLabel = lastSeg ?? "Knowledge"
+
+  const draftNode = draftFolder ? (
+    <DraftFolder
+      mode={view}
+      listColumns={KB_COLUMNS}
+      onCommit={handleDraftCommit}
+      onCancel={(): void => {
+        setDraftFolder(false)
+      }}
+    />
+  ) : undefined
+
+  return (
+    <div className="flex h-full flex-col">
+      <Topbar title="Knowledge" />
+
+      <div className="relative z-20 flex flex-wrap items-center justify-between gap-3 border-b border-border bg-background/70 px-5 py-2.5 backdrop-blur-md">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <button
+            type="button"
+            aria-label="Up one level"
+            disabled={segs.length === 0}
+            onClick={goUp}
+            className="grid h-7 w-7 place-items-center rounded-md text-muted-foreground transition hover:bg-secondary hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+            title={segs.length === 0 ? undefined : "Up"}
+          >
+            <ArrowLeft className="h-3.5 w-3.5" aria-hidden strokeWidth={1.75} />
+          </button>
+          <PathBreadcrumb
+            path={currentPath}
+            onNavigate={goToPath}
+            rootLabel="Knowledge"
+            ariaLabel="Knowledge path"
+          />
+        </div>
+
+        <div className="flex items-center gap-2">
+          <NewMenu
+            onNewFolder={handleNewFolder}
+            onFiles={handleUpload}
+            onFolder={handleUpload}
+          />
+          <ViewToggle value={view} onChange={setView} />
+          <SearchField
+            value={query}
+            onChange={setQuery}
+            className="w-56"
+            ariaLabel="Search knowledge"
+            placeholder={
+              lastSeg ? `Search in ${lastSeg}` : "Search knowledge"
+            }
+          />
+        </div>
+      </div>
+
+      <DropZone
+        className="flex-1 overflow-auto px-5 py-5"
+        onDrop={handleUpload}
+        destinationLabel={destinationLabel}
+      >
+        <div className="mx-auto w-full max-w-7xl">
+          {isSearching ? (
+            <p className="mb-3 text-[12px] text-muted-foreground">
+              {entries.length === 0
+                ? `No matches for "${query}"`
+                : `${String(entries.length)} match${entries.length === 1 ? "" : "es"} for "${query}"`}
+              {lastSeg ? (
+                <>
+                  {" "}
+                  in <span className="text-foreground">{lastSeg}</span>
+                </>
+              ) : null}
+            </p>
+          ) : (
+            <p className="mb-3 text-[12px] text-muted-foreground">
+              {entries.length === 0 && !draftFolder
+                ? "This folder is empty"
+                : `${String(folderCount)} folder${folderCount === 1 ? "" : "s"} · ${String(fileCount)} file${fileCount === 1 ? "" : "s"}`}
+            </p>
+          )}
+
+          {entries.length === 0 && !draftFolder ? (
+            <EmptyPane searching={isSearching} query={query} />
+          ) : view === "grid" ? (
+            <EntryGrid
+              entries={entries}
+              onOpen={onOpenEntry}
+              disableFiles
+              {...(draftNode ? { leadingItem: draftNode } : {})}
+            />
+          ) : (
+            <EntryList
+              entries={entries}
+              columns={KB_COLUMNS}
+              onOpen={onOpenEntry}
+              disableFiles
+              {...(draftNode ? { leadingItem: draftNode } : {})}
+            />
+          )}
+        </div>
+      </DropZone>
+
+      <UploadTray />
+    </div>
+  )
+}
+
+function EmptyPane({
+  searching,
+  query,
+}: {
+  searching: boolean
+  query: string
+}): JSX.Element {
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center justify-center gap-3 py-24 text-center">
+      <span className="grid h-12 w-12 place-items-center rounded-2xl bg-surface-muted text-muted-foreground">
+        <FolderOpen className="h-5 w-5" aria-hidden strokeWidth={1.5} />
+      </span>
+      <p className="text-[14px] font-medium text-foreground">
+        {searching ? "No matches" : "Nothing here yet"}
+      </p>
+      <p className="max-w-xs text-[12.5px] text-muted-foreground">
+        {searching
+          ? `We couldn${"’"}t find anything matching "${query}" in this folder. Try a broader term or clear the search to browse.`
+          : `Drop files here, or use ${"“"}+ New${"”"} to create a folder or upload.`}
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
This pull request introduces several new UI components and significant improvements to the chat history and message handling in the application. The main focus is on enhancing the chat sidebar's interactivity (including inline rename and delete actions), improving keyboard accessibility, and simplifying or refining some existing UI elements.

**Key changes include:**

### New Components and Sidebar Interactivity

* Added a new `ChatHistory` component to display recent conversations with support for inline renaming and deletion, including keyboard focus management and filtering by query. This component uses new `MenuPopover`, `InlineRenameField`, and `InlineConfirmRow` components for row actions and confirmation dialogs. [[1]](diffhunk://#diff-fac699cb16c4cd9b5e512e0d05a1d40c667a65512e3ddcbba30d22ac99f52c47R1-R252) [[2]](diffhunk://#diff-92a4538282a1fb9f5fbcb9505d7f510d9b10ea899c67809515343b3c2f31381fR1-R175) [[3]](diffhunk://#diff-df06c42e907dc96d3aa1648cccf40ae43e5aa3bd9a5cf090d385c0b73da72d4eR1-R48) [[4]](diffhunk://#diff-f66ce4f7ed2cd82330c8ec935d99d34782a77d97794a0d6e5d44373d722baf4eR1-R70)
* Introduced `MenuPopover`, a reusable dropdown menu component with full keyboard navigation and focus restoration, used for row actions in the chat history.
* Added `InlineRenameField` and `InlineConfirmRow` components for inline editing and confirmation dialogs within list rows. [[1]](diffhunk://#diff-df06c42e907dc96d3aa1648cccf40ae43e5aa3bd9a5cf090d385c0b73da72d4eR1-R48) [[2]](diffhunk://#diff-f66ce4f7ed2cd82330c8ec935d99d34782a77d97794a0d6e5d44373d722baf4eR1-R70)

### UI/UX Improvements

* Updated the `Composer` component to optionally hide the disclaimer message and fixed a typo in the disclaimer text. [[1]](diffhunk://#diff-ded550682286be5ec4291e18418c1625772dd00b5a5bd39007abcd27a6c72f59L26-R27) [[2]](diffhunk://#diff-ded550682286be5ec4291e18418c1625772dd00b5a5bd39007abcd27a6c72f59R40) [[3]](diffhunk://#diff-ded550682286be5ec4291e18418c1625772dd00b5a5bd39007abcd27a6c72f59R156-R160)
* Simplified the `EmptyState` component by removing decorative elements and focusing on a cleaner greeting and message. [[1]](diffhunk://#diff-4e97929cc8deb69fed68a9cee23a13cee0213160d8500048efb5dad75f784532L1-L2) [[2]](diffhunk://#diff-4e97929cc8deb69fed68a9cee23a13cee0213160d8500048efb5dad75f784532L38-L61)
* Refined the `MessageBubble` component to remove the brand icon and spinner, and improved the display of "thinking" blocks to better indicate pending status. [[1]](diffhunk://#diff-07977d9cc5570f1d9f3d0bcf0518920c78e1eda11010c4eb3eb6b3084d3ba1d9L4) [[2]](diffhunk://#diff-07977d9cc5570f1d9f3d0bcf0518920c78e1eda11010c4eb3eb6b3084d3ba1d9L60-R60) [[3]](diffhunk://#diff-07977d9cc5570f1d9f3d0bcf0518920c78e1eda11010c4eb3eb6b3084d3ba1d9L84-R79)

---

**References:**  
[[1]](diffhunk://#diff-fac699cb16c4cd9b5e512e0d05a1d40c667a65512e3ddcbba30d22ac99f52c47R1-R252) [[2]](diffhunk://#diff-92a4538282a1fb9f5fbcb9505d7f510d9b10ea899c67809515343b3c2f31381fR1-R175) [[3]](diffhunk://#diff-df06c42e907dc96d3aa1648cccf40ae43e5aa3bd9a5cf090d385c0b73da72d4eR1-R48) [[4]](diffhunk://#diff-f66ce4f7ed2cd82330c8ec935d99d34782a77d97794a0d6e5d44373d722baf4eR1-R70) [[5]](diffhunk://#diff-ded550682286be5ec4291e18418c1625772dd00b5a5bd39007abcd27a6c72f59L26-R27) [[6]](diffhunk://#diff-ded550682286be5ec4291e18418c1625772dd00b5a5bd39007abcd27a6c72f59R40) [[7]](diffhunk://#diff-ded550682286be5ec4291e18418c1625772dd00b5a5bd39007abcd27a6c72f59R156-R160) [[8]](diffhunk://#diff-4e97929cc8deb69fed68a9cee23a13cee0213160d8500048efb5dad75f784532L1-L2) [[9]](diffhunk://#diff-4e97929cc8deb69fed68a9cee23a13cee0213160d8500048efb5dad75f784532L38-L61) [[10]](diffhunk://#diff-07977d9cc5570f1d9f3d0bcf0518920c78e1eda11010c4eb3eb6b3084d3ba1d9L4) [[11]](diffhunk://#diff-07977d9cc5570f1d9f3d0bcf0518920c78e1eda11010c4eb3eb6b3084d3ba1d9L60-R60) [[12]](diffhunk://#diff-07977d9cc5570f1d9f3d0bcf0518920c78e1eda11010c4eb3eb6b3084d3ba1d9L84-R79)

<img width="1440" height="900" alt="01-home" src="https://github.com/user-attachments/assets/56810c5a-4454-49f8-b7e5-d83e2d06182b" />
<img width="1440" height="900" alt="02-sidebar-collapsed" src="https://github.com/user-attachments/assets/5abc1cbc-1e96-4e83-831c-9cefbfd1d7ef" />
<img width="1440" height="900" alt="03-kb-root-grid" src="https://github.com/user-attachments/assets/3d577e74-8098-4ca1-a363-ef5fcf1bff25" />
<img width="1440" height="900" alt="04-kb-root-list" src="https://github.com/user-attachments/assets/305e35ef-e377-4899-810a-e3dfe4548ddc" />
<img width="1440" height="900" alt="05-kb-reports-grid" src="https://github.com/user-attachments/assets/c7e1eeaf-1046-4c2e-ac78-7a8b0e2af9d3" />
<img width="1440" height="900" alt="06-kb-annualreports-list" src="https://github.com/user-attachments/assets/7a173a7a-0f6b-4958-8c45-592dadabf843" />
<img width="1440" height="900" alt="07-kb-newmenu" src="https://github.com/user-attachments/assets/4514905e-2e75-4fc9-aaf7-e974298209ce" />
<img width="1440" height="900" alt="08-kb-folder-draft" src="https://github.com/user-attachments/assets/0bdd8ffd-b986-4fa4-88c5-b8644da1561d" />
<img width="1440" height="900" alt="09-kb-folder-typing" src="https://github.com/user-attachments/assets/236152b1-f3c7-4a15-a82a-f0ace671d577" />
<img width="1440" height="900" alt="10-kb-folder-created" src="https://github.com/user-attachments/assets/1a95fd36-2b4d-4010-9f08-6edf49cbd880" />
<img width="1440" height="900" alt="11-kb-uploading" src="https://github.com/user-attachments/assets/e5ca9458-4071-4084-9530-093b96bcda59" />
<img width="1440" height="900" alt="12-kb-indexing" src="https://github.com/user-attachments/assets/0aed92ef-2301-40f7-9844-470dcc1c3e01" />
<img width="1440" height="900" alt="13-kb-upload-failed" src="https://github.com/user-attachments/assets/b6ffb9d3-39f4-494f-b824-61a9fe1f6c22" />
<img width="1440" height="900" alt="14-kb-search" src="https://github.com/user-attachments/assets/eebfcd22-32cb-41c0-aa7e-f1eeff8263ba" />
<img width="1440" height="900" alt="15-kb-search-empty" src="https://github.com/user-attachments/assets/53b30b68-8028-4210-bd4e-fd87bf14688d" />
<img width="1440" height="900" alt="16-kb-drop-overlay" src="https://github.com/user-attachments/assets/2d419887-3ec6-4707-8f81-dc514d2ca4f0" />
<img width="1440" height="900" alt="17-kb-dark" src="https://github.com/user-attachments/assets/fe34033c-2a6f-41fe-b75a-87d484bacabc" />
<img width="1440" height="900" alt="18-kb-dark-list" src="https://github.com/user-attachments/assets/89003612-43b6-480e-b4a6-c1dfe6441459" />
