### PR TITLE
feat(v2/pi-mono): add math tool for add/sub/mul/div

### DIFF
--- a/server/backendv2/agent/pi-mono/runner.ts
+++ b/server/backendv2/agent/pi-mono/runner.ts
@@ -13,6 +13,7 @@ import { SessionManager, SettingsManager } from "@mariozechner/pi-coding-agent"
 
 import { createRAGAgent, type RAGAgent } from "@/api/chat/pi-mono/core"
 import type { AgentScope } from "../agent-scope"
+import { mathTool } from "./tools/math"
 import { buildVespaTools } from "./tools/vespa"
 import { getActualNameFromEnum, getModelValueFromLabel } from "@/ai/modelConfig"
 import { Models } from "@/ai/types"
@@ -197,11 +198,14 @@ export async function runPiMonoTurn(
     model: llmModelName,
     baseUrl,
     apiKey,
-    tools: buildVespaTools({
-      userEmail: args.userEmail,
-      logger: log,
-      ...(args.agentScope ? { agentScope: args.agentScope } : {}),
-    }),
+    tools: [
+      ...buildVespaTools({
+        userEmail: args.userEmail,
+        logger: log,
+        ...(args.agentScope ? { agentScope: args.agentScope } : {}),
+      }),
+      mathTool,
+    ],
     systemPrompt: args.systemPrompt ?? DEFAULT_SYSTEM_PROMPT,
     sessionManager,
     settingsManager: SettingsManager.inMemory({

--- a/server/backendv2/agent/pi-mono/tools/math.ts
+++ b/server/backendv2/agent/pi-mono/tools/math.ts
@@ -18,14 +18,32 @@ const errorResult = (text: string, error: string): ToolReturn => ({
   isError: true,
 })
 
+const BINARY_OPS = new Set(["add", "subtract", "multiply", "divide"])
+const REQUIRE_NONEMPTY = new Set(["sum", "avg", "min", "max"])
+
+// Truncate long arrays in the human-readable string so the LLM doesn't pay
+// for thousands of tokens echoing its own input back. The full array is
+// preserved in `details` for tracing/UI.
+const formatValues = (values: number[]): string => {
+  if (values.length <= 8) {
+    return `[${values.join(", ")}]`
+  }
+  const head = values.slice(0, 4).join(", ")
+  const tail = values.slice(-2).join(", ")
+  return `[${head}, …, ${tail}] (N=${values.length})`
+}
+
 export const mathTool = defineTool({
   name: "math",
   label: "Math",
   description:
-    "Perform a single arithmetic operation on two numbers. Supports " +
-    "addition, subtraction, multiplication, and division.",
+    "Perform a single arithmetic or aggregate operation on numbers. " +
+    "Binary ops (add, subtract, multiply, divide) require exactly 2 values; " +
+    "subtract and divide are non-commutative — values=[a, b] means a-b / a/b. " +
+    "Aggregates: sum, avg, min, max need at least 1 value; count and " +
+    "count_distinct accept an empty array.",
   promptSnippet:
-    "Use `math` for any arithmetic on two numbers — do not compute by hand.",
+    "Use `math` for arithmetic or aggregates over numeric values. Always pass `values` as an array of numbers; the `operation` field picks the op.",
   parameters: Type.Object({
     operation: Type.Union(
       [
@@ -33,55 +51,112 @@ export const mathTool = defineTool({
         Type.Literal("subtract"),
         Type.Literal("multiply"),
         Type.Literal("divide"),
+        Type.Literal("sum"),
+        Type.Literal("avg"),
+        Type.Literal("count"),
+        Type.Literal("min"),
+        Type.Literal("max"),
+        Type.Literal("count_distinct"),
       ],
-      { description: "Which arithmetic operation to perform." },
+      { description: "Which operation to perform." },
     ),
-    a: Type.Number({ description: "Left operand." }),
-    b: Type.Number({ description: "Right operand." }),
+    values: Type.Array(Type.Number(), {
+      description:
+        "Operands. Binary ops (add/subtract/multiply/divide) require exactly 2. Aggregates: sum/avg/min/max need 1+; count/count_distinct accept 0+. For subtract: [a, b] → a - b. For divide: [a, b] → a / b.",
+    }),
   }),
   // eslint-disable-next-line @typescript-eslint/require-await
   async execute(_toolCallId, params) {
-    const { operation, a, b } = params
+    const { operation, values } = params
 
-    if (!Number.isFinite(a) || !Number.isFinite(b)) {
+    if (values.some((v) => !Number.isFinite(v))) {
       return errorResult(
-        `Refused: operands must be finite numbers (got a=${String(a)}, b=${String(b)}).`,
+        `Refused: values must all be finite numbers.`,
         "non_finite_operand",
       )
     }
 
+    if (BINARY_OPS.has(operation) && values.length !== 2) {
+      return errorResult(
+        `Refused: '${operation}' requires exactly 2 values; got ${String(values.length)}.`,
+        "wrong_arity",
+      )
+    }
+
+    if (REQUIRE_NONEMPTY.has(operation) && values.length === 0) {
+      return errorResult(
+        `Refused: '${operation}' requires at least 1 value.`,
+        "empty_input",
+      )
+    }
+
     let value: number
-    let symbol: string
+    let pretty: string
+
     switch (operation) {
       case "add":
-        value = a + b
-        symbol = "+"
-        break
       case "subtract":
-        value = a - b
-        symbol = "-"
-        break
       case "multiply":
-        value = a * b
-        symbol = "*"
-        break
-      case "divide":
-        if (b === 0) {
+      case "divide": {
+        // Arity already enforced above; destructure with a defensive guard
+        // to satisfy noUncheckedIndexedAccess.
+        const [a, b] = values
+        if (a === undefined || b === undefined) {
           return errorResult(
-            "Refused: division by zero.",
-            "division_by_zero",
+            `Refused: '${operation}' requires exactly 2 values.`,
+            "wrong_arity",
           )
         }
-        value = a / b
-        symbol = "/"
+        if (operation === "divide" && b === 0) {
+          return errorResult("Refused: division by zero.", "division_by_zero")
+        }
+        const symbol =
+          operation === "add"
+            ? "+"
+            : operation === "subtract"
+              ? "-"
+              : operation === "multiply"
+                ? "*"
+                : "/"
+        value =
+          operation === "add"
+            ? a + b
+            : operation === "subtract"
+              ? a - b
+              : operation === "multiply"
+                ? a * b
+                : a / b
+        pretty = `${String(a)} ${symbol} ${String(b)} = ${String(value)}`
+        break
+      }
+      case "sum":
+        value = values.reduce((acc, v) => acc + v, 0)
+        pretty = `sum(${formatValues(values)}) = ${String(value)}`
+        break
+      case "avg":
+        value = values.reduce((acc, v) => acc + v, 0) / values.length
+        pretty = `avg(${formatValues(values)}) = ${String(value)}`
+        break
+      case "count":
+        value = values.length
+        pretty = `count(${formatValues(values)}) = ${String(value)}`
+        break
+      case "min":
+        value = Math.min(...values)
+        pretty = `min(${formatValues(values)}) = ${String(value)}`
+        break
+      case "max":
+        value = Math.max(...values)
+        pretty = `max(${formatValues(values)}) = ${String(value)}`
+        break
+      case "count_distinct":
+        // Exact equality via Set — fine for integers; for floats note that
+        // 0.1+0.2 !== 0.3, so distinctness is bit-exact, not numeric.
+        value = new Set(values).size
+        pretty = `count_distinct(${formatValues(values)}) = ${String(value)}`
         break
     }
 
-    return textResult(`${a} ${symbol} ${b} = ${String(value)}`, {
-      operation,
-      a,
-      b,
-      value,
-    })
+    return textResult(pretty, { operation, values, value })
   },
 })

--- a/server/backendv2/agent/pi-mono/tools/math.ts
+++ b/server/backendv2/agent/pi-mono/tools/math.ts
@@ -1,0 +1,87 @@
+import { defineTool } from "@mariozechner/pi-coding-agent"
+import { Type } from "@sinclair/typebox"
+
+type ToolReturn = {
+  content: { type: "text"; text: string }[]
+  details: unknown
+  isError?: boolean
+}
+
+const textResult = (text: string, details: unknown = {}): ToolReturn => ({
+  content: [{ type: "text", text }],
+  details,
+})
+
+const errorResult = (text: string, error: string): ToolReturn => ({
+  content: [{ type: "text", text }],
+  details: { error },
+  isError: true,
+})
+
+export const mathTool = defineTool({
+  name: "math",
+  label: "Math",
+  description:
+    "Perform a single arithmetic operation on two numbers. Supports " +
+    "addition, subtraction, multiplication, and division.",
+  promptSnippet:
+    "Use `math` for any arithmetic on two numbers — do not compute by hand.",
+  parameters: Type.Object({
+    operation: Type.Union(
+      [
+        Type.Literal("add"),
+        Type.Literal("subtract"),
+        Type.Literal("multiply"),
+        Type.Literal("divide"),
+      ],
+      { description: "Which arithmetic operation to perform." },
+    ),
+    a: Type.Number({ description: "Left operand." }),
+    b: Type.Number({ description: "Right operand." }),
+  }),
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async execute(_toolCallId, params) {
+    const { operation, a, b } = params
+
+    if (!Number.isFinite(a) || !Number.isFinite(b)) {
+      return errorResult(
+        `Refused: operands must be finite numbers (got a=${String(a)}, b=${String(b)}).`,
+        "non_finite_operand",
+      )
+    }
+
+    let value: number
+    let symbol: string
+    switch (operation) {
+      case "add":
+        value = a + b
+        symbol = "+"
+        break
+      case "subtract":
+        value = a - b
+        symbol = "-"
+        break
+      case "multiply":
+        value = a * b
+        symbol = "*"
+        break
+      case "divide":
+        if (b === 0) {
+          return errorResult(
+            "Refused: division by zero.",
+            "division_by_zero",
+          )
+        }
+        value = a / b
+        symbol = "/"
+        break
+    }
+
+    return textResult(`${a} ${symbol} ${b} = ${String(value)}`, {
+      operation,
+      a,
+      b,
+      value,
+    })
+  },
+})


### PR DESCRIPTION
Wires a discrete two-operand arithmetic tool into the per-turn tool list alongside the Vespa retrieval tools. Guards non-finite operands and division by zero.

### Description

<!-- Summarize the changes in this PR. -->
<!-- Explain the purpose of the change (e.g., bug fix, feature, refactor). -->
<!-- Describe how this change affects the system or users. -->

### Testing

<!-- List the tests you’ve added or updated. -->
<!-- Provide instructions for reviewers to test the changes locally. -->

### Additional Notes

<!-- Mention any related PRs, libraries, or systems. -->
<!-- Highlight any potential risks or areas needing special attention. -->
<!-- Attach visuals or logs if applicable. -->
