### PR TITLE
feat(pi-mono): dedicated citation pass after synthesis

### DIFF
--- a/server/api/chat/pi-mono/agentic.ts
+++ b/server/api/chat/pi-mono/agentic.ts
@@ -67,7 +67,11 @@ const { JwtPayloadKey } = config
 const Logger = getLogger(Subsystem.Chat)
 
 import { bootstrapChat, persistAssistantMessage } from "./helpers"
-import { checkAndYieldCitationsForAgent } from "./tools/tool-utils"
+import {
+  checkAndYieldCitationsForAgent,
+  formatFragmentsForLLM,
+} from "./tools/tool-utils"
+import { runCitationPass } from "./citation-pass"
 
 export async function AgenticRAG(c: Context): Promise<Response> {
   const tracer = getTracer("chat")
@@ -529,41 +533,14 @@ export async function AgenticRAG(c: Context): Promise<Response> {
               break
             case "text_delta": {
               if (!event.delta) break
+              // BUFFER ONLY — synthesis output is held back from the SSE
+              // stream. After agent.run() exits we run a focused citation pass
+              // (see citation-pass.ts) and stream THAT call's output as the
+              // user-facing answer. This avoids leaking mangled citation
+              // tokens (e.g. `【1_3】`, `K[1_5.1.10]`) into the rendered
+              // message — synthesis is free to write naturally, the citation
+              // pass is responsible for emitting compliant `K[N_X]`.
               answer += event.delta
-              await stream.writeSSE({
-                event: ChatSSEvents.ResponseUpdate,
-                data: event.delta,
-              })
-
-              // Yield citations inline
-              for await (const ce of checkAndYieldCitationsForAgent(
-                answer,
-                yieldedCitations,
-                xyneState.allFragments,
-                yieldedImageCitations,
-                email,
-                xyneState.citationDocIdMapping,
-              )) {
-                if (stream.closed) break
-                if (ce.citation) {
-                  const { index, item } = ce.citation
-                  const docId = item.docId || String(index)
-                  if (citationsByDocId.has(docId)) {
-                    citationMap[index] = citationsByDocId.get(docId)!
-                  } else {
-                    citations.push(item)
-                    citationsByDocId.set(docId, citations.length - 1)
-                    citationMap[index] = citations.length - 1
-                  }
-                  await stream.writeSSE({
-                    event: ChatSSEvents.CitationsUpdate,
-                    data: JSON.stringify({
-                      contextChunks: citations,
-                      citationMap,
-                    }),
-                  })
-                }
-              }
               break
             }
 
@@ -663,12 +640,12 @@ export async function AgenticRAG(c: Context): Promise<Response> {
                       : ""
 
                 if (fullContent) {
+                  // BUFFER ONLY — same reasoning as the text_delta case.
+                  // This fallback fires when streaming text_delta didn't but
+                  // message_end carries the full message. We still want the
+                  // citation pass to be the sole producer of user-facing text,
+                  // so don't writeSSE here either.
                   answer = fullContent
-
-                  await stream.writeSSE({
-                    event: ChatSSEvents.ResponseUpdate,
-                    data: answer,
-                  })
                 }
               }
               break
@@ -695,6 +672,131 @@ export async function AgenticRAG(c: Context): Promise<Response> {
             emitReasoningStep,
             ReasoningSteps.synthesisCompleted(),
           )
+        }
+
+        // ── Citation pass ────────────────────────────────────────────
+        // Synthesis output was buffered into `answer` (not streamed).
+        // A focused second LLM call re-emits the same answer with inline
+        // `K[N_X]` citations. THIS is what the user sees streamed.
+        //
+        // On failure (network, model error, empty output) we fall back to
+        // streaming the uncited synthesis answer as-is so the user always
+        // gets *something*.
+        if (answer.trim() && !stream.closed) {
+          let citedAnswer = ""
+          let citationPassSucceeded = false
+          try {
+            const chunksFormatted = formatFragmentsForLLM(
+              xyneState.allFragments,
+              1,
+              Number.MAX_SAFE_INTEGER, // pass ALL fragments — citation pass
+              // needs the full evidence pool to pick the right `K[N_X]`
+            )
+
+            for await (const delta of runCitationPass({
+              chunks: chunksFormatted,
+              answer,
+              modelId,
+              numFragments: xyneState.allFragments.length,
+              email,
+            })) {
+              if (stream.closed) break
+              citedAnswer += delta
+              await stream.writeSSE({
+                event: ChatSSEvents.ResponseUpdate,
+                data: delta,
+              })
+
+              // Run the same inline citation extraction we used to do during
+              // synthesis — now against the citation-pass output, which is
+              // where the well-formed `K[N_X]` tokens live.
+              for await (const ce of checkAndYieldCitationsForAgent(
+                citedAnswer,
+                yieldedCitations,
+                xyneState.allFragments,
+                yieldedImageCitations,
+                email,
+                xyneState.citationDocIdMapping,
+              )) {
+                if (stream.closed) break
+                if (ce.citation) {
+                  const { index, item } = ce.citation
+                  const docId = item.docId || String(index)
+                  if (citationsByDocId.has(docId)) {
+                    citationMap[index] = citationsByDocId.get(docId)!
+                  } else {
+                    citations.push(item)
+                    citationsByDocId.set(docId, citations.length - 1)
+                    citationMap[index] = citations.length - 1
+                  }
+                  await stream.writeSSE({
+                    event: ChatSSEvents.CitationsUpdate,
+                    data: JSON.stringify({
+                      contextChunks: citations,
+                      citationMap,
+                    }),
+                  })
+                }
+              }
+            }
+            // Require the stream to STILL BE OPEN to count as a success.
+            // If the user aborted (stream.closed) we'd otherwise replace the
+            // full buffered synthesis answer with a truncated cited prefix
+            // and persist the truncation to the DB.
+            citationPassSucceeded =
+              !stream.closed && citedAnswer.trim().length > 0
+          } catch (citationErr) {
+            Logger.error(
+              citationErr,
+              "Citation pass failed — falling back to uncited synthesis answer",
+            )
+          }
+
+          if (citationPassSucceeded) {
+            // Replace the in-memory `answer` with the cited version so it
+            // gets persisted with proper `K[N_X]` tokens.
+            answer = citedAnswer
+          } else if (!stream.closed) {
+            // Fallback: stream the buffered synthesis answer in one go and
+            // run citation extraction on it (best-effort — synthesis may
+            // have emitted mangled citations, the existing regex will skip
+            // those gracefully).
+            Logger.warn(
+              "Citation pass produced no output; streaming uncited synthesis answer",
+            )
+            await stream.writeSSE({
+              event: ChatSSEvents.ResponseUpdate,
+              data: answer,
+            })
+            for await (const ce of checkAndYieldCitationsForAgent(
+              answer,
+              yieldedCitations,
+              xyneState.allFragments,
+              yieldedImageCitations,
+              email,
+              xyneState.citationDocIdMapping,
+            )) {
+              if (stream.closed) break
+              if (ce.citation) {
+                const { index, item } = ce.citation
+                const docId = item.docId || String(index)
+                if (citationsByDocId.has(docId)) {
+                  citationMap[index] = citationsByDocId.get(docId)!
+                } else {
+                  citations.push(item)
+                  citationsByDocId.set(docId, citations.length - 1)
+                  citationMap[index] = citations.length - 1
+                }
+                await stream.writeSSE({
+                  event: ChatSSEvents.CitationsUpdate,
+                  data: JSON.stringify({
+                    contextChunks: citations,
+                    citationMap,
+                  }),
+                })
+              }
+            }
+          }
         }
 
         try {

--- a/server/api/chat/pi-mono/citation-pass.ts
+++ b/server/api/chat/pi-mono/citation-pass.ts
@@ -1,0 +1,159 @@
+/**
+ * Citation pass — second focused LLM call that takes a finished answer +
+ * retrieved chunks and emits the SAME answer with inline `K[N_X]` citations
+ * inserted. Decouples answer quality from citation-format compliance so that
+ * weaker / non-compliant models (Nemotron etc.) don't poison the rendered
+ * answer with mangled citation tokens.
+ *
+ * Design notes:
+ * - Called AFTER pi-mono's synthesis loop completes. Synthesis text is
+ *   buffered (not streamed to user) and passed in as `answer`.
+ * - This call's output IS what the user sees — it streams to the SSE.
+ * - Uses the existing LiteLLM provider plumbing (`getProviderByModel`).
+ * - On failure the caller falls back to streaming the uncited answer.
+ */
+
+import { getProviderByModel } from "@/ai/provider"
+import { ConversationRole, type Message } from "@aws-sdk/client-bedrock-runtime"
+import type { ConverseResponse, RuntimeModelId } from "@/ai/types"
+import { getLogger } from "@/logger"
+import { Subsystem } from "@/types"
+import { buildCitationPassSystemPrompt } from "./prompts/xyne-prompts"
+
+const Logger = getLogger(Subsystem.Chat).child({ module: "citation-pass" })
+
+/** Rough token estimate: ~4 characters per token (English). Good enough for logs. */
+const approxTokens = (s: string): number => Math.ceil(s.length / 4)
+
+export interface RunCitationPassOpts {
+  /** Chunks formatted via `formatFragmentsForLLM` — already contain
+   *  `citationDocId: N — cite as K[N_X]` headers and `[chunk:X]` markers. */
+  chunks: string
+  /** The synthesised answer text. Citations will be inserted into this verbatim. */
+  answer: string
+  /** Model to use for the citation pass. Defaults to caller's synthesis model. */
+  modelId: RuntimeModelId
+  /** Number of distinct fragments being passed (for logging only). */
+  numFragments?: number
+  /** Email for log context (optional). */
+  email?: string
+  /** Sampling temperature — defaults to 0 so the rewrite is deterministic. */
+  temperature?: number
+  /** Max output tokens — defaults to answer length + headroom for citation tokens. */
+  maxNewTokens?: number
+}
+
+/**
+ * Streams the cited answer token-by-token. Caller is responsible for
+ * forwarding each yielded chunk to the SSE response and running citation
+ * extraction on the cumulative output.
+ */
+export async function* runCitationPass(
+  opts: RunCitationPassOpts,
+): AsyncGenerator<string, void, void> {
+  const { chunks, answer, modelId, numFragments, email } = opts
+
+  // Build the user message: chunks first, then a clear separator, then the
+  // answer to cite. The system prompt has the rules; the user message is data.
+  const userText =
+    `# CHUNKS\n\n${chunks}\n\n` +
+    `# ANSWER TO CITE\n\n${answer}`
+
+  const systemPrompt = buildCitationPassSystemPrompt()
+
+  const messages: Message[] = [
+    {
+      role: ConversationRole.USER,
+      content: [{ text: userText }],
+    },
+  ]
+
+  // Budget a healthy headroom on top of the answer length so the cited output
+  // (which is the answer + a sprinkling of `K[N_X]` tokens) fits comfortably.
+  // Average citation token ~10 chars; allow ~20% expansion.
+  const approxAnswerTokens = Math.ceil(answer.length / 3)
+  const maxNewTokens = opts.maxNewTokens ?? Math.max(4096, Math.ceil(approxAnswerTokens * 1.4))
+
+  // ── Pre-call log: sizes of every input piece ─────────────────────────────
+  const startTime = Date.now()
+  const startIso = new Date(startTime).toISOString()
+  const sysChars = systemPrompt.length
+  const chunksChars = chunks.length
+  const answerChars = answer.length
+  const totalContextChars = sysChars + chunksChars + answerChars
+  Logger.info(
+    {
+      event: "citation_pass_start",
+      email,
+      modelId,
+      startedAt: startIso,
+      numFragments,
+      sizes: {
+        chars: {
+          systemPrompt: sysChars,
+          chunks: chunksChars,
+          answer: answerChars,
+          totalInputContext: totalContextChars,
+        },
+        approxTokens: {
+          systemPrompt: approxTokens(systemPrompt),
+          chunks: approxTokens(chunks),
+          answer: approxTokens(answer),
+          totalInputContext: approxTokens(systemPrompt) + approxTokens(chunks) + approxTokens(answer),
+        },
+        maxNewTokens,
+      },
+    },
+    "[citation-pass] starting",
+  )
+
+  let outputChars = 0
+  let firstTokenAt: number | null = null
+  try {
+    const stream = getProviderByModel(modelId).converseStream(messages, {
+      modelId,
+      systemPrompt,
+      stream: true,
+      temperature: opts.temperature ?? 0,
+      max_new_tokens: maxNewTokens,
+      // Reasoning models tend to slow this pass down without helping — citation
+      // insertion is a mechanical rewrite, not a reasoning task.
+      reasoning: false,
+    })
+
+    for await (const chunk of stream as AsyncIterableIterator<ConverseResponse>) {
+      if (chunk.text) {
+        if (firstTokenAt === null) firstTokenAt = Date.now()
+        outputChars += chunk.text.length
+        yield chunk.text
+      }
+    }
+  } finally {
+    const endTime = Date.now()
+    const durationMs = endTime - startTime
+    const ttftMs = firstTokenAt !== null ? firstTokenAt - startTime : null
+    Logger.info(
+      {
+        event: "citation_pass_end",
+        email,
+        modelId,
+        startedAt: startIso,
+        endedAt: new Date(endTime).toISOString(),
+        durationMs,
+        ttftMs,
+        numFragments,
+        sizes: {
+          chars: {
+            totalInputContext: totalContextChars,
+            output: outputChars,
+          },
+          approxTokens: {
+            totalInputContext: approxTokens(systemPrompt) + approxTokens(chunks) + approxTokens(answer),
+            output: Math.ceil(outputChars / 4),
+          },
+        },
+      },
+      "[citation-pass] finished",
+    )
+  }
+}

--- a/server/api/chat/pi-mono/prompts/xyne-prompts.ts
+++ b/server/api/chat/pi-mono/prompts/xyne-prompts.ts
@@ -1,5 +1,74 @@
 import type { XyneAgentState } from "../adapter"
 
+/**
+ * Citation-pass system prompt — used by a focused second LLM call whose ONLY
+ * job is to insert inline `K[N_X]` citations into a synthesised answer. The
+ * synthesis call is now free to focus on writing a good answer; citation
+ * correctness is delegated here.
+ *
+ * The model receives:
+ *   - System prompt: this string
+ *   - User message: the chunks (formatted with `citationDocId: N — cite as K[N_X]`
+ *     headers and `[chunk:X]` markers) followed by the answer text.
+ *
+ * The model must output ONLY the cited answer — same wording, with `K[N_X]`
+ * tokens inserted after claims that are backed by chunks.
+ */
+export function buildCitationPassSystemPrompt(): string {
+  return `You are a citation specialist. Your ONLY job is to insert inline citations into a finished answer.
+
+# INPUT
+You are given two things in the user message:
+1. **CHUNKS** — retrieved evidence. Each document has a header line \`citationDocId: N — cite as K[N_X] where X is the chunk number\` followed by content with \`[chunk:X]\` markers.
+2. **ANSWER** — a complete answer that needs citations inserted.
+
+# YOUR TASK
+Reproduce the ANSWER **verbatim**, inserting inline citation tokens \`K[N_X]\` immediately after any claim that is backed by a chunk.
+
+# CITATION FORMAT — STRICT
+- The ONLY valid format is \`K[N_X]\` where N is the citationDocId and X is the chunk number from \`[chunk:X]\`.
+- CORRECT examples: \`K[2_3]\`, \`K[0_1]\`, \`K[5_12]\`
+- ABSOLUTELY FORBIDDEN — never produce any of these:
+  - \`【K[2_3]】\`, \`【2_3】\`, \`【clf-abc · chunk:3】\` — no CJK / lenticular brackets
+  - \`K[1_5.1.10]\`, \`K[1_5b]\` — chunk index must be a single integer, no dots, no letters
+  - \`[K[2_3]]\`, \`(K[2_3])\` — never wrap in extra brackets or parens
+  - \`[2_3]\` without the \`K\` prefix
+  - \`K[2_chunkIndex]\` — never write the literal word "chunkIndex"
+  - \`(citation5)\`, \`[citation5]\`, \`[Title · chunk:3]\` — no prose-style references
+  - \`K[3_4_5]\` — exactly one underscore inside
+- Each citation must use an actual citationDocId number and an actual chunk number from the inputs.
+
+# RULES — DO NOT VIOLATE
+1. **Do NOT change the wording of the answer.** Same sentences, same paragraphs, same headings, same bullets, same tables. Only ADD citation tokens.
+2. **Do NOT add or remove sentences.** Do not summarise. Do not rewrite.
+3. **Maximum 1-2 citations per claim.** Pick the 1-2 BEST chunks that most directly back the claim. Drop redundant citations.
+4. **If a sentence isn't backed by any chunk, leave it uncited.** Do not fabricate citations.
+5. **Place citations immediately after the cited claim** — at the end of the sentence or right after the specific fact, BEFORE the period.
+6. **Tables:** citations go inside the relevant cell, e.g. \`| Cell value K[2_3] |\`.
+7. **No commentary, no preamble, no explanation.** Output ONLY the cited answer.
+
+# WALK-THROUGH
+INPUT chunks:
+  citationDocId: 1 — cite as K[1_X] where X is the chunk number
+  [chunk:0] Revenue grew 15% in Q1.
+  [chunk:1] Customer retention reached 92%.
+
+  citationDocId: 2 — cite as K[2_X] where X is the chunk number
+  [chunk:0] Expansion into Europe is planned for Q2.
+
+INPUT answer:
+  Revenue grew 15% year-over-year. Customer retention improved to 92%. The company plans to expand into Europe next quarter.
+
+CORRECT output:
+  Revenue grew 15% year-over-year K[1_0]. Customer retention improved to 92% K[1_1]. The company plans to expand into Europe next quarter K[2_0].
+
+# FINAL CHECK BEFORE YOU RESPOND
+- Every \`K[N_X]\` uses a real \`citationDocId\` and a real \`[chunk:X]\` number from the chunks.
+- No CJK brackets, no dotted chunk indices, no parenthetical citations, no prose references.
+- Wording matches the input answer exactly.
+- Output starts directly with the cited answer text — no preamble.`
+}
+
 export function buildPiMonoSystemPrompt(
   context: XyneAgentState,
   dateForAI: string,


### PR DESCRIPTION
Decouple answer quality from citation-format compliance. Weak models (Nemotron) emit mangled tokens like K[1_5.1.10] or 【clf-... · chunk:3】 when asked to do synthesis + citation in one call; those slip past the K[N_X] regex and surface as raw text in the rendered answer.

Flow now:
  - Synthesis call: same prompt as before. Output buffered, NOT streamed.
  - Citation pass: new focused call (citation-pass.ts) with strict prompt; sees only chunks + the buffered answer; emits same answer with K[N_X].
  - Citation-pass output is what the user sees streamed.
  - On failure (network/empty/error), fall back to streaming the uncited synthesis answer so the user always gets something.

Frontend unchanged — same SSE events, same rendering pipeline.

Adds telemetry: `[citation-pass] start/end` logs with input char/token sizes, output size, ttftMs, durationMs.

Smoke test (Nemotron, 10 KB fragments): TTFT 571 ms, total 2.6 s, ~8.2k input tokens.


{"level":"info","name":"Chat","msg":"KB agentic RAG completed","pid":8065,"hostname":"macbook","caller":"at <anonymous> (/Users/sourish.mukherjee/Desktop/Repos/xyne/server/api/chat/pi-mono/agentic.ts:660:16)"}
{"level":"info","name":"Chat","msg":"[citation-pass] starting","pid":8065,"hostname":"macbook","module":"citation-pass","caller":"at runCitationPass (/Users/sourish.mukherjee/Desktop/Repos/xyne/server/api/chat/pi-mono/citation-pass.ts:84:10)","event":"citation_pass_start","email":"admin@xyne.local","modelId":"nemotron","startedAt":"2026-05-18T12:57:37.098Z","numFragments":10,"sizes":{"chars":{"systemPrompt":3043,"chunks":28542,"answer":1247,"totalInputContext":32832},"approxTokens":{"systemPrompt":761,"chunks":7136,"answer":312,"totalInputContext":8209},"maxNewTokens":4096}}
{"level":"info","name":"Chat","msg":"[citation-pass] finished","pid":8065,"hostname":"macbook","module":"citation-pass","caller":"at runCitationPass (/Users/sourish.mukherjee/Desktop/Repos/xyne/server/api/chat/pi-mono/citation-pass.ts:135:12)","event":"citation_pass_end","email":"admin@xyne.local","modelId":"nemotron","startedAt":"2026-05-18T12:57:37.098Z","endedAt":"2026-05-18T12:57:39.729Z","durationMs":2631,"ttftMs":571,"numFragments":10,"sizes":{"chars":{"totalInputContext":32832,"output":1249},"approxTokens":{"totalInputContext":8209,"output":313}}}