### PR TITLE
fix(chunks): skip empty docling image chunk descriptions

### DIFF
--- a/server/lib/chunkByDocling.ts
+++ b/server/lib/chunkByDocling.ts
@@ -522,8 +522,13 @@ function transformImageChunks(doclingImageChunks: DoclingImageChunk[]): {
   for (let index = 0; index < doclingImageChunks.length; index++) {
     const imgChunk = doclingImageChunks[index]
 
-    // Use the VLM-extracted text as the searchable content
-    const description = imgChunk.text?.trim() || ""
+    // Use the VLM-extracted text as the searchable content.
+    // Skip chunks with no text so empty strings never land in image_chunks
+    // (they surface as "" entries in chunks_summary).
+    const description = imgChunk.text?.trim()
+    if (!description) {
+      continue
+    }
 
     image_chunks.push(description)
     // Docling returns 1-based page numbers (first page = 1)
@@ -532,7 +537,7 @@ function transformImageChunks(doclingImageChunks: DoclingImageChunk[]): {
       ? imgChunk.page_number - 1
       : undefined
     image_chunks_map.push({
-      chunk_index: index,
+      chunk_index: image_chunks.length - 1,
       page_numbers: pageNumber !== undefined ? [pageNumber] : [],
       block_labels: ["image"],
       bbox: imgChunk.bbox,


### PR DESCRIPTION
Fixes #300

## Problem

Empty strings were appearing in `chunks_summary` for documents processed through the Docling pipeline.

In `transformImageChunks` (server/lib/chunkByDocling.ts), image chunks with no VLM-extracted text fell through to `imgChunk.text?.trim() || ""` and were pushed into `image_chunks` unconditionally. Those empty strings are then indexed in Vespa and surface as `""` entries in `chunks_summary`.

The OCR path (`chunkByOCR.ts`) already guards this case with `if (!description) continue`; the Docling path was missing the same guard.

## Fix

- Skip docling image chunks whose trimmed description is empty, mirroring the existing OCR-path guard.
- Keep `image_chunks_map[].chunk_index` contiguous by deriving it from `image_chunks.length - 1`, so the map stays positionally aligned with `image_chunks` after skipped entries (consumers zip these arrays by index).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented empty image content from appearing as searchable entries.
  - Improved image result ordering and indexing for more consistent search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->